### PR TITLE
Change optional bools to be private options

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -114,19 +114,19 @@ func DefaultConfig() (*Config, error) {
 
 	return &Config{
 		ContainersConfig: ContainersConfig{
-			AdditionalDevices:   []string{},
-			ApparmorProfile:     DefaultApparmorProfile,
-			CgroupManager:       SystemdCgroupsManager,
-			DefaultCapabilities: DefaultCapabilities,
-			DefaultSysctls:      []string{},
-			DefaultUlimits:      []string{},
-			EnableLabeling:      NewOptionalBool(selinuxEnabled()),
+			AdditionalDevices:      []string{},
+			ApparmorProfile:        DefaultApparmorProfile,
+			CgroupManager:          SystemdCgroupsManager,
+			DefaultCapabilities:    DefaultCapabilities,
+			DefaultSysctls:         []string{},
+			DefaultUlimits:         []string{},
+			optionalEnableLabeling: newOptionalBool(selinuxEnabled()),
 			Env: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			},
 			HooksDir:            DefaultHooksDirs,
 			HTTPProxy:           []string{},
-			Init:                NewOptionalBool(false),
+			optionalInit:        newOptionalBool(false),
 			LogSizeMax:          DefaultLogSizeMax,
 			PidsLimit:           DefaultPidsLimit,
 			SeccompProfile:      SeccompDefaultPath,
@@ -215,15 +215,15 @@ func defaultConfigFromMemory() (*LibpodConfig, error) {
 	}
 	c.RuntimeSupportsNoCgroups = []string{"crun"}
 	c.InitPath = DefaultInitPath
-	c.NoPivotRoot = NewOptionalBool(false)
+	c.optionalNoPivotRoot = newOptionalBool(false)
 
 	c.InfraCommand = DefaultInfraCommand
 	c.InfraImage = DefaultInfraImage
-	c.EnablePortReservation = NewOptionalBool(true)
+	c.optionalEnablePortReservation = newOptionalBool(true)
 	c.NumLocks = 2048
 	c.EventsLogger = "file"
 	c.DetachKeys = DefaultDetachKeys
-	c.SDNotify = NewOptionalBool(false)
+	c.optionalSDNotify = newOptionalBool(false)
 	// TODO - ideally we should expose a `type LockType string` along with
 	// constants.
 	c.LockType = "shm"

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -54,11 +54,11 @@ func (c *Config) mergeConfig(other *Config) error {
 	c.NumLocks = mergeUint32s(c.NumLocks, other.NumLocks)
 
 	// bools
-	c.EnableLabeling = mergeOptionalBools(c.EnableLabeling, other.EnableLabeling)
-	c.EnablePortReservation = mergeOptionalBools(c.EnablePortReservation, other.EnablePortReservation)
-	c.Init = mergeOptionalBools(c.Init, other.Init)
-	c.NoPivotRoot = mergeOptionalBools(c.NoPivotRoot, other.NoPivotRoot)
-	c.SDNotify = mergeOptionalBools(c.SDNotify, other.SDNotify)
+	c.optionalEnableLabeling = mergeOptionalBools(c.optionalEnableLabeling, other.optionalEnableLabeling)
+	c.optionalEnablePortReservation = mergeOptionalBools(c.optionalEnablePortReservation, other.optionalEnablePortReservation)
+	c.optionalInit = mergeOptionalBools(c.optionalInit, other.optionalInit)
+	c.optionalNoPivotRoot = mergeOptionalBools(c.optionalNoPivotRoot, other.optionalNoPivotRoot)
+	c.optionalSDNotify = mergeOptionalBools(c.optionalSDNotify, other.optionalSDNotify)
 
 	// state type
 	if c.StateType == InvalidStateStore {
@@ -131,8 +131,8 @@ func mergeBools(a, b bool) bool {
 	return a
 }
 
-func mergeOptionalBools(a, b OptionalBool) OptionalBool {
-	if a == OptionalBoolUndefined {
+func mergeOptionalBools(a, b optionalBool) optionalBool {
+	if a == optionalBoolUndefined {
 		return b
 	}
 	return a

--- a/pkg/config/merge_test.go
+++ b/pkg/config/merge_test.go
@@ -159,14 +159,14 @@ func TestMergeBools(t *testing.T) {
 
 func TestMergeOptionalBools(t *testing.T) {
 	testData := []struct {
-		a   OptionalBool
-		b   OptionalBool
-		res OptionalBool
+		a   optionalBool
+		b   optionalBool
+		res optionalBool
 	}{
-		{OptionalBoolUndefined, OptionalBoolTrue, OptionalBoolTrue},
-		{OptionalBoolFalse, OptionalBoolTrue, OptionalBoolFalse},
-		{OptionalBoolTrue, OptionalBoolFalse, OptionalBoolTrue},
-		{OptionalBoolUndefined, OptionalBoolUndefined, OptionalBoolUndefined},
+		{optionalBoolUndefined, optionalBoolTrue, optionalBoolTrue},
+		{optionalBoolFalse, optionalBoolTrue, optionalBoolFalse},
+		{optionalBoolTrue, optionalBoolFalse, optionalBoolTrue},
+		{optionalBoolUndefined, optionalBoolUndefined, optionalBoolUndefined},
 	}
 	for _, data := range testData {
 		res := mergeOptionalBools(data.a, data.b)


### PR DESCRIPTION
We want to hide Optional Bools from the default configuration.  Callers should only have to deal with boolean
fields and not deal with optionals.

Add accessor functions for all optional bools, easier.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
