### PR TITLE
Add missing fields to be used with podman

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,8 +58,11 @@ type Config struct {
 // containers global options for containers tools
 type ContainersConfig struct {
 
-	// Devices to add to containers
+	// Devices to add to all containers
 	AdditionalDevices []string `toml:"additional_devices"`
+
+	// Volumes to add to all containers
+	AdditionalVolumes []string `toml:"additional_volumes"`
 
 	// ApparmorProfile is the apparmor profile name which is used as the
 	// default for the runtime.
@@ -69,18 +72,26 @@ type ContainersConfig struct {
 	// and "systemd".
 	CgroupManager string `toml:"cgroup_manager"`
 
+	// Default way to create a cgroup namespace for the container
+	CgroupNS string `toml:"cgroupns"`
+
 	// Capabilities to add to all containers.
 	DefaultCapabilities []string `toml:"default_capabilities"`
-
-	// DefaultMountsFile is the path to the default mounts file for testing
-	// purposes only.
-	DefaultMountsFile string `toml:"-"`
 
 	// Sysctls to add to all containers.
 	DefaultSysctls []string `toml:"default_sysctls"`
 
 	// DefaultUlimits specifies the default ulimits to apply to containers
 	DefaultUlimits []string `toml:"default_ulimits"`
+
+	// DNS set default DNS servers.
+	DNS string `toml:"default_ulimits"`
+
+	// DNSOptions set default DNS options.
+	DNSOptions []string `toml:"dns_options"`
+
+	// DNSSearches set default DNS search domains.
+	DNSSearches []string `toml:"dns_searches"`
 
 	// EnableLabeling tells the container engines whether to use MAC
 	// Labeling to separate containers (SELinux)
@@ -89,17 +100,30 @@ type ContainersConfig struct {
 	// Env is the environment variable list for container process.
 	Env []string `toml:"env"`
 
+	// EnvHost Pass all host environment variables into the container.
+	EnvHost bool `toml:"env_host"`
+
 	// HooksDir holds paths to the directories containing hooks
 	// configuration files. When the same filename is present in in
 	// multiple directories, the file in the directory listed last in
 	// this slice takes precedence.
 	HooksDir []string `toml:"hooks_dir"`
 
-	// Run an init inside the container that forwards signals and reaps processes.
-	Init bool `toml:"init"`
-
 	// HTTPProxy is the proxy environment variable list to apply to container process
 	HTTPProxy []string `toml:"http_proxy"`
+
+	// Init tells container runtimes whether to run init inside the
+	// container that forwards signals and reaps processes.
+	Init bool `toml:"init"`
+
+	// InitPath is the path for init to run if the Init bool is enabled
+	InitPath string `toml:"init_path"`
+
+	// IPCNS way to to create a ipc namespace for the container
+	IPCNS string `toml:"ipcns"`
+
+	// LogDriver  for the container.  For example: k8s-file and journald
+	LogDriver string `toml:"log_driver"`
 
 	// LogSizeMax is the maximum number of bytes after which the log file
 	// will be truncated. It can be expressed as a human-friendly string
@@ -107,9 +131,18 @@ type ContainersConfig struct {
 	// Negative values indicate that the log file won't be truncated.
 	LogSizeMax int64 `toml:"log_size_max"`
 
+	// NetNS indicates how to create a network namespace for the container
+	NetNS string `toml:"netns"`
+
+	// NoHost tells container engine whether to create its own /etc/hosts
+	NoHost bool `toml:"no_host"`
+
 	// PidsLimit is the number of processes each container is restricted to
 	// by the cgroup process number controller.
 	PidsLimit int64 `toml:"pids_limit"`
+
+	// PidNS indicates how to create a pid namespace for the container
+	PidNS string `toml:"pidns"`
 
 	// SeccompProfile is the seccomp.json profile path which is used as the
 	// default for the runtime.
@@ -121,7 +154,16 @@ type ContainersConfig struct {
 	// SignaturePolicyPath is the path to a signature policy to use for
 	// validating images. If left empty, the containers/image default signature
 	// policy will be used.
-	SignaturePolicyPath string `toml:"signature_policy_path,omitempty"`
+	SignaturePolicyPath string `toml:"_"`
+
+	// UTSNS indicates how to create a UTS namespace for the container
+	UTSNS string `toml:"utsns"`
+
+	// UserNS indicates how to create a User namespace for the container
+	UserNS string `toml:"userns"`
+
+	// UserNSSize how many UIDs to allocate for automatically created UserNS
+	UserNSSize int `toml:"userns_size"`
 }
 
 // LibpodConfig contains configuration options used to set up a libpod runtime

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -1,20 +1,34 @@
 # The containers configuration file specifies all of the available configuration
-# options and command-line flags for container runtime tools like Podman & Buildah,
+# command-line options/flags for container runtime tools like Podman & Buildah,
 # but in a TOML format that can be easily modified and versioned.
 
 # Please refer to containers.conf(5) for details of all configuration options.
+# Not all container tools implement all of the options.
+# All of the options have hard coded defaults and these options will override
+# the built in defaults. Users can then override these options via the command
+# line. Container engines will read containers.conf files in up to three
+# locations in the following order:
+#  1. /usr/share/containers/containers.conf
+#  2. /etc/containers/containers.conf
+#  3. $HOME/.config/containers/containers.conf (Rootless containers ONLY)
+#  Items specified in the latter containers.conf, if they exist, override the
+# previous containers.conf # settings, or the default settings.
 
 [containers]
 
 # List of additional devices. Specified as
-# "<device-on-host>:<device-on-container>:<permissions>", for example: "--device=/dev/sdc:/dev/xvdc:rwm".
-#If it is empty or commented out, only the devices
-# defined in the container json file by the user/kube will be added.
-# additional_devices = [
-# ]
+# "<device-on-host>:<device-on-container>:<permissions>", for example:
+# "/dev/sdc:/dev/xvdc:rwm".
+# If it is empty or commented out, only the default devices will be used
+# additional_devices = []
 
-# Used to change the name of the default AppArmor profile of container engines. The default
-# profile name is "container-default".
+# List of additional volumes. Specified as
+# "<directory-on-host>:<derectory-in-container>:<options>", for example:
+# "/db:/var/lib/db:ro".
+# If it is empty or commented out, no volumes will be added
+# additional_volumes = []
+
+# Used to change the name of the default AppArmor profile of container engines.
 # apparmor_profile = "container-default"
 
 # Default way to to create a cgroup namespace for the container
@@ -24,11 +38,11 @@
 # cgroupns="private"
 
 # Cgroup management implementation used for the runtime.
+# Valid options “systemd” or “cgroupfs”
 # cgroup_manager = "systemd"
 
 # List of default capabilities for containers. If it is empty or commented out,
-# only the capabilities defined in the containers json file by the user/kube
-# will be added.
+# the default capabilities defined in the container engine will be added.
 # default_capabilities = [
 #    "AUDIT_WRITE",
 #    "CHOWN",
@@ -45,41 +59,43 @@
 #    "SYS_CHROOT",
 # ]
 
-# A list of ulimits to be set in containers by default, specified as
-# "<ulimit name>=<soft limit>:<hard limit>", for example:
-# "nofile=1024:2048"
-# See setrlimit(2) for a list of resource names.
-# Any limit not specified here will be inherited from the process launching the container engine
-# default_ulimits = [
-# ]
-
 # List of default sysctls. If it is empty or commented out, only the sysctls
 # defined in the container json file by the user/kube will be added.
 # default_sysctls = [
 # ]
 
+# A list of ulimits to be set in containers by default, specified as
+# "<ulimit name>=<soft limit>:<hard limit>", for example:
+# "nofile=1024:2048"
+# See setrlimit(2) for a list of resource names.
+# Any limit not specified here will be inherited from the process launching the
+# container engine.
+# Ulimits has limits for non privileged container engines.
+# default_ulimits = [
+#  “nofile”=”1280:2560”,
+# ]
+
 # Set default DNS servers.
-# This option can be used to override the DNS configuration passed to the container. Typically this is necessary
-# when the host DNS configuration is invalid for the container (e.g., 127.0.0.1).
-# When  this  is  the case the --dns flags is necessary for every run.
-# The  special  value none can be specified to disable creation of /etc/resolv.conf in the container.
+# This option can be used to override the DNS configuration passed to the
+# container. The special value “none” can be specified to disable creation of
+# /etc/resolv.conf in the container.
 # The /etc/resolv.conf file in the image will be used without changes.
 # dns=
 
 # Set default DNS options.
-# dns-option=
+# dns_options = []
 
 # Set default DNS search domains.
-# dns-search=
+# dns_searches = []
 
-# Environment variable list for the conmon process, used for passing necessary
+# Environment variable list for the conmon process; used for passing necessary
 # environment variables to conmon or the runtime.
 # env = [
 #    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 # ]
 
-# Use host environment inside of the container. See Environment note below for precedence.
-# env-host=false
+# Pass all host environment variables into the container.
+# env_host=false
 
 # Path to OCI hooks directories for automatically executed hooks.
 # hooks_dir = [
@@ -89,39 +105,33 @@
 # Run an init inside the container that forwards signals and reaps processes.
 # init = false
 
-# Default proxy environment variables passed into the container.  The environment variables passed in  include
-# http_proxy,  https_proxy,  ftp_proxy, no_proxy, and also the upper case versions of these.  This option is
-# only needed when the host system must use a proxy but the container should not use any proxy.  Proxy envi‐
-# ronment  variables  specified  for the container in any other way will override the values that would have
-# been passed thru from the host.  (Other ways to specify the proxy for the container  include  passing  the
-# values with the --env flag, or hard coding the proxy environment at container build time.)
-# proxy environment variables are passed into the container
+# Container init binary
+# init_path = "/usr/libexec/podman/catatonit"
+
+# Default proxy environment variables passed into the container.
+# The environment variables passed in include:
+# http_proxy, https_proxy, ftp_proxy, no_proxy, and the upper case versions of
+# these. This option is needed when host system uses a proxy but container
+# should not use proxy. Proxy environment variables specified for the container
+# in any other way will override the values passed from the host.
 # http_proxy=true
 
-# container engines use container separation using MAC(SELinux) labeling.
-# label = true
-
-# Tells container engines how to handle the builtin image volumes.
-#  The options are: bind, tmpfs, or ignore (default bind)
-#  · bind:  A directory is created inside the container state directory and bind mounted into the
-#           container for the volumes.
-#  · tmpfs: The volume is mounted onto the container as a tmpfs, which allows the users to create
-#           content that disappears when the container is stopped.
-#  · ignore: All volumes are just ignored and no action is taken.
-# image-volume="bind"
-
-# Default way to to create a IPC namespace (POSIX SysV IPC) for the container
+# Default way to to create an IPC namespace (POSIX SysV IPC) for the container
 # Options are:
 # `private` Create private IPC Namespace for the container.
 # `host`    Share host IPC Namespace with the container.
 # ipcns="private"
 
+# container engines use container separation using MAC(SELinux) labeling.
+# Flag is ignored on label disabled systems.
+# label = true
+
 # Logging  driver  for the container.  Available options: k8s-file and journald
-# log-driver="k8s-file"
+# log_driver="k8s-file"
 
 # Maximum size allowed for the container log file. Negative numbers indicate
-# that no size limit is imposed. If it is positive, it must be >= 8192 to
-# match/exceed conmon's read buffer. The file is truncated and re-opened so the
+# that no size limit is imposed. If positive, it must be >= 8192 to match or
+# exceed conmon's read buffer. The file is truncated and re-opened so the
 # limit is never exceeded.
 # log_size_max = -1
 
@@ -129,12 +139,15 @@
 # Options are:
 # `private` Create private Network Namespace for the container.
 # `host`    Share host Network Namespace with the container.
-# `none`    Containers do not use the netwoek
+# `none`    Containers do not use the network
 # netns="private"
 
-# Create /etc/hosts for the container.  By default, container engines manage /etc/hosts,  adding  the
-# container's  own  IP  address.
-# no-host="false"
+# Create /etc/hosts for the container.  By default, container engines manage
+# /etc/hosts, automatically adding  the container's  own  IP  address.
+# no_host="false"
+
+# Maximum number of processes allowed in a container.
+# pids_limit = 2048
 
 # Default way to to create a PID namespace for the container
 # Options are:
@@ -142,21 +155,32 @@
 # `host`    Share host PID Namespace with the container.
 # pidns="private"
 
-# Maximum number of processes allowed in a container.
-# pids_limit = 2048
-
 # Path to the seccomp.json profile which is used as the default seccomp profile
 # for the runtime.
 # seccomp_profile = "/usr/share/containers/seccomp.json"
 
 # Size of /dev/shm. Specified as <number><unit>.
-# Unit is optional and can be b (bytes), k (kilobytes), m (megabytes), or g (gigabytes). If the unit is omitted, the system uses bytes.
+# Unit is optional, values:
+# b (bytes), k (kilobytes), m (megabytes), or g (gigabytes).
+# If the unit is omitted, the system uses bytes.
 # shm_size = "65536k"
 
 # Default way to to create a UTS namespace for the container
-# Options are: # `private` Create private UTS Namespace for the container.
+# Options are:
+# `private`        Create private UTS Namespace for the container.
 # `host`    Share host UTS Namespace with the container.
 # utsns="private"
+
+# Default way to to create a User namespace for the container
+# Options are:
+# `auto`        Create unique User Namespace for the container.
+# `host`    Share host User Namespace with the container.
+# userns="host"
+
+# Number of UIDs to allocate for the automatic container creation.
+# UIDs are allocated from the “container” UIDs listed in
+# /etc/subuid & /etc/subgid
+# userns_size=65536
 
 # The network table containers settings pertaining to the management of
 # CNI plugins.
@@ -168,6 +192,9 @@
 # Path to the directory where CNI configuration files are located.
 # network_config_dir = "/etc/cni/net.d/"
 
+# User-mode networking for unprivileged network namespaces executable
+# usermode_tool=”/usr/bin/slirp4netns”
+
 [libpod]
 
 # Default transport method for pulling and pushing for images
@@ -175,25 +202,23 @@
 
 # Environment variables to pass into conmon
 # conmon_env_vars = [
-#		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+#        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 # ]
 
-# Paths to look for the Conmon container manager binary
+# Paths to look for the conmon container manager binary
 # conmon_path = [
-#	    "/usr/libexec/podman/conmon",
-#	    "/usr/local/libexec/podman/conmon",
-#	    "/usr/local/lib/podman/conmon",
-#	    "/usr/bin/conmon",
-#	    "/usr/sbin/conmon",
-#	    "/usr/local/bin/conmon",
-#	    "/usr/local/sbin/conmon"
+#        "/usr/libexec/podman/conmon",
+#        "/usr/local/libexec/podman/conmon",
+#        "/usr/local/lib/podman/conmon",
+#        "/usr/bin/conmon",
+#        "/usr/sbin/conmon",
+#        "/usr/local/bin/conmon",
+#        "/usr/local/sbin/conmon"
 # ]
 
-# Container init binary
-# init_path = "/usr/libexec/podman/catatonit"
 
 # Directory for persistent libpod files (database, etc)
-# By default, this will be configured relative to where containers/storage
+# By default, this will be configured relative to where the containers/storage
 # stores containers
 # Uncomment to change location from this default
 # static_dir = "/var/lib/containers/storage/libpod"
@@ -220,14 +245,11 @@
 
 # Determines whether libpod will reserve ports on the host when they are
 # forwarded to containers. When enabled, when ports are forwarded to containers,
-# they are held open by conmon as long as the container is running, ensuring that
+# ports are held open by as long as the container is running, ensuring that
 # they cannot be reused by other programs on the host. However, this can cause
 # significant memory usage if a container has many ports forwarded to it.
 # Disabling this can save memory.
 # enable_port_reservation = true
-
-# Default libpod support for container labeling
-# label=true
 
 # Number of locks available for containers and pods.
 # If this is changed, a lock renumber must be performed (e.g. with the
@@ -240,15 +262,14 @@
 # Uncomment to change location from this default.
 # volume_path = "/var/lib/containers/storage/volumes"
 
-# Selects which logging mechanism to use for container engine events.  Valid values
-# are `journald` or `file`.
+# Selects which logging mechanism to use for container engine events.
+# Valid values are `journald` or `file`.
 # events_logger = "file"
 
 # Specify the keys sequence used to detach a container.
 # Format is a single character [a-Z] or a comma separated sequence of
 # `ctrl-<value>`, where `<value>` is one of:
 # `a-z`, `@`, `^`, `[`, `\`, `]`, `^` or `_`
-#
 # detach_keys = "ctrl-p,ctrl-q"
 
 # Default OCI runtime
@@ -261,37 +282,27 @@
 # Paths to look for a valid OCI runtime (runc, runv, etc)
 [libpod.runtimes]
 # runc = [
-#		"/usr/bin/runc",
-#		"/usr/sbin/runc",
-#		"/usr/local/bin/runc",
-#		"/usr/local/sbin/runc",
-#		"/sbin/runc",
-#		"/bin/runc",
-#		"/usr/lib/cri-o-runc/sbin/runc",
+#        "/usr/bin/runc",
+#        "/usr/sbin/runc",
+#        "/usr/local/bin/runc",
+#        "/usr/local/sbin/runc",
+#        "/sbin/runc",
+#        "/bin/runc",
+#        "/usr/lib/cri-o-runc/sbin/runc",
 # ]
 
 # crun = [
-#			"/usr/bin/crun",
-#			"/usr/sbin/crun",
-#			"/usr/local/bin/crun",
-#			"/usr/local/sbin/crun",
-#			"/sbin/crun",
-#			"/bin/crun",
-#			"/run/current-system/sw/bin/crun",
+#            "/usr/bin/crun",
+#            "/usr/sbin/crun",
+#            "/usr/local/bin/crun",
+#            "/usr/local/sbin/crun",
+#            "/sbin/crun",
+#            "/bin/crun",
+#            "/run/current-system/sw/bin/crun",
 # ]
 
-# The [libpod.runtimes] table MUST be the last thing in this file.
+# The [libpod.runtimes] table MUST be the last entry in this file.
 # (Unless another table is added)
 # TOML does not provide a way to end a table other than a further table being
 # defined, so every key hereafter will be part of [runtimes] and not the main
 # config.
-
-# The network table containers settings pertaining to the management of
-# CNI plugins.
-[network]
-
-# Path to directory where CNI plugin binaries are located.
-# cni_plugin_dirs = ["/usr/libexec/cni"]
-
-# Path to the directory where CNI configuration files are located.
-# network_config_dir = "/etc/cni/net.d/"

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -17,6 +17,11 @@
 # profile name is "container-default".
 # apparmor_profile = "container-default"
 
+# Default way to to create a cgroup namespace for the container
+# Options are:
+# `private` Create private Cgroup Namespace for the container.
+# `host`    Share host Cgroup Namespace with the container.
+# cgroupns="private"
 
 # Cgroup management implementation used for the runtime.
 # cgroup_manager = "systemd"
@@ -53,25 +58,66 @@
 # default_sysctls = [
 # ]
 
+# Set default DNS servers.
+# This option can be used to override the DNS configuration passed to the container. Typically this is necessary
+# when the host DNS configuration is invalid for the container (e.g., 127.0.0.1).
+# When  this  is  the case the --dns flags is necessary for every run.
+# The  special  value none can be specified to disable creation of /etc/resolv.conf in the container.
+# The /etc/resolv.conf file in the image will be used without changes.
+# dns=
+
+# Set default DNS options.
+# dns-option=
+
+# Set default DNS search domains.
+# dns-search=
+
 # Environment variable list for the conmon process, used for passing necessary
 # environment variables to conmon or the runtime.
 # env = [
 #    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 # ]
 
+# Use host environment inside of the container. See Environment note below for precedence.
+# env-host=false
+
 # Path to OCI hooks directories for automatically executed hooks.
 # hooks_dir = [
+# “/usr/share/containers/oci/hooks.d”,
 # ]
 
 # Run an init inside the container that forwards signals and reaps processes.
 # init = false
 
+# Default proxy environment variables passed into the container.  The environment variables passed in  include
+# http_proxy,  https_proxy,  ftp_proxy, no_proxy, and also the upper case versions of these.  This option is
+# only needed when the host system must use a proxy but the container should not use any proxy.  Proxy envi‐
+# ronment  variables  specified  for the container in any other way will override the values that would have
+# been passed thru from the host.  (Other ways to specify the proxy for the container  include  passing  the
+# values with the --env flag, or hard coding the proxy environment at container build time.)
 # proxy environment variables are passed into the container
-# http_proxy = [
-# ]
+# http_proxy=true
 
-# whether the container tool will support container labeling.
+# container engines use container separation using MAC(SELinux) labeling.
 # label = true
+
+# Tells container engines how to handle the builtin image volumes.
+#  The options are: bind, tmpfs, or ignore (default bind)
+#  · bind:  A directory is created inside the container state directory and bind mounted into the
+#           container for the volumes.
+#  · tmpfs: The volume is mounted onto the container as a tmpfs, which allows the users to create
+#           content that disappears when the container is stopped.
+#  · ignore: All volumes are just ignored and no action is taken.
+# image-volume="bind"
+
+# Default way to to create a IPC namespace (POSIX SysV IPC) for the container
+# Options are:
+# `private` Create private IPC Namespace for the container.
+# `host`    Share host IPC Namespace with the container.
+# ipcns="private"
+
+# Logging  driver  for the container.  Available options: k8s-file and journald
+# log-driver="k8s-file"
 
 # Maximum size allowed for the container log file. Negative numbers indicate
 # that no size limit is imposed. If it is positive, it must be >= 8192 to
@@ -79,16 +125,38 @@
 # limit is never exceeded.
 # log_size_max = -1
 
+# Default way to to create a Network namespace for the container
+# Options are:
+# `private` Create private Network Namespace for the container.
+# `host`    Share host Network Namespace with the container.
+# `none`    Containers do not use the netwoek
+# netns="private"
+
+# Create /etc/hosts for the container.  By default, container engines manage /etc/hosts,  adding  the
+# container's  own  IP  address.
+# no-host="false"
+
+# Default way to to create a PID namespace for the container
+# Options are:
+# `private` Create private PID Namespace for the container.
+# `host`    Share host PID Namespace with the container.
+# pidns="private"
+
 # Maximum number of processes allowed in a container.
 # pids_limit = 2048
 
 # Path to the seccomp.json profile which is used as the default seccomp profile
 # for the runtime.
-# seccomp_profile = "/tmp/seccomp.json"
+# seccomp_profile = "/usr/share/containers/seccomp.json"
 
 # Size of /dev/shm. Specified as <number><unit>.
 # Unit is optional and can be b (bytes), k (kilobytes), m (megabytes), or g (gigabytes). If the unit is omitted, the system uses bytes.
 # shm_size = "65536k"
+
+# Default way to to create a UTS namespace for the container
+# Options are: # `private` Create private UTS Namespace for the container.
+# `host`    Share host UTS Namespace with the container.
+# utsns="private"
 
 # The network table containers settings pertaining to the management of
 # CNI plugins.
@@ -172,7 +240,7 @@
 # Uncomment to change location from this default.
 # volume_path = "/var/lib/containers/storage/volumes"
 
-# Selects which logging mechanism to use for Podman events.  Valid values
+# Selects which logging mechanism to use for container engine events.  Valid values
 # are `journald` or `file`.
 # events_logger = "file"
 
@@ -193,7 +261,7 @@
 # Paths to look for a valid OCI runtime (runc, runv, etc)
 [libpod.runtimes]
 # runc = [
-#	   	"/usr/bin/runc",
+#		"/usr/bin/runc",
 #		"/usr/sbin/runc",
 #		"/usr/local/bin/runc",
 #		"/usr/local/sbin/runc",
@@ -217,3 +285,13 @@
 # TOML does not provide a way to end a table other than a further table being
 # defined, so every key hereafter will be part of [runtimes] and not the main
 # config.
+
+# The network table containers settings pertaining to the management of
+# CNI plugins.
+[network]
+
+# Path to directory where CNI plugin binaries are located.
+# cni_plugin_dirs = ["/usr/libexec/cni"]
+
+# Path to the directory where CNI configuration files are located.
+# network_config_dir = "/etc/cni/net.d/"

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -91,17 +91,20 @@ const (
 	DefaultApparmorProfile = "container-default"
 	// SystemdCgroupsManager represents systemd native cgroup manager
 	SystemdCgroupsManager = "systemd"
+	// DefaultLogDriver is the default type of log files
+	DefaultLogDriver = "k8s-file"
 	// DefaultLogSizeMax is the default value for the maximum log size
 	// allowed for a container. Negative values mean that no limit is imposed.
 	DefaultLogSizeMax = -1
 	// DefaultPidsLimit is the default value for maximum number of processes
 	// allowed inside a container
 	DefaultPidsLimit = 2048
-	// DefaultRootlessSignaturePolicyPath points to the default path of the
 	// rootless policy.json file.
 	DefaultRootlessSignaturePolicyPath = ".config/containers/policy.json"
 	// DefaultShmSize default value
 	DefaultShmSize = "65536k"
+	// DefaultUserNSSize default value
+	DefaultUserNSSize = 65536
 	// OCIBufSize limits maximum LogSizeMax
 	OCIBufSize = 8192
 	// SeccompOverridePath if this exists it overrides the default seccomp path.
@@ -133,23 +136,38 @@ func DefaultConfig() (*Config, error) {
 	return &Config{
 		Containers: ContainersConfig{
 			AdditionalDevices:   []string{},
+			AdditionalVolumes:   []string{},
 			ApparmorProfile:     DefaultApparmorProfile,
 			CgroupManager:       SystemdCgroupsManager,
+			CgroupNS:            "private",
 			DefaultCapabilities: DefaultCapabilities,
 			DefaultSysctls:      []string{},
 			DefaultUlimits:      []string{},
+			DNS:                 "",
+			DNSOptions:          []string{},
+			DNSSearches:         []string{},
 			EnableLabeling:      selinuxEnabled(),
 			Env: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			},
+			EnvHost:             false,
 			HooksDir:            DefaultHooksDirs,
 			HTTPProxy:           []string{},
 			Init:                false,
+			InitPath:            "",
+			IPCNS:               "private",
+			LogDriver:           DefaultLogDriver,
 			LogSizeMax:          DefaultLogSizeMax,
+			NetNS:               "private",
+			NoHost:              false,
 			PidsLimit:           DefaultPidsLimit,
+			PidNS:               "private",
 			SeccompProfile:      SeccompDefaultPath,
 			ShmSize:             DefaultShmSize,
 			SignaturePolicyPath: signaturePolicyPath,
+			UTSNS:               "private",
+			UserNS:              "private",
+			UserNSSize:          DefaultUserNSSize,
 		},
 		Network: NetworkConfig{
 			DefaultNetwork:   "podman",


### PR DESCRIPTION
We also want to be able to default namespaces to host, so that HPC
machines can default to not using most of the namespaces by default.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
