### PR TITLE
containers.conf: change default for infra_command to ""

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -268,7 +268,7 @@ Disabling this can save memory.
 **image_default_transport**="docker://"
   Default transport method for pulling and pushing images.
 
-**infra_command**="/pause"
+**infra_command**=""
   Command to run the infra container.
 
 **infra_image**="k8s.gcr.io/pause:3.1"

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -274,7 +274,7 @@
 
 # Default command to run the infra container
 #
-# infra_command = "/pause"
+# infra_command = ""
 
 # Infra (pause) container image name for pod infra containers.  When running a
 # pod, we start a `pause` process in a container to hold open the namespaces

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -44,7 +44,7 @@ var (
 	// DefaultInfraImage to use for infra container
 	DefaultInfraImage = "k8s.gcr.io/pause:3.1"
 	// DefaultInfraCommand to be run in an infra container
-	DefaultInfraCommand = "/pause"
+	DefaultInfraCommand = ""
 	// DefaultRootlessSHMLockPath is the default path for rootless SHM locks
 	DefaultRootlessSHMLockPath = "/libpod_rootless_lock"
 	// DefaultDetachKeys is the default keys sequence for detaching a

--- a/pkg/config/testdata/containers_comment.conf
+++ b/pkg/config/testdata/containers_comment.conf
@@ -150,7 +150,7 @@
 # infra_image = "k8s.gcr.io/pause:3.1"
 
 # Default command to run the infra container
-# infra_command = "/pause"
+# infra_command = ""
 
 # Determines whether libpod will reserve ports on the host when they are
 # forwarded to containers. When enabled, when ports are forwarded to containers,

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -154,7 +154,7 @@ no_pivot_root = false
 infra_image = "k8s.gcr.io/pause:3.1"
 
 # Default command to run the infra container
-infra_command = "/pause"
+infra_command = ""
 
 # Determines whether libpod will reserve ports on the host when they are
 # forwarded to containers. When enabled, when ports are forwarded to containers,

--- a/pkg/config/testdata/containers_invalid.conf
+++ b/pkg/config/testdata/containers_invalid.conf
@@ -149,7 +149,7 @@ no_pivot_root = false
 infra_image = "k8s.gcr.io/pause:3.1"
 
 # Default command to run the infra container
-infra_command = "/pause"
+infra_command = ""
 
 # Determines whether libpod will reserve ports on the host when they are
 # forwarded to containers. When enabled, when ports are forwarded to containers,


### PR DESCRIPTION
don't override the command specified in the image by default.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
