### PR TITLE
pkg/cgroups: new package

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -1,0 +1,30 @@
+package cgroups
+
+import (
+	"sync"
+	"syscall"
+)
+
+const (
+	cgroupRoot         = "/sys/fs/cgroup"
+	_cgroup2SuperMagic = 0x63677270
+)
+
+var (
+	isUnifiedOnce sync.Once
+	isUnified     bool
+	isUnifiedErr  error
+)
+
+// IsCgroup2UnifiedMode returns whether we are running in cgroup 2 cgroup2 mode.
+func IsCgroup2UnifiedMode() (bool, error) {
+	isUnifiedOnce.Do(func() {
+		var st syscall.Statfs_t
+		if err := syscall.Statfs(cgroupRoot, &st); err != nil {
+			isUnified, isUnifiedErr = false, err
+		} else {
+			isUnified, isUnifiedErr = st.Type == _cgroup2SuperMagic, nil
+		}
+	})
+	return isUnified, isUnifiedErr
+}


### PR DESCRIPTION
add a slimmed down version of pkg/cgroups, as currently needed by
Buildah.  The rest of the implementation is in libpod, and from there
it is used by both Podman and CRI-O.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
