### PR TITLE
unshare: add getenv from cgo

### DIFF
--- a/pkg/unshare/getenv_linux_cgo.go
+++ b/pkg/unshare/getenv_linux_cgo.go
@@ -1,0 +1,22 @@
+// +build linux,cgo
+
+package unshare
+
+import (
+	"unsafe"
+)
+
+/*
+#cgo remoteclient CFLAGS: -Wall -Werror
+#include <stdlib.h>
+*/
+import "C"
+
+func getenv(name string) string {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	value := C.GoString(C.getenv(cName))
+
+	return value
+}

--- a/pkg/unshare/getenv_linux_nocgo.go
+++ b/pkg/unshare/getenv_linux_nocgo.go
@@ -1,0 +1,11 @@
+// +build linux,!cgo
+
+package unshare
+
+import (
+	"os"
+)
+
+func getenv(name string) string {
+	return os.Getenv(name)
+}


### PR DESCRIPTION
if CGO is enabled, make sure to use C.getenv instead of os.Getenv to
read environment variables.  It is required since rootless libpod
joins the user namespace through Cgo.

The variables set via C.setenv are not visible through os.Getenv, as
the latter uses sync.Once to read the variables once.

Requires: https://github.com/containers/libpod/pull/4911

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
