### PR TITLE
Fix a couple of defaults

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -107,7 +107,7 @@ const (
 	// OCIBufSize limits maximum LogSizeMax
 	OCIBufSize = 8192
 	// SeccompOverridePath if this exists it overrides the default seccomp path.
-	SeccompOverridePath = _etcDir + "/crio/seccomp.json"
+	SeccompOverridePath = _etcDir + "/containers/seccomp.json"
 	// SeccompDefaultPath defines the default seccomp path.
 	SeccompDefaultPath = _installPrefix + "/share/containers/seccomp.json"
 )
@@ -156,7 +156,7 @@ func DefaultConfig() (*Config, error) {
 			IPCNS:               "private",
 			LogDriver:           DefaultLogDriver,
 			LogSizeMax:          DefaultLogSizeMax,
-			NetNS:               "private",
+			NetNS:               "bridge",
 			NoHosts:             false,
 			PidsLimit:           DefaultPidsLimit,
 			PidNS:               "private",
@@ -289,7 +289,7 @@ func defaultTmpDir() (string, error) {
 }
 
 // probeConmon calls conmon --version and verifies it is a new enough version for
-// the runtime expectations podman currently has.
+// the runtime expectations the container engine currently has.
 func probeConmon(conmonBinary string) error {
 	cmd := exec.Command(conmonBinary, "--version")
 	var out bytes.Buffer


### PR DESCRIPTION
The default alternative path for seccomp.json should be /etc/containers/seccomp.json

The DefaultNetwork in network config should be bridge

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
