### PR TITLE
Setup default ulimits to nproc & nofile of current process

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -141,7 +141,7 @@ func DefaultConfig() (*Config, error) {
 			CgroupNS:            "private",
 			DefaultCapabilities: DefaultCapabilities,
 			DefaultSysctls:      []string{},
-			DefaultUlimits:      []string{},
+			DefaultUlimits:      getDefaultProcessLimits(),
 			DNSServers:          []string{},
 			DNSOptions:          []string{},
 			DNSSearches:         []string{},

--- a/pkg/config/default_linux.go
+++ b/pkg/config/default_linux.go
@@ -1,7 +1,13 @@
 package config
 
 import (
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"strings"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // isCgroup2UnifiedMode returns whether we are running in cgroup2 mode.
@@ -16,4 +22,42 @@ func isCgroup2UnifiedMode() (isUnified bool, isUnifiedErr error) {
 		isUnified, isUnifiedErr = st.Type == _cgroup2SuperMagic, nil
 	}
 	return
+}
+
+const (
+	oldMaxSize = uint64(1048576)
+)
+
+// getDefaultProcessLimits returns the nofile and nproc for the current process in ulimits format
+// Note that nfile sometimes cannot be set to unlimited, and the limit is hardcoded
+// to (oldMaxSize) 1048576 (2^20), see: http://stackoverflow.com/a/1213069/1811501
+// In rootless containers this will fail, and the process will just use its current limits
+func getDefaultProcessLimits() []string {
+	rlim := unix.Rlimit{Cur: oldMaxSize, Max: oldMaxSize}
+	oldrlim := rlim
+	// Attempt to set file limit and process limit to pid_max in OS
+	dat, err := ioutil.ReadFile("/proc/sys/kernel/pid_max")
+	if err == nil {
+		val := strings.TrimSuffix(string(dat), "\n")
+		max, err := strconv.ParseUint(val, 10, 64)
+		if err == nil {
+			rlim = unix.Rlimit{Cur: uint64(max), Max: uint64(max)}
+		}
+	}
+	defaultLimits := []string{}
+	if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &rlim); err == nil {
+		defaultLimits = append(defaultLimits, fmt.Sprintf("nofile=%d:%d", rlim.Cur, rlim.Max))
+	} else {
+		if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &oldrlim); err == nil {
+			defaultLimits = append(defaultLimits, fmt.Sprintf("nofile=%d:%d", oldrlim.Cur, oldrlim.Max))
+		}
+	}
+	if err := unix.Setrlimit(unix.RLIMIT_NPROC, &rlim); err == nil {
+		defaultLimits = append(defaultLimits, fmt.Sprintf("nproc=%d:%d", rlim.Cur, rlim.Max))
+	} else {
+		if err := unix.Setrlimit(unix.RLIMIT_NPROC, &oldrlim); err == nil {
+			defaultLimits = append(defaultLimits, fmt.Sprintf("nproc=%d:%d", oldrlim.Cur, oldrlim.Max))
+		}
+	}
+	return defaultLimits
 }

--- a/pkg/config/default_unsupported.go
+++ b/pkg/config/default_unsupported.go
@@ -6,3 +6,8 @@ package config
 func isCgroup2UnifiedMode() (isUnified bool, isUnifiedErr error) {
 	return false, nil
 }
+
+// getDefaultProcessLimits returns the nofile and nproc for the current process in ulimits format
+func getDefaultProcessLimits() []string {
+	return []string{}
+}


### PR DESCRIPTION
In root running containers we want to approach the MAX  Number of processes and
open files, so that services running Podman will work when they have lots of open
files or processes.  In rootless containers this number can not be changed.  This
patch will only increase the numbers if the process is allowed.

Docker set the limit to 2**20 (1048576), it looks like this was the max for RHEL5 OS.
So we fall back to attempt to set this limit if the MAC_PROC limit is not allowed.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
