### PR TITLE
Add Default function to read containers config

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -377,7 +377,7 @@ var _ = Describe("Config", func() {
 			}
 
 			// When
-			config, err := NewConfig("")
+			config, err := Default()
 			// Then
 			Expect(err).To(BeNil())
 			Expect(config.GetDefaultEnv()).To(BeEquivalentTo(envs))


### PR DESCRIPTION
This function should be called to return a default config to be used
by callers.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
