### PR TITLE
Use slirp4netns for default network when in rootless mode

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -121,6 +121,7 @@ func DefaultConfig() (*Config, error) {
 	}
 
 	var signaturePolicyPath string
+	netns := "bridge"
 	if unshare.IsRootless() {
 		home, err := unshare.HomeDir()
 		if err != nil {
@@ -130,6 +131,7 @@ func DefaultConfig() (*Config, error) {
 		if _, err := os.Stat(sigPath); err == nil {
 			signaturePolicyPath = sigPath
 		}
+		netns = "slirp4netns"
 	}
 
 	return &Config{
@@ -156,7 +158,7 @@ func DefaultConfig() (*Config, error) {
 			IPCNS:               "private",
 			LogDriver:           DefaultLogDriver,
 			LogSizeMax:          DefaultLogSizeMax,
-			NetNS:               "bridge",
+			NetNS:               netns,
 			NoHosts:             false,
 			PidsLimit:           DefaultPidsLimit,
 			PidNS:               "private",


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
