### PR TITLE
config: add CAP_SETFCAP to the default capabilities

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -73,6 +73,7 @@ var (
 		"CAP_SETPCAP",
 		"CAP_SETUID",
 		"CAP_SYS_CHROOT",
+		"CAP_SETFCAP",
 	}
 )
 


### PR DESCRIPTION
it is needed by Buildah to set file capabilities.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>


More details here: https://github.com/containers/buildah/issues/2176
