### PR TITLE
Add StopTimeout for podman

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -315,6 +315,9 @@ refer to a member of the runtimes table.
 By default this will be configured relative to where containers/storage
 stores containers.
 
+**stop_timeout**=10
+  Number of seconds to wait for container to exit before sending kill signal.
+
 **tmp_dir**="/var/run/libpod"
   The path to a temporary directory to store per-boot container.
 Must be a tmpfs (wiped after reboot).

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -274,6 +274,10 @@ type LibpodConfig struct {
 	// files.
 	StaticDir string `toml:"static_dir"`
 
+	// StopTimeout is the number of seconds to wait for container to exit
+	// before sending kill signal.
+	StopTimeout uint `toml:"stop_timeout"`
+
 	// StorageConfig is the configuration used by containers/storage Not
 	// included in the on-disk config, use the dedicated containers/storage
 	// configuration file instead.

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -365,6 +365,9 @@
 #            "/run/current-system/sw/bin/crun",
 # ]
 
+# Number of seconds to wait for container to exit before sending kill signal.
+#stop_timeout = 10
+
 # The [libpod.runtimes] table MUST be the last entry in this file.
 # (Unless another table is added)
 # TOML does not provide a way to end a table other than a further table being

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -213,6 +213,7 @@ func defaultConfigFromMemory() (*LibpodConfig, error) {
 		c.OCIRuntime = "crun"
 	}
 	c.CgroupManager = SystemdCgroupsManager
+	c.StopTimeout = uint(10)
 
 	c.OCIRuntimes = map[string][]string{
 		"runc": {


### PR DESCRIPTION
Allow users to modify the default ammount of time to wait to send SIGKILL
after you tell a container to stop with a SIGINT.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
