### PR TITLE
list of label specification for required capabilities 

### DIFF
--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -18,6 +18,10 @@ var (
 
 	// ErrUnknownCapability is thrown when an unknown capability is processed.
 	ErrUnknownCapability = errors.New("unknown capability")
+
+	// ContainerImageLabels - label can indicate the required
+	// capabilities required by containers to run the container image.
+	ContainerImageLabels = []string{"io.containers.capabilities"}
 )
 
 // All is a special value used to add/drop all known capababilities.
@@ -47,6 +51,7 @@ func stringInSlice(s string, sl []string) bool {
 	}
 	return false
 }
+
 // AllCapabilities returns all known capabilities.
 func AllCapabilities() []string {
 	return capabilityList


### PR DESCRIPTION
These labels allows users to specify the list of capabilities required
to run their container image.

Setting a image/container label "io.containers.capabilities=setuid,setgid"
will tell container engines that the contained image should work fine withi
just these two capabilties, instead of running with the default capabilities,

Defined as a list, since this has not been standardized yet, we want to make
this a standard, and the standard label might be different then the label we
choose, so eventually we might need to add a standard label.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>