### PR TITLE
Add pull_policy to LibpodConfig

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -274,7 +274,7 @@ Disabling this can save memory.
 **infra_image**="k8s.gcr.io/pause:3.1"
   Infra (pause) container image name for pod infra containers.  When running a
 pod, we start a `pause` process in a container to hold open the namespaces
-associated with the  pod.  This container does nothing other then sleep, 
+associated with the  pod.  This container does nothing other then sleep,
 reserving the pods resources for the lifetime of the pod.
 
 **lock_type**="shm"
@@ -299,6 +299,13 @@ and pods are visible.
 pod consumes one lock.  The default number available is 2048.  If this is
 changed, a lock renumbering must be performed, using the
 `podman system renumber` command.
+
+**pull_policy**="always"|"missing"|"never"
+Pull image before running or creating a container. The default is **missing**.
+
+- **missing**: attempt to pull the latest image from the registries listed in registries.conf if a local image does not exist. Raise an error if the image is not in any listed registry and is not present locally.
+- **always**: pull the image from the first registry it is found in as listed in registries.conf. Raise an error if not found in the registries, even if the image is present locally.
+- **never**: do not pull the image from the registry, use only the local version. Raise an error if the image is not present locally.
 
 **runtime**="crun"
   Default OCI specific runtime in runtimes that will be used by default. Must

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -464,5 +464,20 @@ var _ = Describe("Config", func() {
 			sort.Strings(caps)
 			Expect(caps).To(BeEquivalentTo(addcaps))
 		})
+
+		It("should succeed with default pull_policy", func() {
+			err := sut.Libpod.Validate()
+			Expect(err).To(BeNil())
+			Expect(sut.Libpod.PullPolicy).To(Equal("missing"))
+
+			sut.Libpod.PullPolicy = DefaultPullPolicy
+			err = sut.Libpod.Validate()
+			Expect(err).To(BeNil())
+		})
+		It("should fail with invalid pull_policy", func() {
+			sut.Libpod.PullPolicy = "invalidPullPolicy"
+			err := sut.Libpod.Validate()
+			Expect(err).ToNot(BeNil())
+		})
 	})
 })

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -316,6 +316,9 @@
 #
 # num_locks = 2048
 
+# Whether to pull new image before running a container
+# pull_policy = "missing"
+
 # Directory for persistent libpod files (database, etc)
 # By default, this will be configured relative to where the containers/storage
 # stores containers

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -98,6 +98,8 @@ const (
 	// DefaultPidsLimit is the default value for maximum number of processes
 	// allowed inside a container
 	DefaultPidsLimit = 2048
+	// DefaultPullPolicy pulls the image if it does not exist locally
+	DefaultPullPolicy = "missing"
 	// DefaultRootlessSignaturePolicyPath is the default value for the
 	// rootless policy.json file.
 	DefaultRootlessSignaturePolicyPath = ".config/containers/policy.json"
@@ -249,6 +251,7 @@ func defaultConfigFromMemory() (*LibpodConfig, error) {
 		"/usr/local/sbin/conmon",
 		"/run/current-system/sw/bin/conmon",
 	}
+	c.PullPolicy = DefaultPullPolicy
 	c.RuntimeSupportsJSON = []string{
 		"crun",
 		"runc",


### PR DESCRIPTION
feature required from https://github.com/containers/libpod/issues/4535#issuecomment-592062482
pull_policy is the same as podman run --pull option to determine whether to pull a new image when running a container.
Accepted "always", "missing", and "never". Default value is "missing".
Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
