### PR TITLE
remove CgroupsAndAdjust from NewConfig

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -422,7 +422,6 @@ func NewConfig(userConfigPath string) (*Config, error) {
 		logrus.Debugf("Merged system config %q: %v", path, config)
 	}
 
-	config.checkCgroupsAndAdjustConfig()
 	config.addCAPPrefix()
 
 	if err := config.Validate(); err != nil {
@@ -485,10 +484,10 @@ func systemConfigs() ([]string, error) {
 	return configs, nil
 }
 
-// checkCgroupsAndAdjustConfig checks if we're running rootless with the systemd
+// CheckCgroupsAndAdjustConfig checks if we're running rootless with the systemd
 // cgroup manager. In case the user session isn't available, we're switching the
 // cgroup manager to cgroupfs.  Note, this only applies to rootless.
-func (c *Config) checkCgroupsAndAdjustConfig() {
+func (c *Config) CheckCgroupsAndAdjustConfig() {
 	if !unshare.IsRootless() || c.Libpod.CgroupManager != SystemdCgroupsManager {
 		return
 	}


### PR DESCRIPTION
Export CheckCgroupsAndAdjustConfig() as global function and remove it from NewConfig(). So we can handle it in libpod and avoid Buildah to display cgroup warning message when reading containers.conf.

Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
