### PR TITLE
NewConfig(): passed-in configuration file should matter most

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -394,18 +394,6 @@ func NewConfig(userConfigPath string) (*Config, error) {
 		logrus.Errorf("error reading libpod.conf: %v", err)
 	}
 
-	// If the caller specified a config path to use, then we read this
-	// rather then using the system defaults.
-	if userConfigPath != "" {
-		var err error
-		// readConfigFromFile reads in container config in the specified
-		// file and then merge changes with the current default.
-		config, err = readConfigFromFile(userConfigPath, config)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error reading user config %q", userConfigPath)
-		}
-	}
-
 	// Now, gather the system configs and merge them as needed.
 	configs, err := systemConfigs()
 	if err != nil {
@@ -422,6 +410,18 @@ func NewConfig(userConfigPath string) (*Config, error) {
 		logrus.Debugf("Merged system config %q: %v", path, config)
 	}
 
+	// If the caller specified a config path to use, then we read it to
+	// override the system defaults.
+	if userConfigPath != "" {
+		var err error
+		// readConfigFromFile reads in container config in the specified
+		// file and then merge changes with the current default.
+		config, err = readConfigFromFile(userConfigPath, config)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading user config %q", userConfigPath)
+		}
+		logrus.Debugf("Merged user config %q: %v", userConfigPath, config)
+	}
 	config.addCAPPrefix()
 
 	if err := config.Validate(); err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -405,6 +405,24 @@ var _ = Describe("Config", func() {
 			Expect(config.Containers.PidsLimit).To(BeEquivalentTo(2048))
 		})
 
+		It("contents of passed-in file should override others", func() {
+			// Given we do
+			oldContainersConf, envSet := os.LookupEnv("CONTAINERS_CONF")
+			os.Setenv("CONTAINERS_CONF", "containers.conf")
+			// When
+			config, err := NewConfig("testdata/containers_override.conf")
+			// Undo that
+			if envSet {
+				os.Setenv("CONTAINERS_CONF", oldContainersConf)
+			} else {
+				os.Unsetenv("CONTAINERS_CONF")
+			}
+			// Then
+			Expect(err).To(BeNil())
+			Expect(config).ToNot(BeNil())
+			Expect(config.Containers.ApparmorProfile).To(Equal("overridden-default"))
+		})
+
 		It("should fail with invalid value", func() {
 			// Given
 			// When

--- a/pkg/config/testdata/containers_override.conf
+++ b/pkg/config/testdata/containers_override.conf
@@ -1,0 +1,3 @@
+[containers]
+
+apparmor_profile = "overridden-default"


### PR DESCRIPTION
In NewConfig(), settings in the file whose name we're passed should
matter more than the hardwired default files, or the file named in the
CONTAINERS_CONF environment variable.

Signed-off-by: Nalin Dahyabhai <nalin@redhat.com>
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
