### PR TITLE
pkg/pwalk: add

### DIFF
--- a/pkg/pwalk/pwalk.go
+++ b/pkg/pwalk/pwalk.go
@@ -1,0 +1,99 @@
+package pwalk
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+type WalkFunc = filepath.WalkFunc
+
+// Walk is a wrapper for filepath.Walk which can call multiple walkFn
+// in parallel, allowing to handle each item concurrently. A maximum of
+// twice the runtime.NumCPU() walkFn will be called at any one time.
+// If you want to change the maximum, use WalkN instead.
+//
+// The order of calls is non-deterministic.
+//
+// Note that this implementation only supports primitive error handling:
+//
+// * no errors are ever passed to WalkFn
+//
+// * once a walkFn returns any error, all further processing stops
+//   and the error is returned to the caller of Walk;
+//
+// * filepath.SkipDir is not supported;
+//
+// * if more than one walkFn instance will return an error, only one
+//   of such errors will be propagated and returned by Walk, others
+//   will be silently discarded.
+//
+func Walk(root string, walkFn WalkFunc) error {
+	return WalkN(root, walkFn, runtime.NumCPU()*2)
+}
+
+// WalkN is a wrapper for filepath.Walk which can call multiple walkFn
+// in parallel, allowing to handle each item concurrently. A maximum of
+// num walkFn will be called at any one time.
+func WalkN(root string, walkFn WalkFunc, num int) error {
+	// make sure limit is sensible
+	if num < 1 {
+		return errors.Errorf("walk(%q): num must be > 0", root)
+	}
+
+	files := make(chan *walkArgs, 2*num)
+	errCh := make(chan error, 1) // get the first error, ignore others
+
+	// Start walking a tree asap
+	var err error
+	go func() {
+		err = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+			if err != nil {
+				close(files)
+				return err
+			}
+			// add a file to the queue unless a callback sent an error
+			select {
+			case e := <-errCh:
+				close(files)
+				return e
+			default:
+				files <- &walkArgs{path: p, info: &info}
+				return nil
+			}
+		})
+		if err == nil {
+			close(files)
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(num)
+	for i := 0; i < num; i++ {
+		go func() {
+			for file := range files {
+				if e := walkFn(file.path, *file.info, nil); e != nil {
+					select {
+					case errCh <- e: // sent ok
+					default: // buffer full
+					}
+				}
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	return err
+}
+
+// walkArgs holds the arguments that were passed to the Walk or WalkLimit
+// functions.
+type walkArgs struct {
+	path string
+	info *os.FileInfo
+}

--- a/pkg/pwalk/pwalk_test.go
+++ b/pkg/pwalk/pwalk_test.go
@@ -1,0 +1,217 @@
+package pwalk
+
+import (
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func TestWalk(t *testing.T) {
+	var count uint32
+	concurrency := runtime.NumCPU() * 2
+
+	dir, total, err := prepareTestSet(3, 2, 1)
+	if err != nil {
+		t.Fatalf("dataset creation failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	err = WalkN(dir,
+		func(_ string, _ os.FileInfo, _ error) error {
+			atomic.AddUint32(&count, 1)
+			return nil
+		},
+		concurrency)
+
+	if err != nil {
+		t.Errorf("Walk failed: %v", err)
+	}
+	if count != uint32(total) {
+		t.Errorf("File count mismatch: found %d, expected %d", count, total)
+	}
+
+	t.Logf("concurrency: %d, files found: %d\n", concurrency, count)
+}
+
+func TestWalkManyErrors(t *testing.T) {
+	var count uint32
+
+	dir, total, err := prepareTestSet(3, 3, 2)
+	if err != nil {
+		t.Fatalf("dataset creation failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	max := uint32(total / 2)
+	e42 := errors.New("42")
+	err = Walk(dir,
+		func(p string, i os.FileInfo, _ error) error {
+			if atomic.AddUint32(&count, 1) > max {
+				return e42
+			}
+			return nil
+		})
+	t.Logf("found %d of %d files", count, total)
+
+	if err == nil {
+		t.Errorf("Walk succeeded, but error is expected")
+		if count != uint32(total) {
+			t.Errorf("File count mismatch: found %d, expected %d", count, total)
+		}
+	}
+}
+
+func makeManyDirs(prefix string, levels, dirs, files int) (count int, err error) {
+	for d := 0; d < dirs; d++ {
+		var dir string
+		dir, err = ioutil.TempDir(prefix, "d-")
+		if err != nil {
+			return
+		}
+		count++
+		for f := 0; f < files; f++ {
+			fi, err := ioutil.TempFile(dir, "f-")
+			if err != nil {
+				return count, err
+			}
+			fi.Close()
+			count++
+		}
+		if levels == 0 {
+			continue
+		}
+		var c int
+		if c, err = makeManyDirs(dir, levels-1, dirs, files); err != nil {
+			return
+		}
+		count += c
+	}
+
+	return
+}
+
+// prepareTestSet() creates a directory tree of shallow files,
+// to be used for testing or benchmarking.
+//
+// Total dirs: dirs^levels + dirs^(levels-1) + ... + dirs^1
+// Total files: total_dirs * files
+func prepareTestSet(levels, dirs, files int) (dir string, total int, err error) {
+	dir, err = ioutil.TempDir(".", "pwalk-test-")
+	if err != nil {
+		return
+	}
+	total, err = makeManyDirs(dir, levels, dirs, files)
+	if err != nil && total > 0 {
+		_ = os.RemoveAll(dir)
+		dir = ""
+		total = 0
+		return
+	}
+	total++ // this dir
+
+	return
+}
+
+type walkerFunc func(root string, walkFn WalkFunc) error
+
+func genWalkN(n int) walkerFunc {
+	return func(root string, walkFn WalkFunc) error {
+		return WalkN(root, walkFn, n)
+	}
+}
+
+func BenchmarkWalk(b *testing.B) {
+	const (
+		levels = 5 // how deep
+		dirs   = 3 // dirs on each levels
+		files  = 8 // files on each levels
+	)
+
+	benchmarks := []struct {
+		name string
+		walk filepath.WalkFunc
+	}{
+		{"Empty", cbEmpty},
+		{"ReadFile", cbReadFile},
+		{"ChownChmod", cbChownChmod},
+		{"RandomSleep", cbRandomSleep},
+	}
+
+	walkers := []struct {
+		name   string
+		walker walkerFunc
+	}{
+		{"filepath.Walk", filepath.Walk},
+		{"pwalk.Walk", Walk},
+		// test WalkN with various values of N
+		{"pwalk.Walk1", genWalkN(1)},
+		{"pwalk.Walk2", genWalkN(2)},
+		{"pwalk.Walk4", genWalkN(4)},
+		{"pwalk.Walk8", genWalkN(8)},
+		{"pwalk.Walk16", genWalkN(16)},
+		{"pwalk.Walk32", genWalkN(32)},
+		{"pwalk.Walk64", genWalkN(64)},
+		{"pwalk.Walk128", genWalkN(128)},
+		{"pwalk.Walk256", genWalkN(256)},
+	}
+
+	dir, total, err := prepareTestSet(levels, dirs, files)
+	if err != nil {
+		b.Fatalf("dataset creation failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	b.Logf("dataset: %d levels x %d dirs x %d files, total entries: %d", levels, dirs, files, total)
+
+	for _, bm := range benchmarks {
+		for _, w := range walkers {
+			// preheat
+			err := w.walker(dir, bm.walk)
+			if err != nil {
+				b.Errorf("walk failed: %v", err)
+			}
+			// benchmark
+			b.Run(bm.name+"/"+w.name, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					err := w.walker(dir, bm.walk)
+					if err != nil {
+						b.Errorf("walk failed: %v", err)
+					}
+				}
+			})
+		}
+	}
+}
+func cbEmpty(_ string, _ os.FileInfo, _ error) error {
+	return nil
+}
+
+func cbChownChmod(path string, info os.FileInfo, _ error) error {
+	_ = os.Chown(path, 0, 0)
+	mode := os.FileMode(0644)
+	if info.Mode().IsDir() {
+		mode = os.FileMode(0755)
+	}
+	_ = os.Chmod(path, mode)
+
+	return nil
+}
+
+func cbReadFile(path string, info os.FileInfo, _ error) error {
+	var err error
+	if info.Mode().IsRegular() {
+		_, err = ioutil.ReadFile(path)
+	}
+	return err
+}
+
+func cbRandomSleep(_ string, _ os.FileInfo, _ error) error {
+	time.Sleep(time.Duration(rand.Intn(500)) * time.Microsecond)
+	return nil
+}


### PR DESCRIPTION
_This is a continuation of https://github.com/opencontainers/selinux/pull/85_

Here is a simple implementation of the parallel wrapper for
`filepath.Walk()`, together with some tests and benchmarks.

Here are the benchmark results on my system:

    pwalk_test.go:170: dataset: 5 levels x 3 dirs x 8 files, total entries: 9829
```
 BenchmarkWalk/Empty/filepath.Walk-8         	      51	  24314013 ns/op
 BenchmarkWalk/Empty/pwalk.Walk-8            	      42	  27407753 ns/op
 BenchmarkWalk/Empty/pwalk.Walk1-8           	      37	  31655582 ns/op
 BenchmarkWalk/Empty/pwalk.Walk2-8           	      42	  29311951 ns/op
 BenchmarkWalk/Empty/pwalk.Walk4-8           	      36	  29659797 ns/op
 BenchmarkWalk/Empty/pwalk.Walk8-8           	      44	  28769908 ns/op
 BenchmarkWalk/Empty/pwalk.Walk16-8          	      39	  28937859 ns/op
 BenchmarkWalk/Empty/pwalk.Walk32-8          	      43	  29440959 ns/op
 BenchmarkWalk/Empty/pwalk.Walk64-8          	      38	  28646496 ns/op
 BenchmarkWalk/Empty/pwalk.Walk128-8         	      39	  29820103 ns/op
 BenchmarkWalk/Empty/pwalk.Walk256-8         	      38	  30174497 ns/op
```
The above demonstrates that with a `WalkFunc` callback that does nothing,
the standard non-parallel `filewalk.Path()` is slightly faster.
```
 BenchmarkWalk/ReadFile/filepath.Walk-8      	      20	  54162126 ns/op
 BenchmarkWalk/ReadFile/pwalk.Walk-8         	      34	  38372824 ns/op
 BenchmarkWalk/ReadFile/pwalk.Walk1-8        	      19	  62364024 ns/op
 BenchmarkWalk/ReadFile/pwalk.Walk2-8        	      26	  45500299 ns/op
 BenchmarkWalk/ReadFile/pwalk.Walk4-8        	      28	  41370507 ns/op
 BenchmarkWalk/ReadFile/pwalk.Walk8-8        	      30	  39541122 ns/op
 BenchmarkWalk/ReadFile/pwalk.Walk16-8       	      26	  39121315 ns/op
 BenchmarkWalk/ReadFile/pwalk.Walk32-8       	      26	  40195071 ns/op
 BenchmarkWalk/ReadFile/pwalk.Walk64-8       	      26	  42273973 ns/op
 BenchmarkWalk/ReadFile/pwalk.Walk128-8      	      28	  44640605 ns/op
 BenchmarkWalk/ReadFile/pwalk.Walk256-8      	      24	  43597203 ns/op
```
The above is using `ioutil.ReadFile` from the callback, which is basically
open(2)/read(2)/close(2) on an empty file. We're about 1.5x faster, and
the default value of N (number of goroutines) seems about right.

```
BenchmarkWalk/ChownChmod/filepath.Walk-8    	      22	  51600403 ns/op
BenchmarkWalk/ChownChmod/pwalk.Walk-8       	      28	  39505016 ns/op
BenchmarkWalk/ChownChmod/pwalk.Walk1-8      	      20	  60695986 ns/op
BenchmarkWalk/ChownChmod/pwalk.Walk2-8      	      24	  43997855 ns/op
BenchmarkWalk/ChownChmod/pwalk.Walk4-8      	      26	  42751334 ns/op
BenchmarkWalk/ChownChmod/pwalk.Walk8-8      	      28	  40393079 ns/op
BenchmarkWalk/ChownChmod/pwalk.Walk16-8     	      26	  40208890 ns/op
BenchmarkWalk/ChownChmod/pwalk.Walk32-8     	      27	  40503644 ns/op
BenchmarkWalk/ChownChmod/pwalk.Walk64-8     	      25	  98909603 ns/op
BenchmarkWalk/ChownChmod/pwalk.Walk128-8    	      10	 106485862 ns/op
BenchmarkWalk/ChownChmod/pwalk.Walk256-8    	      13	  80749219 ns/op
```

The above is doing chown and chmod for every file, ignoring all the
errors. We're about 1.4x faster. Default value of N seems about right.
```
BenchmarkWalk/RandomSleep/filepath.Walk-8   	       1	3750651296 ns/op
BenchmarkWalk/RandomSleep/pwalk.Walk-8      	       6	 187372176 ns/op
BenchmarkWalk/RandomSleep/pwalk.Walk1-8     	       1	3517246749 ns/op
BenchmarkWalk/RandomSleep/pwalk.Walk2-8     	       1	1703204737 ns/op
BenchmarkWalk/RandomSleep/pwalk.Walk4-8     	       2	 750193674 ns/op
BenchmarkWalk/RandomSleep/pwalk.Walk8-8     	       3	 367212793 ns/op
BenchmarkWalk/RandomSleep/pwalk.Walk16-8    	       6	 182113053 ns/op
BenchmarkWalk/RandomSleep/pwalk.Walk32-8    	      13	  90775123 ns/op
BenchmarkWalk/RandomSleep/pwalk.Walk64-8    	      24	  45202819 ns/op
BenchmarkWalk/RandomSleep/pwalk.Walk128-8   	      31	  35768138 ns/op
BenchmarkWalk/RandomSleep/pwalk.Walk256-8   	      28	  36492082 ns/op
```
The above is using a callback doing a random sleep from 0 to 500 us.
This is way too long and is not using any CPUs, so adding more
goroutines help.

The conclusion, I guess, is in most cases the parallel implementation is faster,
and the default number of threads seems about right, except cases when
the callback is really taking a long time (such as maybe waiting for a
disk or network).