### PR TITLE
Drop StorageConfig from containers config structures

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -203,7 +203,6 @@ func defaultConfigFromMemory() (*LibpodConfig, error) {
 	}
 	c.StaticDir = filepath.Join(storeOpts.GraphRoot, "libpod")
 	c.VolumePath = filepath.Join(storeOpts.GraphRoot, "volumes")
-	c.StorageConfig = storeOpts
 
 	c.HooksDir = DefaultHooksDirs
 	c.ImageDefaultTransport = _defaultTransport


### PR DESCRIPTION
Callers should use containers/storage directly.

Also remove MergeDBConfig, this is no longer used by any callers.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
