### PR TITLE
Change references to libpod to engine 

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -217,8 +217,8 @@ plugins.
 **network_config_dir**="/etc/cni/net.d/"
   Path to the directory where CNI configuration files are located.
 
-## LIBPOD TABLE
-The `libpod` table contains configuration options used to set up a libpod runtime.
+## ENGINE TABLE
+The `engine` table contains configuration options used to set up container engines such as Podman and Buildah.
 
 **cgroup_check**=false
 CgroupCheck indicates the configuration has been rewritten after an upgrade to Fedora 31 to change the default OCI runtime for cgroupsv2.
@@ -257,7 +257,7 @@ Format is a single character `[a-Z]` or a comma separated sequence of
 `a-z`, `@`, `^`, `[`, `\`, `]`, `^` or `_`
 
 **enable_port_reservation**=true
-  Determines whether libpod will reserve ports on the host when they are
+  Determines whether the engine will reserve ports on the host when they are
 forwarded to containers. When enabled, when ports are forwarded to containers,
 they are held open by conmon as long as the container is running, ensuring that
 they cannot be reused by other programs on the host. However, this can cause
@@ -288,7 +288,7 @@ faster "shm" lock type.  You may need to run "podman system renumber" after you
 change the lock type.
 
 **namespace**=""
-  Default libpod namespace. If libpod is joined to a namespace, it will see
+  Default engine namespace. If the engine is joined to a namespace, it will see
 only containers and pods that were created in the same namespace, and will
 create new containers and pods in that namespace.  The default namespace is "",
  which corresponds to no namespace. When no namespace is set, all containers

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -284,12 +284,12 @@ var _ = Describe("Config", func() {
 
 			// Then
 			Expect(err).To(BeNil())
-			Expect(defaultConfig.Libpod.CgroupManager).To(Equal("systemd"))
+			Expect(defaultConfig.Engine.CgroupManager).To(Equal("systemd"))
 			Expect(defaultConfig.Containers.Env).To(BeEquivalentTo(envs))
 			Expect(defaultConfig.Containers.PidsLimit).To(BeEquivalentTo(2048))
 			Expect(defaultConfig.Network.CNIPluginDirs).To(Equal(pluginDirs))
-			Expect(defaultConfig.Libpod.NumLocks).To(BeEquivalentTo(2048))
-			Expect(defaultConfig.Libpod.OCIRuntimes).To(Equal(OCIRuntimeMap))
+			Expect(defaultConfig.Engine.NumLocks).To(BeEquivalentTo(2048))
+			Expect(defaultConfig.Engine.OCIRuntimes).To(Equal(OCIRuntimeMap))
 		})
 
 		It("should succeed with commented out configuration", func() {
@@ -367,8 +367,8 @@ var _ = Describe("Config", func() {
 			Expect(config.Containers.PidsLimit).To(BeEquivalentTo(2048))
 			Expect(config.Containers.Env).To(BeEquivalentTo(envs))
 			Expect(config.Network.CNIPluginDirs).To(Equal(pluginDirs))
-			Expect(config.Libpod.NumLocks).To(BeEquivalentTo(2048))
-			Expect(config.Libpod.OCIRuntimes["runc"]).To(Equal(OCIRuntimeMap["runc"]))
+			Expect(config.Engine.NumLocks).To(BeEquivalentTo(2048))
+			Expect(config.Engine.OCIRuntimes["runc"]).To(Equal(OCIRuntimeMap["runc"]))
 		})
 
 		It("verify getDefaultEnv", func() {
@@ -484,17 +484,17 @@ var _ = Describe("Config", func() {
 		})
 
 		It("should succeed with default pull_policy", func() {
-			err := sut.Libpod.Validate()
+			err := sut.Engine.Validate()
 			Expect(err).To(BeNil())
-			Expect(sut.Libpod.PullPolicy).To(Equal("missing"))
+			Expect(sut.Engine.PullPolicy).To(Equal("missing"))
 
-			sut.Libpod.PullPolicy = DefaultPullPolicy
-			err = sut.Libpod.Validate()
+			sut.Engine.PullPolicy = DefaultPullPolicy
+			err = sut.Engine.Validate()
 			Expect(err).To(BeNil())
 		})
 		It("should fail with invalid pull_policy", func() {
-			sut.Libpod.PullPolicy = "invalidPullPolicy"
-			err := sut.Libpod.Validate()
+			sut.Engine.PullPolicy = "invalidPullPolicy"
+			err := sut.Engine.Validate()
 			Expect(err).ToNot(BeNil())
 		})
 	})

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -1,9 +1,9 @@
 # The containers configuration file specifies all of the available configuration
-# command-line options/flags for container runtime tools like Podman & Buildah,
+# command-line options/flags for container engine tools like Podman & Buildah,
 # but in a TOML format that can be easily modified and versioned.
 
 # Please refer to containers.conf(5) for details of all configuration options.
-# Not all container tools implement all of the options.
+# Not all container engines implement all of the options.
 # All of the options have hard coded defaults and these options will override
 # the built in defaults. Users can then override these options via the command
 # line. Container engines will read containers.conf files in up to three
@@ -30,7 +30,7 @@
 #
 # volumes = []
 
-# Used to change the name of the default AppArmor profile of container engines.
+# Used to change the name of the default AppArmor profile of container engine.
 #
 # apparmor_profile = "container-default"
 
@@ -143,7 +143,8 @@
 #
 # ipcns = "private"
 
-# container engines use container separation using MAC(SELinux) labeling.
+# Flag tells container engine to whether to use container separation using
+# MAC(SELinux)labeling or not.
 # Flag is ignored on label disabled systems.
 #
 # label = true
@@ -167,7 +168,7 @@
 #
 # netns = "private"
 
-# Create /etc/hosts for the container.  By default, container engines manage
+# Create /etc/hosts for the container.  By default, container engine manage
 # /etc/hosts, automatically adding  the container's  own  IP  address.
 #
 # no_hosts = false
@@ -228,7 +229,7 @@
 #
 # network_config_dir = "/etc/cni/net.d/"
 
-[libpod]
+[engine]
 
 # Cgroup management implementation used for the runtime.
 # Valid options “systemd” or “cgroupfs”
@@ -260,7 +261,7 @@
 #
 # detach_keys = "ctrl-p,ctrl-q"
 
-# Determines whether libpod will reserve ports on the host when they are
+# Determines whether engine will reserve ports on the host when they are
 # forwarded to containers. When enabled, when ports are forwarded to containers,
 # ports are held open by as long as the container is running, ensuring that
 # they cannot be reused by other programs on the host. However, this can cause
@@ -297,8 +298,8 @@
 #
 # lock_type** = "shm"
 
-# Default libpod namespace
-# If libpod is joined to a namespace, it will see only containers and pods
+# Default engine namespace
+# If engine is joined to a namespace, it will see only containers and pods
 # that were created in the same namespace, and will create new containers and
 # pods in that namespace.
 # The default namespace is "", which corresponds to no namespace. When no
@@ -319,7 +320,7 @@
 # Whether to pull new image before running a container
 # pull_policy = "missing"
 
-# Directory for persistent libpod files (database, etc)
+# Directory for persistent engine files (database, etc)
 # By default, this will be configured relative to where the containers/storage
 # stores containers
 # Uncomment to change location from this default
@@ -342,12 +343,12 @@
 # runtime = "runc"
 
 # List of the OCI runtimes that support --format=json.  When json is supported
-# libpod will use it for reporting nicer errors.
+# engine will use it for reporting nicer errors.
 #
 # runtime_supports_json = ["crun", "runc"]
 
 # Paths to look for a valid OCI runtime (runc, runv, etc)
-[libpod.runtimes]
+[engine.runtimes]
 # runc = [
 #        "/usr/bin/runc",
 #        "/usr/sbin/runc",
@@ -371,7 +372,7 @@
 # Number of seconds to wait for container to exit before sending kill signal.
 #stop_timeout = 10
 
-# The [libpod.runtimes] table MUST be the last entry in this file.
+# The [engine.runtimes] table MUST be the last entry in this file.
 # (Unless another table is added)
 # TOML does not provide a way to end a table other than a further table being
 # defined, so every key hereafter will be part of [runtimes] and not the main

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -118,7 +118,7 @@ const (
 // DefaultConfig defines the default values from containers.conf
 func DefaultConfig() (*Config, error) {
 
-	defaultLibpodConfig, err := defaultConfigFromMemory()
+	defaultEngineConfig, err := defaultConfigFromMemory()
 	if err != nil {
 		return nil, err
 	}
@@ -177,14 +177,14 @@ func DefaultConfig() (*Config, error) {
 			NetworkConfigDir: cniConfigDir,
 			CNIPluginDirs:    cniBinDir,
 		},
-		Libpod: *defaultLibpodConfig,
+		Engine: *defaultEngineConfig,
 	}, nil
 }
 
-// defaultConfigFromMemory returns a default libpod configuration. Note that the
+// defaultConfigFromMemory returns a default engine configuration. Note that the
 // config is different for root and rootless. It also parses the storage.conf.
-func defaultConfigFromMemory() (*LibpodConfig, error) {
-	c := new(LibpodConfig)
+func defaultConfigFromMemory() (*EngineConfig, error) {
+	c := new(EngineConfig)
 	tmp, err := defaultTmpDir()
 	if err != nil {
 		return nil, err

--- a/pkg/config/libpodConfig.go
+++ b/pkg/config/libpodConfig.go
@@ -307,33 +307,33 @@ func (c *Config) libpodConfig() *ConfigFromLibpod {
 		MaxLogSize:          c.Containers.LogSizeMax,
 		EnableLabeling:      c.Containers.EnableLabeling,
 
-		SetOptions:               c.Libpod.SetOptions,
-		VolumePath:               c.Libpod.VolumePath,
-		ImageDefaultTransport:    c.Libpod.ImageDefaultTransport,
-		OCIRuntime:               c.Libpod.OCIRuntime,
-		OCIRuntimes:              c.Libpod.OCIRuntimes,
-		RuntimeSupportsJSON:      c.Libpod.RuntimeSupportsJSON,
-		RuntimeSupportsNoCgroups: c.Libpod.RuntimeSupportsNoCgroups,
-		RuntimePath:              c.Libpod.RuntimePath,
-		ConmonPath:               c.Libpod.ConmonPath,
-		ConmonEnvVars:            c.Libpod.ConmonEnvVars,
-		CgroupManager:            c.Libpod.CgroupManager,
-		StaticDir:                c.Libpod.StaticDir,
-		TmpDir:                   c.Libpod.TmpDir,
-		NoPivotRoot:              c.Libpod.NoPivotRoot,
-		HooksDir:                 c.Libpod.HooksDir,
-		Namespace:                c.Libpod.Namespace,
-		InfraImage:               c.Libpod.InfraImage,
-		InfraCommand:             c.Libpod.InfraCommand,
-		EnablePortReservation:    c.Libpod.EnablePortReservation,
-		NetworkCmdPath:           c.Libpod.NetworkCmdPath,
-		NumLocks:                 c.Libpod.NumLocks,
-		LockType:                 c.Libpod.LockType,
-		EventsLogger:             c.Libpod.EventsLogger,
-		EventsLogFilePath:        c.Libpod.EventsLogFilePath,
-		DetachKeys:               c.Libpod.DetachKeys,
-		SDNotify:                 c.Libpod.SDNotify,
-		CgroupCheck:              c.Libpod.CgroupCheck,
+		SetOptions:               c.Engine.SetOptions,
+		VolumePath:               c.Engine.VolumePath,
+		ImageDefaultTransport:    c.Engine.ImageDefaultTransport,
+		OCIRuntime:               c.Engine.OCIRuntime,
+		OCIRuntimes:              c.Engine.OCIRuntimes,
+		RuntimeSupportsJSON:      c.Engine.RuntimeSupportsJSON,
+		RuntimeSupportsNoCgroups: c.Engine.RuntimeSupportsNoCgroups,
+		RuntimePath:              c.Engine.RuntimePath,
+		ConmonPath:               c.Engine.ConmonPath,
+		ConmonEnvVars:            c.Engine.ConmonEnvVars,
+		CgroupManager:            c.Engine.CgroupManager,
+		StaticDir:                c.Engine.StaticDir,
+		TmpDir:                   c.Engine.TmpDir,
+		NoPivotRoot:              c.Engine.NoPivotRoot,
+		HooksDir:                 c.Engine.HooksDir,
+		Namespace:                c.Engine.Namespace,
+		InfraImage:               c.Engine.InfraImage,
+		InfraCommand:             c.Engine.InfraCommand,
+		EnablePortReservation:    c.Engine.EnablePortReservation,
+		NetworkCmdPath:           c.Engine.NetworkCmdPath,
+		NumLocks:                 c.Engine.NumLocks,
+		LockType:                 c.Engine.LockType,
+		EventsLogger:             c.Engine.EventsLogger,
+		EventsLogFilePath:        c.Engine.EventsLogFilePath,
+		DetachKeys:               c.Engine.DetachKeys,
+		SDNotify:                 c.Engine.SDNotify,
+		CgroupCheck:              c.Engine.CgroupCheck,
 
 		CNIConfigDir:      c.Network.NetworkConfigDir,
 		CNIPluginDir:      c.Network.CNIPluginDirs,
@@ -348,33 +348,33 @@ func (c *Config) libpodToContainersConfig(libpodConf *ConfigFromLibpod) {
 	c.Containers.LogSizeMax = libpodConf.MaxLogSize
 	c.Containers.EnableLabeling = libpodConf.EnableLabeling
 
-	c.Libpod.SetOptions = libpodConf.SetOptions
-	c.Libpod.VolumePath = libpodConf.VolumePath
-	c.Libpod.ImageDefaultTransport = libpodConf.ImageDefaultTransport
-	c.Libpod.OCIRuntime = libpodConf.OCIRuntime
-	c.Libpod.OCIRuntimes = libpodConf.OCIRuntimes
-	c.Libpod.RuntimeSupportsJSON = libpodConf.RuntimeSupportsJSON
-	c.Libpod.RuntimeSupportsNoCgroups = libpodConf.RuntimeSupportsNoCgroups
-	c.Libpod.RuntimePath = libpodConf.RuntimePath
-	c.Libpod.ConmonPath = libpodConf.ConmonPath
-	c.Libpod.ConmonEnvVars = libpodConf.ConmonEnvVars
-	c.Libpod.CgroupManager = libpodConf.CgroupManager
-	c.Libpod.StaticDir = libpodConf.StaticDir
-	c.Libpod.TmpDir = libpodConf.TmpDir
-	c.Libpod.NoPivotRoot = libpodConf.NoPivotRoot
-	c.Libpod.HooksDir = libpodConf.HooksDir
-	c.Libpod.Namespace = libpodConf.Namespace
-	c.Libpod.InfraImage = libpodConf.InfraImage
-	c.Libpod.InfraCommand = libpodConf.InfraCommand
-	c.Libpod.EnablePortReservation = libpodConf.EnablePortReservation
-	c.Libpod.NetworkCmdPath = libpodConf.NetworkCmdPath
-	c.Libpod.NumLocks = libpodConf.NumLocks
-	c.Libpod.LockType = libpodConf.LockType
-	c.Libpod.EventsLogger = libpodConf.EventsLogger
-	c.Libpod.EventsLogFilePath = libpodConf.EventsLogFilePath
-	c.Libpod.DetachKeys = libpodConf.DetachKeys
-	c.Libpod.SDNotify = libpodConf.SDNotify
-	c.Libpod.CgroupCheck = libpodConf.CgroupCheck
+	c.Engine.SetOptions = libpodConf.SetOptions
+	c.Engine.VolumePath = libpodConf.VolumePath
+	c.Engine.ImageDefaultTransport = libpodConf.ImageDefaultTransport
+	c.Engine.OCIRuntime = libpodConf.OCIRuntime
+	c.Engine.OCIRuntimes = libpodConf.OCIRuntimes
+	c.Engine.RuntimeSupportsJSON = libpodConf.RuntimeSupportsJSON
+	c.Engine.RuntimeSupportsNoCgroups = libpodConf.RuntimeSupportsNoCgroups
+	c.Engine.RuntimePath = libpodConf.RuntimePath
+	c.Engine.ConmonPath = libpodConf.ConmonPath
+	c.Engine.ConmonEnvVars = libpodConf.ConmonEnvVars
+	c.Engine.CgroupManager = libpodConf.CgroupManager
+	c.Engine.StaticDir = libpodConf.StaticDir
+	c.Engine.TmpDir = libpodConf.TmpDir
+	c.Engine.NoPivotRoot = libpodConf.NoPivotRoot
+	c.Engine.HooksDir = libpodConf.HooksDir
+	c.Engine.Namespace = libpodConf.Namespace
+	c.Engine.InfraImage = libpodConf.InfraImage
+	c.Engine.InfraCommand = libpodConf.InfraCommand
+	c.Engine.EnablePortReservation = libpodConf.EnablePortReservation
+	c.Engine.NetworkCmdPath = libpodConf.NetworkCmdPath
+	c.Engine.NumLocks = libpodConf.NumLocks
+	c.Engine.LockType = libpodConf.LockType
+	c.Engine.EventsLogger = libpodConf.EventsLogger
+	c.Engine.EventsLogFilePath = libpodConf.EventsLogFilePath
+	c.Engine.DetachKeys = libpodConf.DetachKeys
+	c.Engine.SDNotify = libpodConf.SDNotify
+	c.Engine.CgroupCheck = libpodConf.CgroupCheck
 
 	c.Network.NetworkConfigDir = libpodConf.CNIConfigDir
 	c.Network.CNIPluginDirs = libpodConf.CNIPluginDir

--- a/pkg/config/testdata/containers_comment.conf
+++ b/pkg/config/testdata/containers_comment.conf
@@ -98,7 +98,7 @@
 # cni_plugin_dirs = "/usr/libexec/cni"
 
 
-[libpod]
+[engine]
 
 # Cgroup management implementation used for the runtime.
 # cgroup_manager = "systemd"
@@ -138,8 +138,8 @@
 # Whether to use chroot instead of pivot_root in the runtime
 # no_pivot_root = false
 
-# Default libpod namespace
-# If libpod is joined to a namespace, it will see only containers and pods
+# Default engine namespace
+# If engine is joined to a namespace, it will see only containers and pods
 # that were created in the same namespace, and will create new containers and
 # pods in that namespace.
 # The default namespace is "", which corresponds to no namespace. When no
@@ -152,7 +152,7 @@
 # Default command to run the infra container
 # infra_command = "/pause"
 
-# Determines whether libpod will reserve ports on the host when they are
+# Determines whether engine will reserve ports on the host when they are
 # forwarded to containers. When enabled, when ports are forwarded to containers,
 # they are held open by conmon as long as the container is running, ensuring that
 # they cannot be reused by other programs on the host. However, this can cause
@@ -160,7 +160,7 @@
 # Disabling this can save memory.
 #enable_port_reservation = true
 
-# Default libpod support for container labeling
+# Default engine support for container labeling
 # label=true
 
 # Number of locks available for containers and pods.
@@ -168,7 +168,7 @@
 # 'podman system renumber' command).
 # num_locks = 2048
 
-# Directory for libpod named volumes.
+# Directory for engine named volumes.
 # By default, this will be configured relative to where containers/storage
 # stores containers.
 # Uncomment to change location from this default.
@@ -189,11 +189,11 @@
 # runtime = "runc"
 
 # List of the OCI runtimes that support --format=json.  When json is supported
-# libpod will use it for reporting nicer errors.
+# engine will use it for reporting nicer errors.
 # runtime_supports_json = ["runc"]
 
 # Paths to look for a valid OCI runtime (runc, runv, etc)
-[libpod.runtimes]
+[engine.runtimes]
 # runc = [
 # 	   	"/usr/bin/runc",
 # 		"/usr/sbin/runc",
@@ -209,7 +209,7 @@
 # 	    "/usr/local/bin/crun",
 # ]
 
-# The [libpod.runtimes] table MUST be the last thing in this file.
+# The [engine.runtimes] table MUST be the last thing in this file.
 # (Unless another table is added)
 # TOML does not provide a way to end a table other than a further table being
 # defined, so every key hereafter will be part of [runtimes] and not the main

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -103,7 +103,7 @@ cni_plugin_dirs = [
 # Path to the directory where CNI configuration files are located.
 network_config_dir = "/etc/cni/net.d/"
 
-[libpod]
+[engine]
 
 # Cgroup management implementation used for the runtime.
 cgroup_manager = "systemd"
@@ -143,8 +143,8 @@ tmp_dir = "/var/run/libpod"
 # Whether to use chroot instead of pivot_root in the runtime
 no_pivot_root = false
 
-# Default libpod namespace
-# If libpod is joined to a namespace, it will see only containers and pods
+# Default engine namespace
+# If engine is joined to a namespace, it will see only containers and pods
 # that were created in the same namespace, and will create new containers and
 # pods in that namespace.
 # The default namespace is "", which corresponds to no namespace. When no
@@ -157,7 +157,7 @@ infra_image = "k8s.gcr.io/pause:3.1"
 # Default command to run the infra container
 infra_command = "/pause"
 
-# Determines whether libpod will reserve ports on the host when they are
+# Determines whether engine will reserve ports on the host when they are
 # forwarded to containers. When enabled, when ports are forwarded to containers,
 # they are held open by conmon as long as the container is running, ensuring that
 # they cannot be reused by other programs on the host. However, this can cause
@@ -165,7 +165,7 @@ infra_command = "/pause"
 # Disabling this can save memory.
 #enable_port_reservation = true
 
-# Default libpod support for container labeling
+# Default engine support for container labeling
 # label=true
 
 # Number of locks available for containers and pods.
@@ -173,7 +173,7 @@ infra_command = "/pause"
 # 'podman system renumber' command).
 num_locks = 2048
 
-# Directory for libpod named volumes.
+# Directory for engine named volumes.
 # By default, this will be configured relative to where containers/storage
 # stores containers.
 # Uncomment to change location from this default.
@@ -194,11 +194,11 @@ num_locks = 2048
 runtime = "runc"
 
 # List of the OCI runtimes that support --format=json.  When json is supported
-# libpod will use it for reporting nicer errors.
+# engine will use it for reporting nicer errors.
 runtime_supports_json = ["runc"]
 
 # Paths to look for a valid OCI runtime (runc, runv, etc)
-[libpod.runtimes]
+[engine.runtimes]
 runc = [
 	   	"/usr/bin/runc",
 		"/usr/sbin/runc",
@@ -214,7 +214,7 @@ crun = [
 	    "/usr/local/bin/crun",
 ]
 
-# The [libpod.runtimes] table MUST be the last thing in this file.
+# The [engine.runtimes] table MUST be the last thing in this file.
 # (Unless another table is added)
 # TOML does not provide a way to end a table other than a further table being
 # defined, so every key hereafter will be part of [runtimes] and not the main

--- a/pkg/config/testdata/containers_invalid.conf
+++ b/pkg/config/testdata/containers_invalid.conf
@@ -97,7 +97,7 @@ cni_plugin_dirs = ["/usr/libexec/cni"]
 # Path to the directory where CNI configuration files are located.
 network_config_dir = "/etc/cni/net.d/"
 
-[libpod]
+[engine]
 
 # Cgroup management implementation used for the runtime.
 cgroup_manager = "systemd"
@@ -137,8 +137,8 @@ tmp_dir = "/var/run/libpod"
 # Whether to use chroot instead of pivot_root in the runtime
 no_pivot_root = false
 
-# Default libpod namespace
-# If libpod is joined to a namespace, it will see only containers and pods
+# Default engine namespace
+# If engine is joined to a namespace, it will see only containers and pods
 # that were created in the same namespace, and will create new containers and
 # pods in that namespace.
 # The default namespace is "", which corresponds to no namespace. When no
@@ -151,7 +151,7 @@ infra_image = "k8s.gcr.io/pause:3.1"
 # Default command to run the infra container
 infra_command = "/pause"
 
-# Determines whether libpod will reserve ports on the host when they are
+# Determines whether engine will reserve ports on the host when they are
 # forwarded to containers. When enabled, when ports are forwarded to containers,
 # they are held open by conmon as long as the container is running, ensuring that
 # they cannot be reused by other programs on the host. However, this can cause
@@ -159,7 +159,7 @@ infra_command = "/pause"
 # Disabling this can save memory.
 #enable_port_reservation = true
 
-# Default libpod support for container labeling
+# Default engine support for container labeling
 # label=true
 
 # Number of locks available for containers and pods.
@@ -167,7 +167,7 @@ infra_command = "/pause"
 # 'podman system renumber' command).
 num_locks = 2048
 
-# Directory for libpod named volumes.
+# Directory for engine named volumes.
 # By default, this will be configured relative to where containers/storage
 # stores containers.
 # Uncomment to change location from this default.
@@ -188,11 +188,11 @@ num_locks = 2048
 runtime = "runc"
 
 # List of the OCI runtimes that support --format=json.  When json is supported
-# libpod will use it for reporting nicer errors.
+# engine will use it for reporting nicer errors.
 runtime_supports_json = ["runc"]
 
 # Paths to look for a valid OCI runtime (runc, runv, etc)
-[libpod.runtimes]
+[engine.runtimes]
 runc = [
 	   	"/usr/bin/runc",
 		"/usr/sbin/runc",
@@ -208,7 +208,7 @@ crun = [
 	    "/usr/local/bin/crun",
 ]
 
-# The [libpod.runtimes] table MUST be the last thing in this file.
+# The [engine.runtimes] table MUST be the last thing in this file.
 # (Unless another table is added)
 # TOML does not provide a way to end a table other than a further table being
 # defined, so every key hereafter will be part of [runtimes] and not the main


### PR DESCRIPTION
containers/common pkg/config is for more engines then just libpod.

We want to use the 'libpod' section to configure parts of buildah.  Renaming this
section to engine, makes it more obvious to users that these fields can effect other
container engines.

Certain fields are still libpod specific, so we do not change those fields.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>