### PR TITLE
config: honor XDG_CONFIG_HOME

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -827,6 +827,9 @@ func isDirectory(path string) error {
 }
 
 func rootlessConfigPath() (string, error) {
+	if configHome := os.Getenv("XDG_CONFIG_HOME"); configHome != "" {
+		return filepath.Join(configHome, UserOverrideContainersConfig), nil
+	}
 	home, err := unshare.HomeDir()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
when the env variable is set, use its value for locating the user
configuration file.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
