### PR TITLE
Move SignaturePolicyPath to Engine instead of Containers

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -160,11 +160,6 @@ type ContainersConfig struct {
 	// ShmSize holds the size of /dev/shm.
 	ShmSize string `toml:"shm_size"`
 
-	// SignaturePolicyPath is the path to a signature policy to use for
-	// validating images. If left empty, the containers/image default signature
-	// policy will be used.
-	SignaturePolicyPath string `toml:"_"`
-
 	// UTSNS indicates how to create a UTS namespace for the container
 	UTSNS string `toml:"utsns"`
 
@@ -282,6 +277,11 @@ type EngineConfig struct {
 	// overwritten by values from the database. This behavior guarantees
 	// backwards compat with older version of libpod and Podman.
 	SetOptions
+
+	// SignaturePolicyPath is the path to a signature policy to use for
+	// validating images. If left empty, the containers/image default signature
+	// policy will be used.
+	SignaturePolicyPath string `toml:"_"`
 
 	// SDNotify tells container engine to allow containers to notify the host systemd of
 	// readiness using the SD_NOTIFY mechanism.

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -123,7 +123,6 @@ func DefaultConfig() (*Config, error) {
 		return nil, err
 	}
 
-	var signaturePolicyPath string
 	netns := "bridge"
 	if unshare.IsRootless() {
 		home, err := unshare.HomeDir()
@@ -132,7 +131,7 @@ func DefaultConfig() (*Config, error) {
 		}
 		sigPath := filepath.Join(home, DefaultRootlessSignaturePolicyPath)
 		if _, err := os.Stat(sigPath); err == nil {
-			signaturePolicyPath = sigPath
+			defaultEngineConfig.SignaturePolicyPath = sigPath
 		}
 		netns = "slirp4netns"
 	}
@@ -154,23 +153,22 @@ func DefaultConfig() (*Config, error) {
 			Env: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			},
-			EnvHost:             false,
-			HTTPProxy:           false,
-			Init:                false,
-			InitPath:            "",
-			IPCNS:               "private",
-			LogDriver:           DefaultLogDriver,
-			LogSizeMax:          DefaultLogSizeMax,
-			NetNS:               netns,
-			NoHosts:             false,
-			PidsLimit:           DefaultPidsLimit,
-			PidNS:               "private",
-			SeccompProfile:      SeccompDefaultPath,
-			ShmSize:             DefaultShmSize,
-			SignaturePolicyPath: signaturePolicyPath,
-			UTSNS:               "private",
-			UserNS:              "private",
-			UserNSSize:          DefaultUserNSSize,
+			EnvHost:        false,
+			HTTPProxy:      false,
+			Init:           false,
+			InitPath:       "",
+			IPCNS:          "private",
+			LogDriver:      DefaultLogDriver,
+			LogSizeMax:     DefaultLogSizeMax,
+			NetNS:          netns,
+			NoHosts:        false,
+			PidsLimit:      DefaultPidsLimit,
+			PidNS:          "private",
+			SeccompProfile: SeccompDefaultPath,
+			ShmSize:        DefaultShmSize,
+			UTSNS:          "private",
+			UserNS:         "private",
+			UserNSSize:     DefaultUserNSSize,
 		},
 		Network: NetworkConfig{
 			DefaultNetwork:   "podman",

--- a/pkg/config/libpodConfig.go
+++ b/pkg/config/libpodConfig.go
@@ -302,10 +302,9 @@ func rootlessLibpodConfigPath() (string, error) {
 
 func (c *Config) libpodConfig() *ConfigFromLibpod {
 	return &ConfigFromLibpod{
-		SignaturePolicyPath: c.Containers.SignaturePolicyPath,
-		InitPath:            c.Containers.InitPath,
-		MaxLogSize:          c.Containers.LogSizeMax,
-		EnableLabeling:      c.Containers.EnableLabeling,
+		InitPath:       c.Containers.InitPath,
+		MaxLogSize:     c.Containers.LogSizeMax,
+		EnableLabeling: c.Containers.EnableLabeling,
 
 		SetOptions:               c.Engine.SetOptions,
 		VolumePath:               c.Engine.VolumePath,
@@ -334,6 +333,7 @@ func (c *Config) libpodConfig() *ConfigFromLibpod {
 		DetachKeys:               c.Engine.DetachKeys,
 		SDNotify:                 c.Engine.SDNotify,
 		CgroupCheck:              c.Engine.CgroupCheck,
+		SignaturePolicyPath:      c.Engine.SignaturePolicyPath,
 
 		CNIConfigDir:      c.Network.NetworkConfigDir,
 		CNIPluginDir:      c.Network.CNIPluginDirs,
@@ -343,11 +343,11 @@ func (c *Config) libpodConfig() *ConfigFromLibpod {
 
 func (c *Config) libpodToContainersConfig(libpodConf *ConfigFromLibpod) {
 
-	c.Containers.SignaturePolicyPath = libpodConf.SignaturePolicyPath
 	c.Containers.InitPath = libpodConf.InitPath
 	c.Containers.LogSizeMax = libpodConf.MaxLogSize
 	c.Containers.EnableLabeling = libpodConf.EnableLabeling
 
+	c.Engine.SignaturePolicyPath = libpodConf.SignaturePolicyPath
 	c.Engine.SetOptions = libpodConf.SetOptions
 	c.Engine.VolumePath = libpodConf.VolumePath
 	c.Engine.ImageDefaultTransport = libpodConf.ImageDefaultTransport


### PR DESCRIPTION
Signatures are an engine struct rather then something
per/container.  Moving to proper location.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
