### PR TITLE
isDirectory resolve ~ to User HomeDir

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -806,9 +806,35 @@ func IsValidDeviceMode(mode string) bool {
 	return true
 }
 
+// resolveHomeDir converts a path referencing the home directory via "~"
+// to an absolute path
+func resolveHomeDir(path string) (string, error) {
+	// check if the path references the home dir to avoid work
+	// don't use strings.HasPrefix(path, "~") as this doesn't match "~" alone
+	// use strings.HasPrefix(...) to not match "something/~/something"
+	if !(path == "~" || strings.HasPrefix(path, "~/")) {
+		// path does not reference home dir -> Nothing to do
+		return path, nil
+	}
+	
+	// only get HomeDir when necessary
+	home, err := unshare.HomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	// replace the first "~" (start of path) with the HomeDir to resolve "~"
+	return strings.Replace(path, "~", home, 1), nil
+}
+
 // isDirectory tests whether the given path exists and is a directory. It
 // follows symlinks.
 func isDirectory(path string) error {
+	path, err := resolveHomeDir(path)
+	if err != nil {
+		return err
+	}
+
 	info, err := os.Stat(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
When using podman by putting the prebuild binarys into the users homedirectory, paths in the config starting with "\~" are not resolved as this is normally done by the shell.
Resolving "\~" to HomeDir enables the user (or a config provider) to publish a config which doesn't require adaption for each user (e.G. by changing /home/<username>/usr/bin/cni as this now becomes ~/usr/bin/cni).

This commit adds a new func resolveHomeDir(string) (string, error) which resolves a given path if it contains a reference to homedir or returns the path unchanged when not.
It throws an error when it's unable to get the users HomeDir.

Signed-off-by: Raphael Höser <raphael@hoeser.info>


I'm aware that this is a fairly uncommon usecase, but would make it easier to provide rootless install guides for podman and co.
