### PR TITLE
use `pause:3.2` image for infra containers

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -274,7 +274,7 @@ Disabling this can save memory.
 **infra_command**="/pause"
   Command to run the infra container.
 
-**infra_image**="k8s.gcr.io/pause:3.1"
+**infra_image**="k8s.gcr.io/pause:3.2"
   Infra (pause) container image name for pod infra containers.  When running a
 pod, we start a `pause` process in a container to hold open the namespaces
 associated with the  pod.  This container does nothing other then sleep,

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -288,7 +288,7 @@
 # associated with the  pod.  This container does nothing other then sleep,
 # reserving the pods resources for the lifetime of the pod.
 #
-# infra_image = "k8s.gcr.io/pause:3.1"
+# infra_image = "k8s.gcr.io/pause:3.2"
 
 # Specify the locking mechanism to use; valid values are "shm" and "file".
 # Change the default only if you are sure of what you are doing, in general

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -40,7 +40,7 @@ var (
 	// DefaultInitPath is the default path to the container-init binary
 	DefaultInitPath = "/usr/libexec/podman/catatonit"
 	// DefaultInfraImage to use for infra container
-	DefaultInfraImage = "k8s.gcr.io/pause:3.1"
+	DefaultInfraImage = "k8s.gcr.io/pause:3.2"
 	// DefaultInfraCommand to be run in an infra container
 	DefaultInfraCommand = "/pause"
 	// DefaultRootlessSHMLockPath is the default path for rootless SHM locks

--- a/pkg/config/testdata/containers_comment.conf
+++ b/pkg/config/testdata/containers_comment.conf
@@ -147,7 +147,7 @@
 #namespace = ""
 
 # Default infra (pause) image name for pod infra containers
-# infra_image = "k8s.gcr.io/pause:3.1"
+# infra_image = "k8s.gcr.io/pause:3.2"
 
 # Default command to run the infra container
 # infra_command = "/pause"

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -152,7 +152,7 @@ no_pivot_root = false
 #namespace = ""
 
 # Default infra (pause) image name for pod infra containers
-infra_image = "k8s.gcr.io/pause:3.1"
+infra_image = "k8s.gcr.io/pause:3.2"
 
 # Default command to run the infra container
 infra_command = "/pause"

--- a/pkg/config/testdata/containers_invalid.conf
+++ b/pkg/config/testdata/containers_invalid.conf
@@ -146,7 +146,7 @@ no_pivot_root = false
 #namespace = ""
 
 # Default infra (pause) image name for pod infra containers
-infra_image = "k8s.gcr.io/pause:3.1"
+infra_image = "k8s.gcr.io/pause:3.2"
 
 # Default command to run the infra container
 infra_command = "/pause"


### PR DESCRIPTION
The `pause:3.1` has wrong configs for non-amd64 images as they all claim
to be for amd64.  The issue has now been fixed in the latest
`pause:3.2`.

[1] https://github.com/kubernetes/kubernetes/issues/87325

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
