### PR TITLE
Only default to systemd if built with the systemd buildtag

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -211,7 +211,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	if onCgroupsv2, _ := isCgroup2UnifiedMode(); onCgroupsv2 {
 		c.OCIRuntime = "crun"
 	}
-	c.CgroupManager = SystemdCgroupsManager
+	c.CgroupManager = defaultCgroupManager()
 	c.StopTimeout = uint(10)
 
 	c.OCIRuntimes = map[string][]string{
@@ -269,7 +269,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	c.InfraImage = DefaultInfraImage
 	c.EnablePortReservation = true
 	c.NumLocks = 2048
-	c.EventsLogger = "journald"
+	c.EventsLogger = defaultEventsLogger()
 	c.DetachKeys = DefaultDetachKeys
 	c.SDNotify = false
 	// TODO - ideally we should expose a `type LockType string` along with

--- a/pkg/config/nosystemd.go
+++ b/pkg/config/nosystemd.go
@@ -1,0 +1,11 @@
+// +build !systemd
+
+package config
+
+func defaultCgroupManager() string {
+	return "cgroupfs"
+}
+
+func defaultEventsLogger() string {
+	return "file"
+}

--- a/pkg/config/systemd.go
+++ b/pkg/config/systemd.go
@@ -1,0 +1,10 @@
+// +build systemd
+
+package config
+
+func defaultCgroupManager() string {
+	return SystemdCgroupsManager
+}
+func defaultEventsLogger() string {
+	return "journald"
+}


### PR DESCRIPTION
For packages that don't ship with systemd, this changes the default for those distros.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
