### PR TITLE
Add RuntimeSupportsKVM to config.Engine

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -320,6 +320,9 @@ refer to a member of the runtimes table.
 **runtime_supports_nocgroups**=["crun"]
   The list of OCI runtimes that support running containers without CGroups.
 
+**runtime_supports_kvm**=["kata"]
+  The list of OCI runtimes that support running containers with KVM separation.
+
 **static_dir**="/var/lib/containers/storage/libpod"
   Directory for persistent libpod files (database, etc).
 By default this will be configured relative to where containers/storage

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -271,6 +271,10 @@ type EngineConfig struct {
 	// running containers without CGroups.
 	RuntimeSupportsNoCgroups []string `toml:"runtime_supports_nocgroupv2"`
 
+	// RuntimeSupportsKVM is a list of OCI runtimes that support
+	// KVM separation for conatainers.
+	RuntimeSupportsKVM []string `toml:"runtime_supports_kvm"`
+
 	// SetOptions contains a subset of config options. It's used to indicate if
 	// a given option has either been set by the user or by the parsed
 	// configuration file. If not, the corresponding option might be

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -264,6 +264,8 @@ var _ = Describe("Config", func() {
 					"/usr/local/sbin/kata-runtime",
 					"/sbin/kata-runtime",
 					"/bin/kata-runtime",
+					"/usr/bin/kata-qemu",
+					"/usr/bin/kata-fc",
 				},
 				"runc": {
 					"/usr/bin/runc",

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -347,6 +347,14 @@
 #
 # runtime_supports_json = ["crun", "runc", "kata"]
 
+# List of the OCI runtimes that supports running containers without cgroups.
+#
+# runtime_supports_nocgroups = ["crun"]
+
+# List of the OCI runtimes that supports running containers with KVM Separation.
+#
+# runtime_supports_kvm = ["kata"]
+
 # Paths to look for a valid OCI runtime (runc, runv, kata, etc)
 [engine.runtimes]
 # runc = [
@@ -376,6 +384,8 @@
 #            "/usr/local/sbin/kata-runtime",
 #            "/sbin/kata-runtime",
 #            "/bin/kata-runtime",
+#            "/usr/bin/kata-qemu",
+#            "/usr/bin/kata-fc",
 # ]
 
 # Number of seconds to wait for container to exit before sending kill signal.

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -246,6 +246,8 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 			"/usr/local/sbin/kata-runtime",
 			"/sbin/kata-runtime",
 			"/bin/kata-runtime",
+			"/usr/bin/kata-qemu",
+			"/usr/bin/kata-fc",
 		},
 	}
 	c.ConmonEnvVars = []string{
@@ -267,6 +269,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 		"runc",
 	}
 	c.RuntimeSupportsNoCgroups = []string{"crun"}
+	c.RuntimeSupportsKVM = []string{"kata", "kata-runtime", "kata-qemu", "kata-fc"}
 	c.InitPath = DefaultInitPath
 	c.NoPivotRoot = false
 


### PR DESCRIPTION
We need to identify the list of containers that support KVM separation, these
containers can run with a different SELinux label, and we might be able to
make different decisions in the container engines about how to launch these
containers.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
