### PR TITLE
Add support for cgroups configuration

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -66,6 +66,13 @@ The default profile name is "container-default".
     `private` Create private Cgroup Namespace for the container.
     `host`    Share host Cgroup Namespace with the container.
 
+**cgroups**="enabled"
+  Determines  whether  the  container will create CGroups.
+  Options are:
+    `enabled`   Enable cgroup support within container
+    `disabled`  Disable cgroup support, will inherit cgroups from parent
+    `no-conmon` Container engine runs run without conmon
+
 **default_capabilities**=[]
   List of default capabilities for containers.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,6 +87,9 @@ type ContainersConfig struct {
 	// Default way to create a cgroup namespace for the container
 	CgroupNS string `toml:"cgroupns"`
 
+	// Default cgroup configuration
+	Cgroups string `toml:"cgroups"`
+
 	// Capabilities to add to all containers.
 	DefaultCapabilities []string `toml:"default_capabilities"`
 

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -47,6 +47,15 @@
 #
 # cgroupns = "private"
 
+# Control container cgroup configuration
+# Determines  whether  the  container will create CGroups.
+# Options are:
+# `enabled`   Enable cgroup support within container
+# `disabled`  Disable cgroup support, will inherit cgroups from parent
+# `no-conmon` Container engine runs run without conmon
+#
+# cgroups = "enabled"
+
 # List of default capabilities for containers. If it is empty or commented out,
 # the default capabilities defined in the container engine will be added.
 #

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -148,6 +148,7 @@ func DefaultConfig() (*Config, error) {
 			Annotations:         []string{},
 			ApparmorProfile:     DefaultApparmorProfile,
 			CgroupNS:            "private",
+			Cgroups:             "enabled",
 			DefaultCapabilities: DefaultCapabilities,
 			DefaultSysctls:      []string{},
 			DefaultUlimits:      getDefaultProcessLimits(),
@@ -437,6 +438,11 @@ func (c *Config) PidNS() string {
 // CgroupNS returns the default Cgroup Namespace configuration to run containers with
 func (c *Config) CgroupNS() string {
 	return c.Containers.CgroupNS
+}
+
+// Cgroups returns whether to containers with cgroup confinement
+func (c *Config) Cgroups() string {
+	return c.Containers.Cgroups
 }
 
 // UTSNS returns the default UTS Namespace configuration to run containers with


### PR DESCRIPTION
We need to be able to disable cgroups when running container engines inside of containers.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
