### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Containers Projects Security and Disclosure Information
+
+ * [Reporting a Vulnerability](#Reporting-a-Vulnerability)
+ * [Security Announcements](#Security-Announcements)
+ * [Security Vulnerability Response](#Security-Vulnerability-Response)
+
+## Reporting a Vulnerability
+
+If you think you've identified a security issue in a Containers project,
+please DO NOT report the issue publicly via the Github issue tracker,
+mailing list, or IRC. Instead, send an email with as many details as 
+possible to [security@lists.podman.io](mailto:security@lists.podman.io?subject=Security%20Vunerablity%20Report).
+This is a private mailing list for the core maintainers.
+
+Please do **not** create a public issue.
+
+## Security Announcements
+
+The podman@lists.podman.io email list is used for messages about 
+security and major API announcements.  You can join the list [here](https://lists.podman.io/admin/lists/podman.lists.podman.io/)
+or by sending an email to [podman-join@lists.podman.io](podman-join@lists.podman.io?subject=subscribe)
+with the word "subscribe" in the subject.
+
+## Security Vulnerability Response
+
+Each report is acknowledged and analyzed by the core maintainers within 3 working days.
+
+Any vulnerability information shared with core maintainers stays within a Containers project
+and will not be disseminated to other projects unless it is necessary to get the issue fixed.
+
+As the security issue moves from triage, to an identified fix, to release planning, the core
+maintainers will keep the reporter updated.
+


### PR DESCRIPTION
Add a security policy to the containers common repo
that will then be pointed to by the other containers/*
projects.

This was based off of the one in crun by @giuseppe,
information in libpod, and heavily from [Kubernetes](https://kubernetes.io/docs/reference/issues-security/security/)

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
