### PR TITLE
Hard code libpod.conf EventsLogger to File

### DIFF
--- a/pkg/config/libpodConfig.go
+++ b/pkg/config/libpodConfig.go
@@ -224,6 +224,12 @@ func newLibpodConfig(c *Config) error {
 		}
 	}
 
+	// hard code EventsLogger to "file" to match older podman versions.
+	if config.EventsLogger != "file" {
+		logrus.Debugf("Ignoring lipod.conf EventsLogger setting %q. Use containers.conf if you want to change this setting and remove libpod.conf files.", config.EventsLogger)
+		config.EventsLogger = "file"
+	}
+
 	c.libpodToContainersConfig(config)
 
 	return nil


### PR DESCRIPTION
Previous versions of podman ignored the EventsLogger setting
in libpod.conf and defaulted to "file".  Containers.conf
should follow this for backwards compatibility.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
