### PR TITLE
config: change default for userns to host

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -173,7 +173,7 @@ func DefaultConfig() (*Config, error) {
 			SeccompProfile: SeccompDefaultPath,
 			ShmSize:        DefaultShmSize,
 			UTSNS:          "private",
-			UserNS:         "private",
+			UserNS:         "host",
 			UserNSSize:     DefaultUserNSSize,
 		},
 		Network: NetworkConfig{


### PR DESCRIPTION
by default do not create a user namespace.  A user namespace also
requires mappings to be specified and that is not possible with a
static setting.  We cannot default to "auto" as it requires additional
configuration for the root user.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
