### PR TITLE
config: default to cgroupns="host" on cgroup v1

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -141,13 +141,18 @@ func DefaultConfig() (*Config, error) {
 		netns = "slirp4netns"
 	}
 
+	cgroupNS := "host"
+	if cgroup2, _ := cgroupv2.Enabled(); cgroup2 {
+		cgroupNS = "private"
+	}
+
 	return &Config{
 		Containers: ContainersConfig{
 			Devices:             []string{},
 			Volumes:             []string{},
 			Annotations:         []string{},
 			ApparmorProfile:     DefaultApparmorProfile,
-			CgroupNS:            "private",
+			CgroupNS:            cgroupNS,
 			DefaultCapabilities: DefaultCapabilities,
 			DefaultSysctls:      []string{},
 			DefaultUlimits:      getDefaultProcessLimits(),


### PR DESCRIPTION
cgroupns="private" should be used only on cgroup v2.

On cgroup v1 it would be a breaking change, and also we'd need to
check whether the kernel supports cgroup namespaces.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
