### PR TITLE
Fix config.Capabilities function call

### DIFF
--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -91,17 +91,20 @@ func ValidateCapabilities(caps []string) error {
 // MergeCapabilities computes a set of capabilities by adding capapbitilities
 // to or dropping them from base.
 //
-// Note that "ALL" will cause all known capabilities to be added/dropped but
-// the ones specified to be dropped/added.
+// Note that:
+// "ALL" in capAdd adds returns known capabilities
+// "All" in capDrop returns only the capabilities specified in capAdd
 func MergeCapabilities(base, adds, drops []string) ([]string, error) {
-	if len(adds) == 0 && len(drops) == 0 {
-		// Nothing to tweak; we're done
-		return base, nil
-	}
+	var caps []string
 
+	// Normalize the base capabilities
 	base, err := normalizeCapabilities(base)
 	if err != nil {
 		return nil, err
+	}
+	if len(adds) == 0 && len(drops) == 0 {
+		// Nothing to tweak; we're done
+		return base, nil
 	}
 	capDrop, err := normalizeCapabilities(drops)
 	if err != nil {
@@ -112,35 +115,42 @@ func MergeCapabilities(base, adds, drops []string) ([]string, error) {
 		return nil, err
 	}
 
-	// Make sure that capDrop and capAdd are distinct sets.
+	if stringInSlice(All, capDrop) {
+		// "Drop" all capabilities; return what's in capAdd instead
+		return capAdd, nil
+	}
+
+	if stringInSlice(All, capAdd) {
+		// "Add" all capabilities;
+		return capabilityList, nil
+	}
+
+	for _, add := range capAdd {
+		if stringInSlice(add, capDrop) {
+			return nil, errors.Errorf("capability %q cannot be dropped and added", add)
+		}
+	}
+
 	for _, drop := range capDrop {
 		if stringInSlice(drop, capAdd) {
 			return nil, errors.Errorf("capability %q cannot be dropped and added", drop)
 		}
 	}
 
-	var caps []string
+	// Drop any capabilities in capDrop that are in base
+	for _, cap := range base {
+		if stringInSlice(cap, capDrop) {
+			continue
+		}
+		caps = append(caps, cap)
+	}
 
-	switch {
-	case stringInSlice(All, capAdd):
-		// Add all capabilities except ones on capDrop
-		for _, c := range capabilityList {
-			if !stringInSlice(c, capDrop) {
-				caps = append(caps, c)
-			}
+	// Add any capabilities in capAdd that are not in base
+	for _, cap := range capAdd {
+		if stringInSlice(cap, base) {
+			continue
 		}
-	case stringInSlice(All, capDrop):
-		// "Drop" all capabilities; use what's in capAdd instead
-		caps = capAdd
-	default:
-		// First drop some capabilities
-		for _, c := range base {
-			if !stringInSlice(c, capDrop) {
-				caps = append(caps, c)
-			}
-		}
-		// Then add the list of capabilities from capAdd
-		caps = append(caps, capAdd...)
+		caps = append(caps, cap)
 	}
 	return caps, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -709,7 +709,7 @@ func (c *Config) GetDefaultEnv() []string {
 
 // Capabilities returns the capabilities parses the Add and Drop capability
 // list from the default capabiltiies for the container
-func (c *Config) Capabilities(user string, addCapabilities, dropCapabilities []string) []string {
+func (c *Config) Capabilities(user string, addCapabilities, dropCapabilities []string) ([]string, error) {
 
 	userNotRoot := func(user string) bool {
 		if user == "" || user == "root" || user == "0" {
@@ -718,36 +718,12 @@ func (c *Config) Capabilities(user string, addCapabilities, dropCapabilities []s
 		return true
 	}
 
-	var caps []string
 	defaultCapabilities := c.Containers.DefaultCapabilities
 	if userNotRoot(user) {
 		defaultCapabilities = []string{}
 	}
 
-	mapCap := make(map[string]bool, len(defaultCapabilities))
-	for _, c := range addCapabilities {
-		if strings.ToLower(c) == "all" {
-			defaultCapabilities = capabilities.AllCapabilities()
-			addCapabilities = nil
-			break
-		}
-	}
-
-	for _, c := range append(defaultCapabilities, addCapabilities...) {
-		mapCap[c] = true
-	}
-	for _, c := range dropCapabilities {
-		if "all" == strings.ToLower(c) {
-			return caps
-		}
-		mapCap[c] = false
-	}
-	for cap, add := range mapCap {
-		if add {
-			caps = append(caps, cap)
-		}
-	}
-	return caps
+	return capabilities.MergeCapabilities(defaultCapabilities, addCapabilities, dropCapabilities)
 }
 
 // Device parses device mapping string to a src, dest & permissions string

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -450,7 +450,8 @@ var _ = Describe("Config", func() {
 			// Then
 			Expect(err).To(BeNil())
 			var addcaps, dropcaps []string
-			caps := config.Capabilities("0", addcaps, dropcaps)
+			caps, err := config.Capabilities("0", addcaps, dropcaps)
+			Expect(err).To(BeNil())
 			sort.Strings(caps)
 			defaultCaps := config.Containers.DefaultCapabilities
 			sort.Strings(defaultCaps)
@@ -458,13 +459,15 @@ var _ = Describe("Config", func() {
 
 			// Add all caps
 			addcaps = []string{"all"}
-			caps = config.Capabilities("root", addcaps, dropcaps)
+			caps, err = config.Capabilities("root", addcaps, dropcaps)
+			Expect(err).To(BeNil())
 			sort.Strings(caps)
-			Expect(caps).ToNot(BeEquivalentTo(capabilities.AllCapabilities()))
+			Expect(caps).To(BeEquivalentTo(capabilities.AllCapabilities()))
 
 			// Drop all caps
 			dropcaps = []string{"all"}
-			caps = config.Capabilities("", addcaps, dropcaps)
+			caps, err = config.Capabilities("", addcaps, dropcaps)
+			Expect(err).To(BeNil())
 			sort.Strings(caps)
 			Expect(caps).ToNot(BeEquivalentTo([]string{}))
 
@@ -485,13 +488,23 @@ var _ = Describe("Config", func() {
 			// Add all caps
 			addcaps = []string{"CAP_NET_ADMIN", "CAP_SYS_ADMIN"}
 			dropcaps = []string{"CAP_FOWNER", "CAP_CHOWN"}
-			caps = config.Capabilities("", addcaps, dropcaps)
+			caps, err = config.Capabilities("", addcaps, dropcaps)
+			Expect(err).To(BeNil())
 			sort.Strings(caps)
 			Expect(caps).To(BeEquivalentTo(expectedCaps))
 
-			caps = config.Capabilities("notroot", addcaps, dropcaps)
+			addcaps = []string{"NET_ADMIN", "cap_sys_admin"}
+			dropcaps = []string{"FOWNER", "chown"}
+			caps, err = config.Capabilities("", addcaps, dropcaps)
+			Expect(err).To(BeNil())
 			sort.Strings(caps)
-			Expect(caps).To(BeEquivalentTo(addcaps))
+			Expect(caps).To(BeEquivalentTo(expectedCaps))
+
+			expectedCaps = []string{"CAP_NET_ADMIN", "CAP_SYS_ADMIN"}
+			caps, err = config.Capabilities("notroot", addcaps, dropcaps)
+			Expect(err).To(BeNil())
+			sort.Strings(caps)
+			Expect(caps).To(BeEquivalentTo(expectedCaps))
 		})
 
 		It("should succeed with default pull_policy", func() {


### PR DESCRIPTION
We need to normalize the capadd and capdrop functions, and
we need to return errors if the caller gives us bad input.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
