### PR TITLE
auth pkg supports login empty argument

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/pkg/docker/config"
+	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/image/v5/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -33,9 +34,27 @@ func CheckAuthFile(authfile string) error {
 	return nil
 }
 
-// Login login to the server with creds from Stdin or CLI
-func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginOptions, registry string) error {
-	server := getRegistryName(registry)
+// Login implements a “log in” command with the provided opts and args
+// reading the password from opts.Stdin or the options in opts.
+func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginOptions, args []string) error {
+	var (
+		server string
+		err    error
+	)
+	if len(args) > 1 {
+		return errors.Errorf("login accepts only one registry to login to")
+	}
+	if len(args) == 0 {
+		if !opts.AcceptUnspecifiedRegistry {
+			return errors.Errorf("please provide a registry to login to")
+		}
+		if server, err = defaultRegistryWhenUnspecified(systemContext); err != nil {
+			return err
+		}
+		logrus.Debugf("registry not specified, default to the first registry %q from registries.conf", server)
+	} else {
+		server = getRegistryName(args[0])
+	}
 	authConfig, err := config.GetCredentials(systemContext, server)
 	if err != nil {
 		return errors.Wrapf(err, "error reading auth file")
@@ -151,11 +170,29 @@ func getUserAndPass(opts *LoginOptions, password, userFromAuthFile string) (stri
 	return strings.TrimSpace(username), password, err
 }
 
-// Logout removes the authentication of server from authfile
-// removes all authtication if specifies all in the options
-func Logout(systemContext *types.SystemContext, opts *LogoutOptions, server string) error {
-	if server != "" {
-		server = getRegistryName(server)
+// Logout implements a “log out” command with the provided opts and args
+func Logout(systemContext *types.SystemContext, opts *LogoutOptions, args []string) error {
+	var (
+		server string
+		err    error
+	)
+	if len(args) > 1 {
+		return errors.Errorf("logout accepts only one registry to logout from")
+	}
+	if len(args) == 0 && !opts.All {
+		if !opts.AcceptUnspecifiedRegistry {
+			return errors.Errorf("please provide a registry to logout from")
+		}
+		if server, err = defaultRegistryWhenUnspecified(systemContext); err != nil {
+			return err
+		}
+		logrus.Debugf("registry not specified, default to the first registry %q from registries.conf", server)
+	}
+	if len(args) != 0 {
+		if opts.All {
+			return errors.Errorf("--all takes no arguments")
+		}
+		server = getRegistryName(args[0])
 	}
 	if err := CheckAuthFile(opts.AuthFile); err != nil {
 		return err
@@ -169,7 +206,7 @@ func Logout(systemContext *types.SystemContext, opts *LogoutOptions, server stri
 		return nil
 	}
 
-	err := config.RemoveAuthentication(systemContext, server)
+	err = config.RemoveAuthentication(systemContext, server)
 	switch err {
 	case nil:
 		fmt.Fprintf(opts.Stdout, "Removed login credentials for %s\n", server)
@@ -179,4 +216,17 @@ func Logout(systemContext *types.SystemContext, opts *LogoutOptions, server stri
 	default:
 		return errors.Wrapf(err, "error logging out of %q", server)
 	}
+}
+
+// defaultRegistryWhenUnspecified returns first registry from search list of registry.conf
+// used by login/logout when registry argument is not specified
+func defaultRegistryWhenUnspecified(systemContext *types.SystemContext) (string, error) {
+	registriesFromFile, err := sysregistriesv2.UnqualifiedSearchRegistries(systemContext)
+	if err != nil {
+		return "", errors.Wrapf(err, "error getting registry from registry.conf, please specify a registry")
+	}
+	if len(registriesFromFile) == 0 {
+		return "", errors.Errorf("no registries found in registries.conf, a registry must be provided")
+	}
+	return registriesFromFile[0], nil
 }

--- a/pkg/auth/cli.go
+++ b/pkg/auth/cli.go
@@ -9,22 +9,28 @@ import (
 // LoginOptions represents common flags in login
 // caller should define bool or optionalBool fields for flags --get-login and --tls-verify
 type LoginOptions struct {
+	// CLI flags managed by the FlagSet returned by GetLoginFlags
 	AuthFile      string
 	CertDir       string
-	GetLoginSet   bool
 	Password      string
 	Username      string
 	StdinPassword bool
-	Stdin         io.Reader
-	Stdout        io.Writer
+	// Options caller can set
+	GetLoginSet               bool      // set to true if --get-login is explicitly set
+	Stdin                     io.Reader // set to os.Stdin
+	Stdout                    io.Writer // set to os.Stdout
+	AcceptUnspecifiedRegistry bool      // set to true if allows login with unspecified registry
 }
 
 // LogoutOptions represents the results for flags in logout
 type LogoutOptions struct {
+	// CLI flags managed by the FlagSet returned by GetLogoutFlags
 	AuthFile string
 	All      bool
-	Stdin    io.Reader
-	Stdout   io.Writer
+	// Options caller can set
+	Stdin                     io.Reader // set to os.Stdin
+	Stdout                    io.Writer // set to os.Stdout
+	AcceptUnspecifiedRegistry bool      // set to true if allows logout with unspecified registry
 }
 
 // GetLoginFlags defines and returns login flags for containers tools


### PR DESCRIPTION
auth pkg supports login empty argument
libpod PR applies this PR https://github.com/containers/libpod/pull/6078
Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
