### PR TITLE
Specify default paths to policy.json file

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -105,6 +105,9 @@ const (
 	DefaultPidsLimit = 2048
 	// DefaultPullPolicy pulls the image if it does not exist locally
 	DefaultPullPolicy = "missing"
+	// DefaultSignaturePolicyPath is the default value for the
+	// policy.json file.
+	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
 	// DefaultRootlessSignaturePolicyPath is the default value for the
 	// rootless policy.json file.
 	DefaultRootlessSignaturePolicyPath = ".config/containers/policy.json"
@@ -129,14 +132,19 @@ func DefaultConfig() (*Config, error) {
 	}
 
 	netns := "bridge"
+
+	defaultEngineConfig.SignaturePolicyPath = DefaultSignaturePolicyPath
 	if unshare.IsRootless() {
 		home, err := unshare.HomeDir()
 		if err != nil {
 			return nil, err
 		}
 		sigPath := filepath.Join(home, DefaultRootlessSignaturePolicyPath)
-		if _, err := os.Stat(sigPath); err == nil {
-			defaultEngineConfig.SignaturePolicyPath = sigPath
+		defaultEngineConfig.SignaturePolicyPath = sigPath
+		if _, err := os.Stat(sigPath); err != nil {
+			if _, err := os.Stat(DefaultSignaturePolicyPath); err == nil {
+				defaultEngineConfig.SignaturePolicyPath = DefaultSignaturePolicyPath
+			}
 		}
 		netns = "slirp4netns"
 	}


### PR DESCRIPTION
Currently if a rootless user runs podman in his homedir, and does
not have /etc/containers/policy.json on the system and does not
have ~/config/policy.json in his homedir, the command fails with
an error.

$ podman pull fedora
Error: error pulling image "fedora": unable to pull fedora: open /etc/containers/policy.json: no such file or directory

If the user has no root rights on the system, he can not create the file.
However the system would work fine if he created the file in his homedir.

With this change, we will force the default to be the file in his homedir if
BOTH files do not exist.  Now the error message for a rootless container would
be.

$ podman pull fedora
Error: unable to pull fedora: open /home/dwalsh/.config/containers/policy.json: no such file or directory

And the user has an idea how to fix this situation.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
