### PR TITLE
Don't set pids limit on rootless cgroupv1 systems

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -479,6 +479,8 @@ func (c *Config) PidsLimit() int64 {
 		cgroup2, _ := cgroupv2.Enabled()
 		if cgroup2 {
 			return c.Containers.PidsLimit
+		} else {
+			return 0
 		}
 	}
 	return sysinfo.GetDefaultPidsLimit()


### PR DESCRIPTION
Pids-limit is not supported on rootless cgroup V1 systems.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
