### PR TITLE
Simplify option handling

### DIFF
--- a/pkg/auth/cli.go
+++ b/pkg/auth/cli.go
@@ -29,7 +29,6 @@ type LogoutOptions struct {
 	AuthFile string
 	All      bool
 	// Options caller can set
-	Stdin                     io.Reader // set to os.Stdin
 	Stdout                    io.Writer // set to os.Stdout
 	AcceptUnspecifiedRegistry bool      // set to true if allows logout with unspecified registry
 }

--- a/pkg/auth/cli.go
+++ b/pkg/auth/cli.go
@@ -11,6 +11,8 @@ import (
 // *types.SystemContest)
 type LoginOptions struct {
 	// CLI flags managed by the FlagSet returned by GetLoginFlags
+	// Callers that use GetLoginFlags should not need to touch these values at all; callers that use
+	// other CLI frameworks should set them based on user input.
 	AuthFile      string
 	CertDir       string
 	Password      string
@@ -26,6 +28,8 @@ type LoginOptions struct {
 // LogoutOptions represents the results for flags in logout
 type LogoutOptions struct {
 	// CLI flags managed by the FlagSet returned by GetLogoutFlags
+	// Callers that use GetLogoutFlags should not need to touch these values at all; callers that use
+	// other CLI frameworks should set them based on user input.
 	AuthFile string
 	All      bool
 	// Options caller can set

--- a/pkg/auth/cli.go
+++ b/pkg/auth/cli.go
@@ -7,7 +7,8 @@ import (
 )
 
 // LoginOptions represents common flags in login
-// caller should define bool or optionalBool fields for flags --get-login and --tls-verify
+// In addition, the caller should probably provide a --tls-verify flag (that affects the provided
+// *types.SystemContest)
 type LoginOptions struct {
 	// CLI flags managed by the FlagSet returned by GetLoginFlags
 	AuthFile      string
@@ -15,8 +16,8 @@ type LoginOptions struct {
 	Password      string
 	Username      string
 	StdinPassword bool
+	GetLoginSet   bool
 	// Options caller can set
-	GetLoginSet               bool      // set to true if --get-login is explicitly set
 	Stdin                     io.Reader // set to os.Stdin
 	Stdout                    io.Writer // set to os.Stdout
 	AcceptUnspecifiedRegistry bool      // set to true if allows login with unspecified registry
@@ -41,6 +42,7 @@ func GetLoginFlags(flags *LoginOptions) *pflag.FlagSet {
 	fs.StringVarP(&flags.Password, "password", "p", "", "Password for registry")
 	fs.StringVarP(&flags.Username, "username", "u", "", "Username for registry")
 	fs.BoolVar(&flags.StdinPassword, "password-stdin", false, "Take the password from stdin")
+	fs.BoolVar(&flags.GetLoginSet, "get-login", false, "Return the current login user for the registry")
 	return &fs
 }
 


### PR DESCRIPTION
This moves more of the burden from callers, by directly implementing `AuthFile` and `CertDir`, defining a CLI option for `GetLoginSet`, documenting the expectations more clearly.

It also makes some functions private, it’s unclear if there are any other callers. (It also seems quite tempting to make most of the options private as well.)

See the individual commit messages for details.

Cc: @QiWang19 