### PR TITLE
Revert removal of Set flags

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -345,6 +345,24 @@ type SetOptions struct {
 	// backwards compatibility with older versions of libpod for which we must
 	// query the database configuration. Not included in the on-disk config.
 	StorageConfigGraphDriverNameSet bool `toml:"-"`
+
+	// StaticDirSet indicates if the StaticDir has been explicitly set by the
+	// config or by the user. It's required to guarantee backwards compatibility
+	// with older versions of libpod for which we must query the database
+	// configuration. Not included in the on-disk config.
+	StaticDirSet bool `toml:"-"`
+
+	// VolumePathSet indicates if the VolumePath has been explicitly set by the
+	// config or by the user. It's required to guarantee backwards compatibility
+	// with older versions of libpod for which we must query the database
+	// configuration. Not included in the on-disk config.
+	VolumePathSet bool `toml:"-"`
+
+	// TmpDirSet indicates if the TmpDir has been explicitly set by the config
+	// or by the user. It's required to guarantee backwards compatibility with
+	// older versions of libpod for which we must query the database
+	// configuration. Not included in the on-disk config.
+	TmpDirSet bool `toml:"-"`
 }
 
 // NetworkConfig represents the "network" TOML config table


### PR DESCRIPTION
Even though these are not read from the config file, they are
still required as fields to pass data in libpod.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
