### PR TITLE
fixes for pkg/sysinfo/checkCgroupPids

### DIFF
--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -231,6 +231,7 @@ func checkCgroupPids(quiet bool) cgroupPids {
 	cgroup2, err := cgroupv2.Enabled()
 	if err != nil {
 		logrus.Errorf("Failed to check cgroups version: %v", err)
+		return cgroupPids{}
 	}
 	if !cgroup2 {
 		_, err := cgroups.FindCgroupMountpoint("", "pids")

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -40,7 +40,7 @@ func New(quiet bool) *SysInfo {
 		sysInfo.cgroupCPUInfo = checkCgroupCPU(cgMounts, quiet)
 		sysInfo.cgroupBlkioInfo = checkCgroupBlkioInfo(cgMounts, quiet)
 		sysInfo.cgroupCpusetInfo = checkCgroupCpusetInfo(cgMounts, quiet)
-		sysInfo.cgroupPids = checkCgroupPids(quiet)
+		sysInfo.cgroupPids = checkCgroupPids(cgMounts, quiet)
 	}
 
 	_, ok := cgMounts["devices"]
@@ -227,17 +227,17 @@ func checkCgroupCpusetInfo(cgMounts map[string]string, quiet bool) cgroupCpusetI
 }
 
 // checkCgroupPids reads the pids information from the pids cgroup mount point.
-func checkCgroupPids(quiet bool) cgroupPids {
+func checkCgroupPids(cgMounts map[string]string, quiet bool) cgroupPids {
 	cgroup2, err := cgroupv2.Enabled()
 	if err != nil {
 		logrus.Errorf("Failed to check cgroups version: %v", err)
 		return cgroupPids{}
 	}
 	if !cgroup2 {
-		_, err := cgroups.FindCgroupMountpoint("", "pids")
-		if err != nil {
+		_, ok := cgMounts["pids"]
+		if !ok {
 			if !quiet {
-				logrus.Warn(err)
+				logrus.Warn("unable to find pids cgroup in mounts")
 			}
 			return cgroupPids{}
 		}


### PR DESCRIPTION
### 1. pkg/sysinfo.checkCgroupPids: fix error path

In case we failed to find out what version of cgroup we have,
it makes little sense to return that pids cgroup controller
is available, and yet the current code does it.

Fix this.

### 2. pkg/sysinfo.checkCgroupPids: speedup

For some reason this code chose not to use information already fetched,
and call cgroups.FindCgroupMountpoint() instead. This is not a cheap
call, as it has to parse the whole nine yards of /proc/self/mountinfo,
and the info it tries to get (whether the pids controller is present)
is already available from cgMounts map.

This also prepares the code for the upcoming changes in runc (https://github.com/opencontainers/runc/pull/2411).

