### PR TITLE
Add full path for error messages on containers.conf

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -878,3 +878,16 @@ func Default() (*Config, error) {
 	})
 	return config, err
 }
+
+func Path() string {
+	if path := os.Getenv("CONTAINERS_CONF"); path != "" {
+		return path
+	}
+	if unshare.IsRootless() {
+		if rpath, err := rootlessConfigPath(); err == nil {
+			return rpath
+		}
+		return "$HOME/" + UserOverrideContainersConfig
+	}
+	return OverrideContainersConfig
+}

--- a/pkg/config/libpodConfig.go
+++ b/pkg/config/libpodConfig.go
@@ -226,7 +226,7 @@ func newLibpodConfig(c *Config) error {
 
 	// hard code EventsLogger to "file" to match older podman versions.
 	if config.EventsLogger != "file" {
-		logrus.Debugf("Ignoring lipod.conf EventsLogger setting %q. Use containers.conf if you want to change this setting and remove libpod.conf files.", config.EventsLogger)
+		logrus.Debugf("Ignoring libpod.conf EventsLogger setting %q. Use %q if you want to change this setting and remove libpod.conf files.", Path(), config.EventsLogger)
 		config.EventsLogger = "file"
 	}
 
@@ -262,7 +262,7 @@ func systemLibpodConfigs() ([]string, error) {
 			}
 			// TODO: Raise to Warnf, when Podman is updated to
 			// remove libpod.conf by default
-			logrus.Debugf("Found deprecated file %s, please remove. Use %s to override defaults.\n", path, containersConfPath)
+			logrus.Debugf("Found deprecated file %s, please remove. Use %s to override defaults.\n", Path(), containersConfPath)
 			return []string{path}, nil
 		}
 		return nil, err


### PR DESCRIPTION
Also add new function to allow container engines to tell users
where to edit containers.conf file.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
