### PR TITLE
V2 Store identity associated with remote URL

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -269,6 +269,9 @@ type EngineConfig struct {
 	// RemoteURI containers connection information used to connect to remote system.
 	RemoteURI string `toml:"remote_uri,omitempty"`
 
+	// Identity key file for RemoteURI
+	RemoteIdentity string `toml:"remote_identity,omitempty"`
+
 	// RuntimePath is the path to OCI runtime binary for launching containers.
 	// The first path pointing to a valid file will be used This is used only
 	// when there are no OCIRuntime/OCIRuntimes defined.  It is used only to be


### PR DESCRIPTION
* as workaround user can use --identity option when given commands
  requiring a SSH key

Signed-off-by: Jhon Honce <jhonce@redhat.com>
