### PR TITLE
Add script to rebuild images on quay.io

### DIFF
--- a/tools/rebuild_quay_ctr_images.sh
+++ b/tools/rebuild_quay_ctr_images.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# 
+# rebuild_quay_ctr_images.sh PROJECT AUTHFILE
+#
+# This script expects Podman to be installed on the system and
+# that the user is logged in with `podman login` to the target
+# repository.
+#
+# This script expects one or two parameters, it will query for 
+# the PROJECT if not provided.  It expects these parameters
+# in order:
+#     PROJECT  (buildah, podman or skopeo)
+#     AUTHFILE (Location of the authfile created by podman login)
+#
+# It then builds the quay.io/container/${PROJECT}:latest, 
+# quay.io/${PROJECT}/stable:latest, quay.io/${PROJECT}/upstream:latest,
+# and the quay.io/${PROJECT}/testing:latest container images.
+# It then pushes the images to those repos.
+#
+# This script can be run via cron to build and push the images
+# on a regular basis.  Entries like this within "crontab -e" would 
+# create each of the images for the specified project at 8:00,
+# 9:00 and 10:00 a.m. successively.
+# The entries assume an auth.json file has been created using the
+# `podman login quay.io` command as root.  If run as a rootless
+# user the '0' in the location would need to be changed to the uid
+# of the user.  This also assumes a copy of this file in the
+# /root/quay.io directory.
+#
+#    0 8 * * * /root/quay.io/rebuild_quay_ctr_images.sh buildah /run/user/0/containers/auth.json 
+#    0 9 * * * /root/quay.io/rebuild_quay_ctr_images.sh skopeo /run/user/0/containers/auth.json
+#    0 10 * * * /root/quay.io/rebuild_quay_ctr_images.sh podman /run/user/0/containers/auth.json
+#
+
+PROJECT=$1
+AUTHFILE=$2
+
+########
+# Query for project and authfile 
+# if necessary.
+########
+if [[ "$PROJECT" == "" ]]; then
+  echo "Enter the containers project to create the images for:"
+  read PROJECT
+  echo ""
+fi
+
+if [[ "$AUTHFILE" == "" ]]; then
+  echo "Enter the authfile to use:"
+  read AUTHFILE
+  echo ""
+fi
+
+GITHUBPROJECT=$PROJECT
+# Tweak until podman lives under podman and not libpod in GitHub
+if [[ "$PROJECT" == "podman" ]]; then
+   GITHUBPROJECT="libpod"
+fi  
+
+########
+# Build quay.io/containers/${PROJECT}:latest
+########
+podman build --no-cache -t quay.io/containers/${PROJECT}:latest -f https://raw.githubusercontent.com/containers/${GITHUBPROJECT}/master/contrib/${PROJECT}image/stable/Dockerfile .
+
+########
+# Push quay.io/containers/${PROJECT}:latest
+########
+podman push --authfile ${AUTHFILE} quay.io/containers/${PROJECT}:latest
+
+########
+# Remove quay.io/containers/${PROJECT}:latest
+########
+podman rmi -f quay.io/containers/${PROJECT}:latest
+
+
+########
+# Build quay.io/${PROJECT}/stable:latest
+########
+podman build --no-cache -t quay.io/${PROJECT}/stable:latest -f https://raw.githubusercontent.com/containers/${GITHUBPROJECT}/master/contrib/${PROJECT}image/stable/Dockerfile .
+
+########
+# Push quay.io/${PROJECT}/stable:latest
+########
+podman push --authfile ${AUTHFILE} quay.io/${PROJECT}/stable:latest
+
+########
+# Remove quay.io/${PROJECT}/stable:latest
+########
+podman rmi -f quay.io/${PROJECT}/stable:latest
+
+
+########
+# Build quay.io/${PROJECT}/testing:latest
+########
+podman build --no-cache -t quay.io/${PROJECT}/testing:latest -f https://raw.githubusercontent.com/containers/${GITHUBPROJECT}/master/contrib/${PROJECT}image/testing/Dockerfile .
+
+########
+# Push quay.io/${PROJECT}/testing:latest
+########
+podman push --authfile ${AUTHFILE} quay.io/${PROJECT}/testing:latest
+
+########
+# Remove quay.io/${PROJECT}/testing:latest
+########
+podman rmi -f quay.io/${PROJECT}/testing:latest
+
+
+########
+# Build quay.io/${PROJECT}/upstream:latest
+########
+podman build --no-cache -t quay.io/${PROJECT}/upstream:latest -f https://raw.githubusercontent.com/containers/${GITHUBPROJECT}/master/contrib/${PROJECT}image/upstream/Dockerfile .
+
+########
+# Push quay.io/${PROJECT}/upstream:latest
+########
+podman push --authfile ${AUTHFILE} quay.io/${PROJECT}/upstream:latest
+
+########
+# Remove quay.io/${PROJECT}/upstream:latest
+########
+podman rmi -f quay.io/${PROJECT}/upstream:latest
+
+########
+# That's All Folks!!!
+########


### PR DESCRIPTION
We recently discovered that the build triggers that are employed on
quay.io for the Buildah, Podman, and Skopeo container images do not
refresh the images as frequently as we thought.  Due to Docker using
the `--no-cache` flag under the covers at quay to do the builds, our
images were always using the pre-existing cache unless the `FROM` target
or the Dockerfile changed.  This rarely happened and it would take
weeks or more before the stable version would bump up to the latest
version available.  Ditto the upstream and testing variants.

I've created a script that can be run `by-hand` or via cron to update the
various images.  The script takes the project name and the creds for
an administrator on our repos on quay.io.  If those values are not supplied
the script will ask for them and the password will not be shown when
typed in.

I'm planning to run this via cron on one of my VM's and the images should
be updated every morning that my VM is up, or someone else with admin privs
can run it.  If someone runs this script without privs, they will build the
images locally and they will not be able to push them.

This was the most logical place I could think of to drop this script as it's
usable by all of our projects.  If you've a better location, please let me
know.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
