### PR TITLE
[0.14] Change AppArmor profile prefix and fix name-check

### DIFF
--- a/pkg/apparmor/apparmor.go
+++ b/pkg/apparmor/apparmor.go
@@ -2,14 +2,16 @@ package apparmor
 
 import (
 	"errors"
+
+	"github.com/containers/common/version"
 )
 
 const (
 	// ProfilePrefix is used for version-independent presence checks.
-	ProfilePrefix = "apparmor_profile"
+	ProfilePrefix = "containers-default-"
 
 	// Profile default name
-	Profile = "container-default"
+	Profile = ProfilePrefix + version.Version
 )
 
 var (

--- a/pkg/apparmor/apparmor_linux.go
+++ b/pkg/apparmor/apparmor_linux.go
@@ -255,9 +255,11 @@ func CheckProfileAndLoadDefault(name string) (string, error) {
 		}
 	}
 
-	// If the specified name is not empty or is not a default libpod one,
-	// ignore it and return the name.
-	if name != "" && !strings.HasPrefix(name, ProfilePrefix) {
+	if name == "" {
+		name = Profile
+	} else if !strings.HasPrefix(name, ProfilePrefix) {
+		// If the specified name is not a default one, ignore it and return the
+		// name.
 		isLoaded, err := IsLoaded(name)
 		if err != nil {
 			return "", err
@@ -268,7 +270,6 @@ func CheckProfileAndLoadDefault(name string) (string, error) {
 		return name, nil
 	}
 
-	name = Profile
 	// To avoid expensive redundant loads on each invocation, check
 	// if it's loaded before installing it.
 	isLoaded, err := IsLoaded(name)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/containers/common/pkg/apparmor"
 	"github.com/containers/common/pkg/capabilities"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -22,7 +23,7 @@ var _ = Describe("Config", func() {
 
 			// Then
 			gomega.Expect(err).To(gomega.BeNil())
-			gomega.Expect(defaultConfig.Containers.ApparmorProfile).To(gomega.Equal("container-default"))
+			gomega.Expect(defaultConfig.Containers.ApparmorProfile).To(gomega.Equal(apparmor.Profile))
 			gomega.Expect(defaultConfig.Containers.PidsLimit).To(gomega.BeEquivalentTo(2048))
 		})
 
@@ -235,7 +236,7 @@ var _ = Describe("Config", func() {
 			config, err := NewConfig("")
 			// Then
 			gomega.Expect(err).To(gomega.BeNil())
-			gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal("container-default"))
+			gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal(apparmor.Profile))
 			gomega.Expect(config.Containers.PidsLimit).To(gomega.BeEquivalentTo(2048))
 			gomega.Expect(config.Containers.Env).To(gomega.BeEquivalentTo(envs))
 			gomega.Expect(config.Network.CNIPluginDirs).To(gomega.Equal(pluginDirs))

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version is the version of the build.
+const Version = "0.14.1-dev"


### PR DESCRIPTION
The default AppArmor profile is now prefixed with
`container-default-$VERSION`, whereas the version is now part of a new
`version` package.

Signed-off-by: Sascha Grunert <sgrunert@suse.com>
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>
Backport-of: commit 12b04a21d8ce7c76ad592299f1a9dd27ff96a747