### PR TITLE
Encapsulate tests in own config_test package

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -879,6 +879,7 @@ func ReadCustomConfig() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	// hack since Ommitempty does not seem to work with Write
 	c, err := Default()
 	if err != nil {

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -1,14 +1,15 @@
 // +build !remote
 
-package config
+package config_test
 
 import (
 	"io/ioutil"
 	"os"
 	"path"
 
+	"github.com/containers/common/pkg/config"
 	. "github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Config Local", func() {
@@ -18,7 +19,7 @@ var _ = Describe("Config Local", func() {
 		// Given
 		tmpfile := path.Join(os.TempDir(), "wrong-file")
 		file, err := os.Create(tmpfile)
-		gomega.Expect(err).To(gomega.BeNil())
+		Expect(err).To(BeNil())
 		file.Close()
 		defer os.Remove(tmpfile)
 		sut.Network.NetworkConfigDir = tmpfile
@@ -28,7 +29,7 @@ var _ = Describe("Config Local", func() {
 		err = sut.Network.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		Expect(err).NotTo(BeNil())
 	})
 
 	It("should fail on invalid CNIPluginDirs", func() {
@@ -45,7 +46,7 @@ var _ = Describe("Config Local", func() {
 		err = sut.Network.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		Expect(err).NotTo(BeNil())
 	})
 
 	It("should fail in validating invalid PluginDir", func() {
@@ -62,7 +63,7 @@ var _ = Describe("Config Local", func() {
 		err = sut.Network.Validate()
 
 		// Then
-		gomega.Expect(err).ToNot(gomega.BeNil())
+		Expect(err).ToNot(BeNil())
 	})
 
 	It("should fail on invalid CNIPluginDirs", func() {
@@ -79,7 +80,7 @@ var _ = Describe("Config Local", func() {
 		err = sut.Network.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		Expect(err).NotTo(BeNil())
 	})
 
 	It("should fail during runtime", func() {
@@ -98,7 +99,7 @@ var _ = Describe("Config Local", func() {
 		err = sut.Network.Validate()
 
 		// Then
-		gomega.Expect(err).ToNot(gomega.BeNil())
+		Expect(err).ToNot(BeNil())
 	})
 
 	It("should fail on invalid device mode", func() {
@@ -109,7 +110,7 @@ var _ = Describe("Config Local", func() {
 		err := sut.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		Expect(err).NotTo(BeNil())
 	})
 
 	It("should fail on invalid first device", func() {
@@ -120,7 +121,7 @@ var _ = Describe("Config Local", func() {
 		err := sut.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		Expect(err).NotTo(BeNil())
 	})
 
 	It("should fail on invalid second device", func() {
@@ -131,7 +132,7 @@ var _ = Describe("Config Local", func() {
 		err := sut.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		Expect(err).NotTo(BeNil())
 	})
 
 	It("should fail on invalid device", func() {
@@ -142,7 +143,7 @@ var _ = Describe("Config Local", func() {
 		err := sut.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		Expect(err).NotTo(BeNil())
 	})
 
 	It("should fail on wrong invalid device specification", func() {
@@ -153,7 +154,7 @@ var _ = Describe("Config Local", func() {
 		err := sut.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		Expect(err).NotTo(BeNil())
 	})
 
 	It("should fail on wrong DefaultUlimits", func() {
@@ -164,24 +165,24 @@ var _ = Describe("Config Local", func() {
 		err := sut.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		Expect(err).NotTo(BeNil())
 	})
 
 	It("Expect Remote to be False", func() {
 		// Given
 		// When
-		config, err := NewConfig("")
+		config, err := config.NewConfig("")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config.Engine.Remote).To(gomega.BeFalse())
+		Expect(err).To(BeNil())
+		Expect(config.Engine.Remote).To(BeFalse())
 	})
 
 	It("write", func() {
 		tmpfile := "containers.conf.test"
 		oldContainersConf, envSet := os.LookupEnv("CONTAINERS_CONF")
 		os.Setenv("CONTAINERS_CONF", tmpfile)
-		config, err := ReadCustomConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		config, err := config.ReadCustomConfig()
+		Expect(err).To(BeNil())
 		config.Containers.Devices = []string{"/dev/null:/dev/null:rw",
 			"/dev/sdc/",
 			"/dev/sdc:/dev/xvdc",
@@ -190,7 +191,7 @@ var _ = Describe("Config Local", func() {
 
 		err = config.Write()
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		Expect(err).To(BeNil())
 		defer os.Remove(tmpfile)
 		// Undo that
 		if envSet {

--- a/pkg/config/config_remote_test.go
+++ b/pkg/config/config_remote_test.go
@@ -1,13 +1,13 @@
 // +build remote
 
-package config
+package config_test
 
 import (
 	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Config Remote", func() {
@@ -27,7 +27,7 @@ var _ = Describe("Config Remote", func() {
 		err = sut.Network.Validate()
 
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		Expect(err).To(BeNil())
 	})
 
 	It("should succeed on invalid device mode", func() {
@@ -38,7 +38,7 @@ var _ = Describe("Config Remote", func() {
 		err := sut.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		Expect(err).To(BeNil())
 	})
 
 	It("should succeed on invalid first device", func() {
@@ -49,7 +49,7 @@ var _ = Describe("Config Remote", func() {
 		err := sut.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		Expect(err).To(BeNil())
 	})
 
 	It("should succeed on invalid second device", func() {
@@ -60,7 +60,7 @@ var _ = Describe("Config Remote", func() {
 		err := sut.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		Expect(err).To(BeNil())
 	})
 
 	It("should succeed on invalid device", func() {
@@ -71,7 +71,7 @@ var _ = Describe("Config Remote", func() {
 		err := sut.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		Expect(err).To(BeNil())
 	})
 
 	It("should succeed on wrong invalid device specification", func() {
@@ -82,7 +82,7 @@ var _ = Describe("Config Remote", func() {
 		err := sut.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		Expect(err).To(BeNil())
 	})
 
 	It("Expect Remote to be true", func() {
@@ -90,8 +90,8 @@ var _ = Describe("Config Remote", func() {
 		// When
 		config, err := NewConfig("")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config.Engine.Remote).To(gomega.BeTrue())
+		Expect(err).To(BeNil())
+		Expect(config.Engine.Remote).To(BeTrue())
 	})
 
 	It("should succeed on wrong DefaultUlimits", func() {
@@ -102,7 +102,7 @@ var _ = Describe("Config Remote", func() {
 		err := sut.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		Expect(err).To(BeNil())
 	})
 
 	It("should succeed on invalid CNIPluginDirs", func() {
@@ -119,7 +119,7 @@ var _ = Describe("Config Remote", func() {
 		err = sut.Network.Validate()
 
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		Expect(err).To(BeNil())
 	})
 
 	It("should succeed in validating invalid PluginDir", func() {
@@ -136,7 +136,7 @@ var _ = Describe("Config Remote", func() {
 		err = sut.Network.Validate()
 
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		Expect(err).To(BeNil())
 	})
 
 })

--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -1,14 +1,15 @@
-package config
+package config_test
 
 import (
 	"testing"
 
+	"github.com/containers/common/pkg/config"
 	. "github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func TestConfig(t *testing.T) {
-	gomega.RegisterFailHandler(Fail)
+	RegisterFailHandler(Fail)
 	RunSpecs(t, "Config Suite")
 }
 
@@ -17,16 +18,16 @@ const (
 )
 
 var (
-	sut *Config
+	sut *config.Config
 )
 
 func beforeEach() {
 	sut = defaultConfig()
 }
 
-func defaultConfig() *Config {
-	c, err := DefaultConfig()
-	gomega.Expect(err).To(gomega.BeNil())
-	gomega.Expect(c).NotTo(gomega.BeNil())
+func defaultConfig() *config.Config {
+	c, err := config.DefaultConfig()
+	Expect(err).To(BeNil())
+	Expect(c).NotTo(BeNil())
 	return c
 }


### PR DESCRIPTION
To be able to ensure proper test encapsulation, we now split-up the
`config` package from the `config_test` package.

This also implies an API change which makes the `ReadConfigFromFile`
function now public.

We also dot-import the gomega matcher to reduce the test noise.
