### PR TITLE
[0.14] Remove race condition on sync.Once

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -822,6 +822,7 @@ func stringsEq(a, b []string) bool {
 
 var (
 	configOnce sync.Once
+	configErr  error
 	config     *Config
 )
 
@@ -837,11 +838,10 @@ var (
 // The system defaults container config files can be overwritten using the
 // CONTAINERS_CONF environment variable.  This is usually done for testing.
 func Default() (*Config, error) {
-	var err error
 	configOnce.Do(func() {
-		config, err = NewConfig("")
+		config, configErr = NewConfig("")
 	})
-	return config, err
+	return config, configErr
 }
 
 func Path() string {


### PR DESCRIPTION
We had a race condition where the sync.Once was called, and initializing
the default Config, but another thread hit it simultaniously and got the
nil value.
This patch will always return a correct value.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>
Backpord-of: commit 2ba9aff8fc5aa1edb9b2c0d111eb12e93ed73070

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
