### PR TITLE
v0.14.2

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.14.2-dev"
+const Version = "0.14.2"


### PR DESCRIPTION
Remove the `VERSION` file which was causing issues in non-master
branches for `go`.  The version is now tracked in the `version`
package.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan PTAL ... we're almost there

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
