### PR TITLE
Fix location of stop_timeout in default containers.conf

### DIFF
--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -372,6 +372,9 @@
 #
 # runtime_supports_kvm = ["kata"]
 
+# Number of seconds to wait for container to exit before sending kill signal.
+# stop_timeout = 10
+
 # Paths to look for a valid OCI runtime (runc, runv, kata, etc)
 [engine.runtimes]
 # runc = [
@@ -404,9 +407,6 @@
 #            "/usr/bin/kata-qemu",
 #            "/usr/bin/kata-fc",
 # ]
-
-# Number of seconds to wait for container to exit before sending kill signal.
-#stop_timeout = 10
 
 # The [engine.runtimes] table MUST be the last entry in this file.
 # (Unless another table is added)


### PR DESCRIPTION
stop_timeout has to be defined in the engine section not
the engine.runtimes section.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
