### PR TITLE
readConfig(): don't return a pointer that's often ignored

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -419,11 +419,10 @@ func NewConfig(userConfigPath string) (*Config, error) {
 		// Merge changes in later configs with the previous configs.
 		// Each config file that specified fields, will override the
 		// previous fields.
-		config, err := readConfigFromFile(path, config)
-		if err != nil {
+		if err = readConfigFromFile(path, config); err != nil {
 			return nil, errors.Wrapf(err, "error reading system config %q", path)
 		}
-		logrus.Debugf("Merged system config %q: %v", path, config)
+		logrus.Debugf("Merged system config %q: %+v", path, config)
 	}
 
 	// If the caller specified a config path to use, then we read it to
@@ -432,11 +431,10 @@ func NewConfig(userConfigPath string) (*Config, error) {
 		var err error
 		// readConfigFromFile reads in container config in the specified
 		// file and then merge changes with the current default.
-		config, err = readConfigFromFile(userConfigPath, config)
-		if err != nil {
+		if err = readConfigFromFile(userConfigPath, config); err != nil {
 			return nil, errors.Wrapf(err, "error reading user config %q", userConfigPath)
 		}
-		logrus.Debugf("Merged user config %q: %v", userConfigPath, config)
+		logrus.Debugf("Merged user config %q: %+v", userConfigPath, config)
 	}
 	config.addCAPPrefix()
 
@@ -451,13 +449,12 @@ func NewConfig(userConfigPath string) (*Config, error) {
 // unmarshal its content into a Config. The config param specifies the previous
 // default config. If the path, only specifies a few fields in the Toml file
 // the defaults from the config parameter will be used for all other fields.
-func readConfigFromFile(path string, config *Config) (*Config, error) {
+func readConfigFromFile(path string, config *Config) error {
 	logrus.Debugf("Reading configuration file %q", path)
-	_, err := toml.DecodeFile(path, config)
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode configuration %v: %v", path, err)
+	if _, err := toml.DecodeFile(path, config); err != nil {
+		return errors.Wrapf(err, "unable to decode configuration %v", path)
 	}
-	return config, err
+	return nil
 }
 
 // Returns the list of configuration files, if they exist in order of hierarchy.
@@ -895,8 +892,7 @@ func ReadCustomConfig() (*Config, error) {
 
 	newConfig := &Config{}
 	if _, err := os.Stat(path); err == nil {
-		newConfig, err = readConfigFromFile(path, newConfig)
-		if err != nil {
+		if err = readConfigFromFile(path, newConfig); err != nil {
 			return nil, err
 		}
 	} else {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -113,8 +113,8 @@ var _ = Describe("Config", func() {
 		It("should succeed with default config", func() {
 			// Given
 			// When
-			conf, _ := DefaultConfig()
-			defaultConfig, err := readConfigFromFile("testdata/containers_default.conf", conf)
+			defaultConfig, _ := DefaultConfig()
+			err := readConfigFromFile("testdata/containers_default.conf", defaultConfig)
 
 			OCIRuntimeMap := map[string][]string{
 				"kata": {
@@ -168,7 +168,7 @@ var _ = Describe("Config", func() {
 			// Given
 			// When
 			conf := Config{}
-			_, err := readConfigFromFile("testdata/containers_comment.conf", &conf)
+			err := readConfigFromFile("testdata/containers_comment.conf", &conf)
 
 			// Then
 			gomega.Expect(err).To(gomega.BeNil())
@@ -178,7 +178,7 @@ var _ = Describe("Config", func() {
 			// Given
 			// When
 			conf := Config{}
-			_, err := readConfigFromFile("/invalid/file", &conf)
+			err := readConfigFromFile("/invalid/file", &conf)
 
 			// Then
 			gomega.Expect(err).NotTo(gomega.BeNil())
@@ -188,7 +188,7 @@ var _ = Describe("Config", func() {
 			// Given
 			// When
 			conf := Config{}
-			_, err := readConfigFromFile("config.go", &conf)
+			err := readConfigFromFile("config.go", &conf)
 
 			// Then
 			gomega.Expect(err).NotTo(gomega.BeNil())


### PR DESCRIPTION
Remove the often-unused result value from readConfig().

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
