### PR TITLE
[0.14] Fix location of stop_timeout in default containers.conf

### DIFF
--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -364,6 +364,9 @@
 #
 # runtime_supports_kvm = ["kata"]
 
+# Number of seconds to wait for container to exit before sending kill signal.
+# stop_timeout = 10
+
 # Paths to look for a valid OCI runtime (runc, runv, kata, etc)
 [engine.runtimes]
 # runc = [
@@ -396,9 +399,6 @@
 #            "/usr/bin/kata-qemu",
 #            "/usr/bin/kata-fc",
 # ]
-
-# Number of seconds to wait for container to exit before sending kill signal.
-#stop_timeout = 10
 
 # The [engine.runtimes] table MUST be the last entry in this file.
 # (Unless another table is added)


### PR DESCRIPTION
stop_timeout has to be defined in the engine section not
the engine.runtimes section.

Cherry-pick: commit b1dc0118e22012a67bb0bb93f099008b030a6603
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
