### PR TITLE
multi_image_archive: add option for `podman save`

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -356,6 +356,10 @@ Change the default only if you are sure of what you are doing, in general
 faster "shm" lock type.  You may need to run "podman system renumber" after you
 change the lock type.
 
+**multi_image_archive**=false
+
+Allows for creating archives (e.g., tarballs) with more than one image.  Some container engines, such as Podman, interpret additional arguments as tags for one image and hence do not store more than one image.  The default behavior can be altered with this option.
+
 **namespace**=""
 
 Default engine namespace. If the engine is joined to a namespace, it will see

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -244,6 +244,11 @@ type EngineConfig struct {
 	// LockType is the type of locking to use.
 	LockType string `toml:"lock_type,omitempty"`
 
+	// MultiImageArchive - if true, the container engine allows for storing
+	// archives (e.g., of the docker-archive transport) with multiple
+	// images.  By default, Podman creates single-image archives.
+	MultiImageArchive bool `toml:"multi_image_archive,omitempty"`
+
 	// Namespace is the engine namespace to use. Namespaces are used to create
 	// scopes to separate containers and pods in the state. When namespace is
 	// set, engine will only view containers and pods in the same namespace. All

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -322,6 +322,12 @@
 #
 # lock_type** = "shm"
 
+# MultiImageArchive - if true, the container engine allows for storing archives
+# (e.g., of the docker-archive transport) with multiple images.  By default,
+# Podman creates single-image archives.
+#
+# multi_image_archive = "false"
+
 # Default engine namespace
 # If engine is joined to a namespace, it will see only containers and pods
 # that were created in the same namespace, and will create new containers and


### PR DESCRIPTION
Add an option to control the default behavior of `podman save` or other
container engines.  If set to "true", the engine will create a
multi-image (docker) archive.  By default, Podman will interpret
additional arguments as tags that'll be stored in the archive's
manifest.  Docker interprets additional arguments as images to allow for
creating multi-image archives.  This option allows users to chose how
they wish the default behavior to look like, so we don't break
compatibility with existing Podman workloads while being compatible
with Docker.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
