### PR TITLE
Add config reload

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -936,3 +936,13 @@ func (c *Config) Write() error {
 	}
 	return nil
 }
+
+// Reload reloads the configuration from containers.conf files
+func Reload() (*Config, error) {
+	var err error
+	config, err = NewConfig("")
+	if err != nil {
+		return nil, errors.Wrapf(err, "containers.conf reload failed")
+	}
+	return Default()
+}


### PR DESCRIPTION
Add Reload() to reload configurations from containers.conf files.

Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
