### PR TITLE
rootless: permit custom configuration for cni

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -598,9 +598,17 @@ func (c *ContainersConfig) Validate() error {
 // execution checks. It returns an `error` on validation failure, otherwise
 // `nil`.
 func (c *NetworkConfig) Validate() error {
-	if c.NetworkConfigDir != _cniConfigDir {
-		err := isDirectory(c.NetworkConfigDir)
+	expectedConfigDir := _cniConfigDir
+	if unshare.IsRootless() {
+		home, err := unshare.HomeDir()
 		if err != nil {
+			return err
+		}
+		expectedConfigDir = filepath.Join(home, _cniConfigDirRootless)
+	}
+	if c.NetworkConfigDir != expectedConfigDir {
+		err := isDirectory(c.NetworkConfigDir)
+		if err != nil && !os.IsNotExist(err) {
 			return errors.Wrapf(err, "invalid network_config_dir: %s", c.NetworkConfigDir)
 		}
 	}

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -92,8 +92,10 @@ const (
 	// InstallPrefix is the prefix where podman will be installed.
 	// It can be overridden at build time.
 	_installPrefix = "/usr"
-	// _cniConfigDir is the directory where cni plugins are found
+	// _cniConfigDir is the directory where cni configuration is found
 	_cniConfigDir = "/etc/cni/net.d/"
+	// _cniConfigDirRootless is the directory where cni plugins are found
+	_cniConfigDirRootless = ".config/cni/net.d/"
 	// CgroupfsCgroupsManager represents cgroupfs native cgroup manager
 	CgroupfsCgroupsManager = "cgroupfs"
 	// DefaultApparmorProfile  specifies the default apparmor profile for the container.
@@ -138,6 +140,8 @@ func DefaultConfig() (*Config, error) {
 
 	netns := "bridge"
 
+	cniConfig := _cniConfigDir
+
 	defaultEngineConfig.SignaturePolicyPath = DefaultSignaturePolicyPath
 	if unshare.IsRootless() {
 		home, err := unshare.HomeDir()
@@ -152,6 +156,7 @@ func DefaultConfig() (*Config, error) {
 			}
 		}
 		netns = "slirp4netns"
+		cniConfig = filepath.Join(home, _cniConfigDirRootless)
 	}
 
 	cgroupNS := "host"
@@ -197,7 +202,7 @@ func DefaultConfig() (*Config, error) {
 		},
 		Network: NetworkConfig{
 			DefaultNetwork:   "podman",
-			NetworkConfigDir: _cniConfigDir,
+			NetworkConfigDir: cniConfig,
 			CNIPluginDirs:    cniBinDir,
 		},
 		Engine: *defaultEngineConfig,


### PR DESCRIPTION
I am experimenting with supporting CNI in rootless Podman.  There is
no harm in preparing common to support such case and allow a custom
per-user configuration.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
