### PR TITLE
Add support for multiple service destinations

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -322,15 +322,23 @@ pod consumes one lock.  The default number available is 2048.  If this is
 changed, a lock renumbering must be performed, using the
 `podman system renumber` command.
 
-**remote_uri**=""
-  URI to access the Podman service.
+**active_service**=""
+  Name of destination for accessing the Podman service.
+
+**[service_destinations]**
+
+**[service_destinations.{name}]**
+  **uri="ssh://user@production.example.com/run/user/1001/podman/podman.sock"**
 
     Example URIs:
 
-- **rootless local**  - unix://run/user/$UID/podman/podman.sock
-- **rootless remote** - ssh://engineering.lab.company.com/run/user/1000/podman/podman.sock
+- **rootless local**  - unix://run/user/1000/podman/podman.sock
+- **rootless remote** - ssh://user@engineering.lab.company.com/run/user/1000/podman/podman.sock
 - **rootfull local**  - unix://run/podman/podman.sock
 - **rootfull remote** - ssh://root@10.10.1.136:22/run/podman/podman.sock
+
+  **identity="~/.ssh/id_rsa**
+    Path to file containing ssh identity key
 
 **pull_policy**="always"|"missing"|"never"
 Pull image before running or creating a container. The default is **missing**.

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -340,14 +340,6 @@
 # Whether to pull new image before running a container
 # pull_policy = "missing"
 
-# Default Remote URI to access the Podman service.
-# Examples:
-#  rootless "unix://run/user/$UID/podman/podman.sock" (Default)
-#  rootfull "unix://run/podman/podman.sock.(Default)
-#  remote rootless ssh://engineering.lab.company.com/run/user/1000/podman/podman.sock
-#  remote rootfull ssh://root@10.10.1.136:22/run/podman/podman.sock
-# remote_uri= ""
-
 # Directory for persistent engine files (database, etc)
 # By default, this will be configured relative to where the containers/storage
 # stores containers
@@ -385,6 +377,22 @@
 
 # Number of seconds to wait for container to exit before sending kill signal.
 # stop_timeout = 10
+
+# Index to the active service
+# active_service = production
+
+# map of service destinations
+# [service_destinations]
+#   [service_destinations.production]
+#     URI to access the Podman service
+#     Examples:
+#       rootless "unix://run/user/$UID/podman/podman.sock" (Default)
+#       rootfull "unix://run/podman/podman.sock (Default)
+#       remote rootless ssh://engineering.lab.company.com/run/user/1000/podman/podman.sock
+#       remote rootfull ssh://root@10.10.1.136:22/run/podman/podman.sock
+#     uri="ssh://user@production.example.com/run/user/1001/podman/podman.sock"
+#     Path to file containing ssh identity key
+#     identity = "~/.ssh/id_rsa"
 
 # Paths to look for a valid OCI runtime (runc, runv, kata, etc)
 [engine.runtimes]


### PR DESCRIPTION
Allow users to setup N destinations for connecting to podman services.

Signed-off-by: Jhon Honce <jhonce@redhat.com>
