### PR TITLE
Ensure that rootless cgroupsv1 will select cgroupfs

### DIFF
--- a/pkg/config/systemd.go
+++ b/pkg/config/systemd.go
@@ -2,7 +2,17 @@
 
 package config
 
+import (
+	"github.com/containers/common/pkg/cgroupv2"
+	"github.com/containers/storage/pkg/unshare"
+)
+
 func defaultCgroupManager() string {
+	enabled, err := cgroupv2.Enabled()
+	if err == nil && !enabled && unshare.IsRootless() {
+		return CgroupfsCgroupsManager
+	}
+
 	return SystemdCgroupsManager
 }
 func defaultEventsLogger() string {


### PR DESCRIPTION
The current logic is that, if Podman was built with the systemd build flag, we will always select systemd cgroups by default. Then, if we detect no systemd dbus session, we will swap to cgroupfs. Problem: there are cases where a systemd dbus session is available, but systemd cgroups don't work - most notably, rootless mode on cgroups v1 systems. Special-case this so that we will not try to force systemd mode and break rootless containers.

Fixes https://github.com/containers/podman/issues/6982
