### PR TITLE
[0.14] Ensure that rootless cgroupsv1 will select cgroupfs

### DIFF
--- a/pkg/config/systemd.go
+++ b/pkg/config/systemd.go
@@ -2,7 +2,17 @@
 
 package config
 
+import (
+	"github.com/containers/common/pkg/cgroupv2"
+	"github.com/containers/storage/pkg/unshare"
+)
+
 func defaultCgroupManager() string {
+	enabled, err := cgroupv2.Enabled()
+	if err == nil && !enabled && unshare.IsRootless() {
+		return CgroupfsCgroupsManager
+	}
+
 	return SystemdCgroupsManager
 }
 func defaultEventsLogger() string {

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.14.5"
+const Version = "0.14.6-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.14.5-dev"
+const Version = "0.14.5"


### PR DESCRIPTION
The current logic is that, if Podman was built with the systemd
build flag, we will always select systemd cgroups by default.
Then, if we detect no systemd dbus session, we will swap to
cgroupfs. Problem: there are cases where a systemd dbus session
is available, but systemd cgroups don't work - most notably,
rootless mode on cgroups v1 systems. Special-case this so that we
will not try to force systemd mode and break rootless containers.

Fixes https://github.com/containers/podman/issues/6982

Cherry-picked commit a61c5e2c9bb3b6a7a0764d4aebcc269145136b1c.

Signed-off-by: Matthew Heon <matthew.heon@pm.me>
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
