### PR TITLE
Move retry code to pkg/retry

### DIFF
--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -1,4 +1,4 @@
-package image
+package retry
 
 import (
 	"context"


### PR DESCRIPTION
Move the retry helper functions to pkg/retry.

Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
