### PR TITLE
[0.14] Fix documenation

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -125,9 +125,6 @@ environment variables to the container.
 **env_host**=false
   Pass all host environment variables into the container.
 
-**hooks_dir**=["/etc/containers/oci/hooks.d", ...]
-  Path to the OCI hooks directories for automatically executed hooks.
-
 **http_proxy**=false
   Default proxy environment variables will be passed into the container.
   The environment variables passed in include:
@@ -275,6 +272,9 @@ Disabling this can save memory.
   Default method to use when logging events.
   Valid values: `file`, `journald`, and `none`.
 
+**hooks_dir**=["/etc/containers/oci/hooks.d", ...]
+  Path to the OCI hooks directories for automatically executed hooks.
+
 **image_default_transport**="docker://"
   Default transport method for pulling and pushing images.
 
@@ -300,6 +300,9 @@ only containers and pods that were created in the same namespace, and will
 create new containers and pods in that namespace.  The default namespace is "",
  which corresponds to no namespace. When no namespace is set, all containers
 and pods are visible.
+
+**network_cmd_path**=""
+  NetworkCmdPath is the path to the slirp4netns binary.
 
 **no_pivot_root**=false
   Whether to use chroot instead of pivot_root in the runtime.

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -122,12 +122,6 @@
 #
 # env_host = false
 
-# Path to OCI hooks directories for automatically executed hooks.
-#
-# hooks_dir = [
-#     "/usr/share/containers/oci/hooks.d",
-# ]
-
 # Default proxy environment variables passed into the container.
 # The environment variables passed in include:
 # http_proxy, https_proxy, ftp_proxy, no_proxy, and the upper case versions of
@@ -284,6 +278,12 @@
 #
 # events_logger = "journald"
 
+# Path to OCI hooks directories for automatically executed hooks.
+#
+# hooks_dir = [
+#     "/usr/share/containers/oci/hooks.d",
+# ]
+
 # Default transport method for pulling and pushing for images
 #
 # image_default_transport = "docker://"
@@ -315,6 +315,10 @@
 # namespace is set, all containers and pods are visible.
 #
 # namespace = ""
+
+# NetworkCmdPath is the path to the slirp4netns binary
+#
+# network_cmd_path=""
 
 # Whether to use chroot instead of pivot_root in the runtime
 #


### PR DESCRIPTION
hooks_dir_path was in wrong location, should be under Enigne section

network_cmd_path was not documented.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
