### PR TITLE
Move testdata hooks_dir to [engine]

### DIFF
--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -58,10 +58,6 @@ env = [
     "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 ]
 
-# Path to OCI hooks directories for automatically executed hooks.
-hooks_dir = [
-]
-
 # Run an init inside the container that forwards signals and reaps processes.
 init = false
 
@@ -159,6 +155,10 @@ no_pivot_root = false
 # The default namespace is "", which corresponds to no namespace. When no
 # namespace is set, all containers and pods are visible.
 #namespace = ""
+
+# Path to OCI hooks directories for automatically executed hooks.
+hooks_dir = [
+]
 
 # Default infra (pause) image name for pod infra containers
 infra_image = "k8s.gcr.io/pause:3.2"

--- a/pkg/config/testdata/containers_invalid.conf
+++ b/pkg/config/testdata/containers_invalid.conf
@@ -75,10 +75,6 @@ devices = [
 # limit is never exceeded.
 log_size_max = -1
 
-# Path to OCI hooks directories for automatically executed hooks.
-hooks_dir = [
-]
-
 # Size of /dev/shm. Specified as <number><unit>.
 # Unit is optional and can be b (bytes), k (kilobytes), m (megabytes), or g (gigabytes). If the unit is omitted, the system uses bytes.
 shm_size = "-5536k"
@@ -133,6 +129,9 @@ conmon_path = [
 # Directory for temporary files. Must be tmpfs (wiped after reboot)
 tmp_dir = "/var/run/libpod"
 
+# Path to OCI hooks directories for automatically executed hooks.
+hooks_dir = [
+]
 
 # Whether to use chroot instead of pivot_root in the runtime
 no_pivot_root = false


### PR DESCRIPTION
Move hooks_dir in test files to [engine] table.

Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
