### PR TITLE
Do not mention libpod.conf if no files found

### DIFF
--- a/pkg/config/libpodConfig.go
+++ b/pkg/config/libpodConfig.go
@@ -197,6 +197,10 @@ func newLibpodConfig(c *Config) error {
 		return errors.Wrapf(err, "error finding config on system")
 	}
 
+	if len(configs) == 0 {
+		return nil
+	}
+
 	for _, path := range configs {
 		config, err = readLibpodConfigFromFile(path, config)
 		if err != nil {


### PR DESCRIPTION
We are throwing warning about libpod.conf when no files are
found.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
