### PR TITLE
Omit apparmor_parser warnings when parsing the version

### DIFF
--- a/pkg/apparmor/apparmor_linux.go
+++ b/pkg/apparmor/apparmor_linux.go
@@ -163,7 +163,7 @@ func execAAParser(dir string, args ...string) (string, error) {
 	c := exec.Command("apparmor_parser", args...)
 	c.Dir = dir
 
-	output, err := c.CombinedOutput()
+	output, err := c.Output()
 	if err != nil {
 		return "", fmt.Errorf("running `%s %s` failed with output: %s\nerror: %v", c.Path, strings.Join(c.Args, " "), output, err)
 	}


### PR DESCRIPTION
The `execAAParser()` function also takes `stderr` into account when
parsing the output. This function is right now only called by the
`getAAParserVersion()` function. Depending on the system configuration,
it might be possible that `apparmor_parser` prints a warning, for
example if `/etc/apparmor/parser.conf` does not exist on the system. To
thake this input not into account for the version parsing, we now just
use `stdout` as the returned result.