### PR TITLE
Add CONTAINERS_STORAGE_CONF Environment hanlding for testing

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -221,7 +221,7 @@ the system uses `65536k`.
 **tz=**""
 
 Set timezone in container. Takes IANA timezones as well as `local`, which sets the timezone in the container to match the host machine.
-If not set, then containers will run with the time zone specified in the image. 
+If not set, then containers will run with the time zone specified in the image.
 Examples:
   `tz="local"`
   `tz="America/New_York"`
@@ -452,6 +452,9 @@ containers. This convention is followed by the default volume driver, but may
 not be by other drivers.
 
 # FILES
+
+**containers.conf**
+
 Distributions often provide a `/usr/share/containers/containers.conf` file to
 define default container configuration. Administrators can override fields in
 this file by creating `/etc/containers/containers.conf` to specify their own
@@ -464,6 +467,16 @@ this path will be used.  This is primarily used for testing.
 
 Fields specified in the containers.conf file override the default options, as
 well as options in previously read containers.conf files.
+
+**storage.conf**
+
+The `/etc/containers/storage.conf` file is the default storage configuration file.
+Rootless users can override fields in the storage config by creating
+`$HOME/.config/containers/storage.conf`.
+
+If the `CONTAINERS_STORAGE_CONF` path environment variable is set, this path
+is used for the storage.conf file rather than the default.
+This is primarily used for testing.
 
 # SEE ALSO
 containers-storage.conf(5), containers-policy.json(5), containers-registries.conf(5)

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -223,10 +223,16 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 
 	c.EventsLogFilePath = filepath.Join(c.TmpDir, "events", "events.log")
 
-	storeOpts, err := storage.DefaultStoreOptions(unshare.IsRootless(), unshare.GetRootlessUID())
-	if err != nil {
-		return nil, err
+	var storeOpts storage.StoreOptions
+	if path, ok := os.LookupEnv("CONTAINER_STORAGE_CONF"); ok {
+		storage.ReloadConfigurationFile(path, &storeOpts)
+	} else {
+		storeOpts, err = storage.DefaultStoreOptions(unshare.IsRootless(), unshare.GetRootlessUID())
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	if storeOpts.GraphRoot == "" {
 		logrus.Warnf("Storage configuration is unset - using hardcoded default graph root %q", _defaultGraphRoot)
 		storeOpts.GraphRoot = _defaultGraphRoot


### PR DESCRIPTION
Currently it is difficult to modify the path to the storage.conf
file for setting up testing. It is hard coded to use /etc/containers/storage.conf.

Adding this envionment variable, will allow us to write tests on storage.conf
that do not override the system defaults.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
