### PR TITLE
Add TERM=xterm to default setting for env

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -129,7 +129,7 @@ A list of dns servers to override the DNS configuration passed to the
 container. The special value “none” can be specified to disable creation of
 /etc/resolv.conf in the container.
 
-**env**=["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]
+**env**=["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "TERM=xterm"]
 
 Environment variable list for the container process, used for passing
 environment variables to the container.

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -223,6 +223,7 @@ var _ = Describe("Config Local", func() {
 	It("verify getDefaultEnv", func() {
 		envs := []string{
 			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"TERM=xterm",
 		}
 		// Given we do
 		oldContainersConf, envSet := os.LookupEnv("CONTAINERS_CONF")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -153,6 +153,7 @@ var _ = Describe("Config", func() {
 
 			envs := []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+				"TERM=xterm",
 			}
 
 			// Then
@@ -230,6 +231,7 @@ var _ = Describe("Config", func() {
 
 			envs := []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+				"TERM=xterm",
 			}
 
 			// When
@@ -370,7 +372,7 @@ var _ = Describe("Config", func() {
 
 		BeforeEach(func() {
 			ConfPath.Value, ConfPath.IsSet = os.LookupEnv("CONTAINERS_CONF")
-			conf, _ := ioutil.TempFile("","containersconf")
+			conf, _ := ioutil.TempFile("", "containersconf")
 			os.Setenv("CONTAINERS_CONF", conf.Name())
 		})
 
@@ -473,7 +475,7 @@ env=["foo=bar"]`
 				os.Unsetenv("CONTAINERS_CONF")
 			}
 
-			expectOldEnv := []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
+			expectOldEnv := []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "TERM=xterm"}
 			expectNewEnv := []string{"foo=bar"}
 			gomega.Expect(cfg.Containers.Env).To(gomega.Equal(expectOldEnv))
 			gomega.Expect(newCfg.Containers.Env).To(gomega.Equal(expectNewEnv))

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -116,6 +116,7 @@
 #
 # env = [
 #    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+#    "TERM=xterm",
 # ]
 
 # Pass all host environment variables into the container.

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -182,6 +182,7 @@ func DefaultConfig() (*Config, error) {
 			EnableLabeling:      selinuxEnabled(),
 			Env: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+				"TERM=xterm",
 			},
 			EnvHost:        false,
 			HTTPProxy:      false,

--- a/pkg/config/testdata/containers_comment.conf
+++ b/pkg/config/testdata/containers_comment.conf
@@ -18,6 +18,7 @@
 # environment variables to conmon or the runtime.
 # env = [
 #     "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+#     "TERM=xterm",
 # ]
 
 # proxy environment variables are passed into the container

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -56,6 +56,7 @@ default_sysctls = [
 # environment variables to conmon or the runtime.
 env = [
     "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    "TERM=xterm",
 ]
 
 # Run an init inside the container that forwards signals and reaps processes.

--- a/pkg/config/testdata/containers_invalid.conf
+++ b/pkg/config/testdata/containers_invalid.conf
@@ -18,6 +18,7 @@ default_ulimits = [
 # environment variables to conmon or the runtime.
 env = [
     "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    "TERM=xterm",
 ]
 
 # proxy environment variables are passed into the container


### PR DESCRIPTION
We want to make sure that the TERM envionment variable is always
set.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
