### PR TITLE
containers.conf: Fix ulimits nofile example syntax

### DIFF
--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -92,7 +92,7 @@
 # Ulimits has limits for non privileged container engines.
 #
 # default_ulimits = [
-#  "nofile"="1280:2560",
+#  "nofile=1280:2560",
 # ]
 
 # List of default DNS options to be added to /etc/resolv.conf inside of the container.


### PR DESCRIPTION
Uncommenting the nofile example will result in a syntax error as there are extra
quote (") characters. Remove them.

Fixes: bd0a08c617cc ("Add new fields to containers.conf")
Signed-off-by: Patrick Talbert <ptalbert@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
