### PR TITLE
Podman v2.0.5 backports

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -310,6 +310,24 @@ pod consumes one lock.  The default number available is 2048.  If this is
 changed, a lock renumbering must be performed, using the
 `podman system renumber` command.
 
+**active_service**=""
+  Name of destination for accessing the Podman service.
+
+**[service_destinations]**
+
+**[service_destinations.{name}]**
+  **uri="ssh://user@production.example.com/run/user/1001/podman/podman.sock"**
+
+    Example URIs:
+
+- **rootless local**  - unix://run/user/1000/podman/podman.sock
+- **rootless remote** - ssh://user@engineering.lab.company.com/run/user/1000/podman/podman.sock
+- **rootfull local**  - unix://run/podman/podman.sock
+- **rootfull remote** - ssh://root@10.10.1.136:22/run/podman/podman.sock
+
+  **identity="~/.ssh/id_rsa**
+    Path to file containing ssh identity key
+
 **pull_policy**="always"|"missing"|"never"
 Pull image before running or creating a container. The default is **missing**.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -195,7 +195,7 @@ type EngineConfig struct {
 	// The first path pointing to a valid file will be used.
 	ConmonPath []string `toml:"conmon_path,omitempty"`
 
-	//DetachKeys is the sequence of keys used to detach a container.
+	// DetachKeys is the sequence of keys used to detach a container.
 	DetachKeys string `toml:"detach_keys,omitempty"`
 
 	// EnablePortReservation determines whether engine will reserve ports on the
@@ -266,11 +266,19 @@ type EngineConfig struct {
 	// Indicates whether the application should be running in Remote mode
 	Remote bool `toml:"-"`
 
+	// RemoteURI is deprecated, see ActiveService
 	// RemoteURI containers connection information used to connect to remote system.
 	RemoteURI string `toml:"remote_uri,omitempty"`
 
-	// Identity key file for RemoteURI
+	// RemoteIdentity is deprecated, ServiceDestinations
+	// RemoteIdentity key file for RemoteURI
 	RemoteIdentity string `toml:"remote_identity,omitempty"`
+
+	// ActiveService index to Destinations added v2.0.3
+	ActiveService string `toml:"active_service,omitempty"`
+
+	// Destinations mapped by service Names
+	ServiceDestinations map[string]Destination `toml:"service_destinations,omitempty"`
 
 	// RuntimePath is the path to OCI runtime binary for launching containers.
 	// The first path pointing to a valid file will be used This is used only
@@ -385,6 +393,15 @@ type NetworkConfig struct {
 
 	// NetworkConfigDir is where CNI network configuration files are stored.
 	NetworkConfigDir string `toml:"network_config_dir,omitempty"`
+}
+
+// Destination represents destination for remote service
+type Destination struct {
+	// URI, required. Example: ssh://root@example.com:22/run/podman/podman.sock
+	URI string `toml:"uri"`
+
+	// Identity file with ssh key, optional
+	Identity string `toml:"identity,omitempty"`
 }
 
 // NewConfig creates a new Config. It starts with an empty config and, if
@@ -872,8 +889,8 @@ func customConfigFile() (string, error) {
 	return OverrideContainersConfig, nil
 }
 
-//ReadCustomConfig reads the custom config and only generates a config based on it
-//If the custom config file does not exists, function will return an empty config
+// ReadCustomConfig reads the custom config and only generates a config based on it
+// If the custom config file does not exists, function will return an empty config
 func ReadCustomConfig() (*Config, error) {
 	path, err := customConfigFile()
 	if err != nil {
@@ -929,4 +946,36 @@ func (c *Config) Write() error {
 		return err
 	}
 	return nil
+}
+
+// Reload reloads the configuration from containers.conf files
+func Reload() (*Config, error) {
+	var err error
+	config, err = NewConfig("")
+	if err != nil {
+		return nil, errors.Wrapf(err, "containers.conf reload failed")
+	}
+	return Default()
+}
+
+func (c *Config) ActiveDestination() (string, string, error){
+	if uri, found := os.LookupEnv("CONTAINER_HOST"); found {
+		var ident string
+		if v, found := os.LookupEnv("CONTAINER_SSHKEY"); found {
+			ident = v
+		}
+		return uri, ident, nil
+	}
+
+	switch {
+	case c.Engine.ActiveService != "":
+		d, found := c.Engine.ServiceDestinations[c.Engine.ActiveService]
+		if !found {
+			return "", "", errors.Errorf("%q service destination not found", c.Engine.ActiveService)
+		}
+		return d.URI, d.Identity, nil
+	case c.Engine.RemoteURI != "":
+		return c.Engine.RemoteURI, c.Engine.RemoteIdentity, nil
+	}
+	return "", "", errors.New("no service destination configured")
 }

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -199,5 +199,4 @@ var _ = Describe("Config Local", func() {
 			os.Unsetenv("CONTAINERS_CONF")
 		}
 	})
-
 })

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -378,6 +378,7 @@ var _ = Describe("Config", func() {
 			err = sut.Engine.Validate()
 			gomega.Expect(err).To(gomega.BeNil())
 		})
+
 		It("should fail with invalid pull_policy", func() {
 			sut.Engine.PullPolicy = "invalidPullPolicy"
 			err := sut.Engine.Validate()
@@ -385,4 +386,124 @@ var _ = Describe("Config", func() {
 		})
 	})
 
+	Describe("Service Destinations", func() {
+		ConfPath := struct {
+			Value string
+			IsSet bool
+		}{}
+
+		BeforeEach(func() {
+			ConfPath.Value, ConfPath.IsSet = os.LookupEnv("CONTAINERS_CONF")
+			conf, _ := ioutil.TempFile("","containersconf")
+			os.Setenv("CONTAINERS_CONF", conf.Name())
+		})
+
+		AfterEach(func() {
+			os.Remove(os.Getenv("CONTAINERS_CONF"))
+			if ConfPath.IsSet {
+				os.Setenv("CONTAINERS_CONF", ConfPath.Value)
+			} else {
+				os.Unsetenv("CONTAINERS_CONF")
+			}
+		})
+
+		It("succeed to set and read", func() {
+			cfg, err := ReadCustomConfig()
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			cfg.Engine.ActiveService = "QA"
+			cfg.Engine.ServiceDestinations = map[string]Destination{
+				"QA": {
+					URI:      "https://qa/run/podman/podman.sock",
+					Identity: "/.ssh/id_rsa",
+				},
+			}
+			err = cfg.Write()
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			cfg, err = ReadCustomConfig()
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			gomega.Expect(cfg.Engine.ActiveService, "QA")
+			gomega.Expect(cfg.Engine.ServiceDestinations["QA"].URI,
+				"https://qa/run/podman/podman.sock")
+			gomega.Expect(cfg.Engine.ServiceDestinations["QA"].Identity,
+				"/.ssh/id_rsa")
+		})
+
+		It("succeed ActiveDestinations()", func() {
+			cfg, err := ReadCustomConfig()
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			cfg.Engine.ActiveService = "QA"
+			cfg.Engine.ServiceDestinations = map[string]Destination{
+				"QA": {
+					URI:      "https://qa/run/podman/podman.sock",
+					Identity: "/.ssh/id_rsa",
+				},
+			}
+			err = cfg.Write()
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			cfg, err = ReadCustomConfig()
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			u, i, err := cfg.ActiveDestination()
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			gomega.Expect(u).To(gomega.Equal("https://qa/run/podman/podman.sock"))
+			gomega.Expect(i).To(gomega.Equal("/.ssh/id_rsa"))
+		})
+
+		It("fail ActiveDestination() no configuration", func() {
+			cfg, err := ReadCustomConfig()
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			_, _, err = cfg.ActiveDestination()
+			gomega.Expect(err).Should(gomega.HaveOccurred())
+		})
+	})
+
+	Describe("Reload", func() {
+		It("test new config from reload", func() {
+			// Default configuration
+			defaultTestFile := "testdata/containers_default.conf"
+			oldEnv, set := os.LookupEnv("CONTAINERS_CONF")
+			os.Setenv("CONTAINERS_CONF", defaultTestFile)
+			cfg, err := Default()
+			gomega.Expect(err).To(gomega.BeNil())
+			if set {
+				os.Setenv("CONTAINERS_CONF", oldEnv)
+			} else {
+				os.Unsetenv("CONTAINERS_CONF")
+			}
+
+			// Reload from new configuration file
+			testFile := "testdata/temp.conf"
+			content := `[containers]
+env=["foo=bar"]`
+			err = ioutil.WriteFile(testFile, []byte(content), os.ModePerm)
+			defer os.Remove(testFile)
+			gomega.Expect(err).To(gomega.BeNil())
+			oldEnv, set = os.LookupEnv("CONTAINERS_CONF")
+			os.Setenv("CONTAINERS_CONF", testFile)
+			_, err = Reload()
+			gomega.Expect(err).To(gomega.BeNil())
+			newCfg, err := Default()
+			gomega.Expect(err).To(gomega.BeNil())
+			if set {
+				os.Setenv("CONTAINERS_CONF", oldEnv)
+			} else {
+				os.Unsetenv("CONTAINERS_CONF")
+			}
+
+			expectOldEnv := []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
+			expectNewEnv := []string{"foo=bar"}
+			gomega.Expect(cfg.Containers.Env).To(gomega.Equal(expectOldEnv))
+			gomega.Expect(newCfg.Containers.Env).To(gomega.Equal(expectNewEnv))
+			// Reload change back to default global configuration
+			_, err = Reload()
+			gomega.Expect(err).To(gomega.BeNil())
+		})
+	})
 })

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -394,7 +395,7 @@ var _ = Describe("Config", func() {
 
 		BeforeEach(func() {
 			ConfPath.Value, ConfPath.IsSet = os.LookupEnv("CONTAINERS_CONF")
-			conf, _ := ioutil.TempFile("","containersconf")
+			conf, _ := ioutil.TempFile("", "containersconf")
 			os.Setenv("CONTAINERS_CONF", conf.Name())
 		})
 

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -367,6 +367,22 @@
 # Number of seconds to wait for container to exit before sending kill signal.
 # stop_timeout = 10
 
+# Index to the active service
+# active_service = production
+
+# map of service destinations
+# [service_destinations]
+#   [service_destinations.production]
+#     URI to access the Podman service
+#     Examples:
+#       rootless "unix://run/user/$UID/podman/podman.sock" (Default)
+#       rootfull "unix://run/podman/podman.sock (Default)
+#       remote rootless ssh://engineering.lab.company.com/run/user/1000/podman/podman.sock
+#       remote rootfull ssh://root@10.10.1.136:22/run/podman/podman.sock
+#     uri="ssh://user@production.example.com/run/user/1001/podman/podman.sock"
+#     Path to file containing ssh identity key
+#     identity = "~/.ssh/id_rsa"
+
 # Paths to look for a valid OCI runtime (runc, runv, kata, etc)
 [engine.runtimes]
 # runc = [


### PR DESCRIPTION
These are backports identified as necessary for Podman v2.0.5 (specifically related to the `podman system connection` command).