### PR TITLE
Export NormalizeCapabilities function

### DIFF
--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -57,9 +57,9 @@ func AllCapabilities() []string {
 	return capabilityList
 }
 
-// normalizeCapabilities normalizes caps by adding a "CAP_" prefix (if not yet
+// NormalizeCapabilities normalizes caps by adding a "CAP_" prefix (if not yet
 // present).
-func normalizeCapabilities(caps []string) ([]string, error) {
+func NormalizeCapabilities(caps []string) ([]string, error) {
 	normalized := make([]string, len(caps))
 	for i, c := range caps {
 		c = strings.ToUpper(c)
@@ -98,7 +98,7 @@ func MergeCapabilities(base, adds, drops []string) ([]string, error) {
 	var caps []string
 
 	// Normalize the base capabilities
-	base, err := normalizeCapabilities(base)
+	base, err := NormalizeCapabilities(base)
 	if err != nil {
 		return nil, err
 	}
@@ -106,11 +106,11 @@ func MergeCapabilities(base, adds, drops []string) ([]string, error) {
 		// Nothing to tweak; we're done
 		return base, nil
 	}
-	capDrop, err := normalizeCapabilities(drops)
+	capDrop, err := NormalizeCapabilities(drops)
 	if err != nil {
 		return nil, err
 	}
-	capAdd, err := normalizeCapabilities(adds)
+	capAdd, err := NormalizeCapabilities(adds)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/capabilities/capabilities_test.go
+++ b/pkg/capabilities/capabilities_test.go
@@ -60,12 +60,12 @@ func TestMergeCapabilitiesAddAll(t *testing.T) {
 
 func TestNormalizeCapabilities(t *testing.T) {
 	strSlice := []string{"SYS_ADMIN", "net_admin", "CAP_CHOWN"}
-	caps, err := normalizeCapabilities(strSlice)
+	caps, err := NormalizeCapabilities(strSlice)
 	require.Nil(t, err)
 	err = ValidateCapabilities(caps)
 	require.Nil(t, err)
 	strSlice = []string{"no_ADMIN", "net_admin", "CAP_CHMOD"}
-	_, err = normalizeCapabilities(strSlice)
+	_, err = NormalizeCapabilities(strSlice)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
We need access to this function in Podman to translate
user entry into standardized format.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
