### PR TITLE
 getCustomConfigFile for windows and darwin

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -908,21 +908,6 @@ func Path() string {
 	return OverrideContainersConfig
 }
 
-func customConfigFile() (string, error) {
-	path := os.Getenv("CONTAINERS_CONF")
-	if path != "" {
-		return path, nil
-	}
-	if unshare.IsRootless() {
-		path, err := rootlessConfigPath()
-		if err != nil {
-			return "", err
-		}
-		return path, nil
-	}
-	return OverrideContainersConfig, nil
-}
-
 // ReadCustomConfig reads the custom config and only generates a config based on it
 // If the custom config file does not exists, function will return an empty config
 func ReadCustomConfig() (*Config, error) {

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"os"
+)
+
+func customConfigFile() (string, error) {
+	path := os.Getenv("CONTAINERS_CONF")
+	if path != "" {
+		return path, nil
+	}
+	return rootlessConfigPath()
+}

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -5,8 +5,7 @@ import (
 )
 
 func customConfigFile() (string, error) {
-	path := os.Getenv("CONTAINERS_CONF")
-	if path != "" {
+	if path, found := os.LookupEnv("CONTAINERS_CONF"); found {
 		return path, nil
 	}
 	return rootlessConfigPath()

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -1,7 +1,27 @@
 package config
 
-import selinux "github.com/opencontainers/selinux/go-selinux"
+import (
+	"os"
+
+	"github.com/containers/storage/pkg/unshare"
+	selinux "github.com/opencontainers/selinux/go-selinux"
+)
 
 func selinuxEnabled() bool {
 	return selinux.GetEnabled()
+}
+
+func customConfigFile() (string, error) {
+	path := os.Getenv("CONTAINERS_CONF")
+	if path != "" {
+		return path, nil
+	}
+	if unshare.IsRootless() {
+		path, err := rootlessConfigPath()
+		if err != nil {
+			return "", err
+		}
+		return path, nil
+	}
+	return OverrideContainersConfig, nil
 }

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -12,8 +12,7 @@ func selinuxEnabled() bool {
 }
 
 func customConfigFile() (string, error) {
-	path := os.Getenv("CONTAINERS_CONF")
-	if path != "" {
+	if path, found := os.LookupEnv("CONTAINERS_CONF"); found {
 		return path, nil
 	}
 	if unshare.IsRootless() {

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -3,8 +3,7 @@ package config
 import "os"
 
 func customConfigFile() (string, error) {
-	path := os.Getenv("CONTAINERS_CONF")
-	if path != "" {
+	if path, found := os.LookupEnv("CONTAINERS_CONF"); found {
 		return path, nil
 	}
 	return os.Getenv("LOCALAPPDATA"), nil

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -1,0 +1,11 @@
+package config
+
+import "os"
+
+func customConfigFile() (string, error) {
+	path := os.Getenv("CONTAINERS_CONF")
+	if path != "" {
+		return path, nil
+	}
+	return os.Getenv("LOCALAPPDATA"), nil
+}


### PR DESCRIPTION
 getCustomConfigFile for windows and darwin

podman remote clients that run on windows and darwin cannot use the isRootless to determine the configuration file locations.  here we do by OS and also honor the environment variable.

Signed-off-by: Brent Baude <bbaude@redhat.com>