### PR TITLE
Fix nested elseif

### DIFF
--- a/pkg/config/default_linux.go
+++ b/pkg/config/default_linux.go
@@ -32,10 +32,8 @@ func getDefaultProcessLimits() []string {
 	defaultLimits := []string{}
 	if err := unix.Setrlimit(unix.RLIMIT_NPROC, &rlim); err == nil {
 		defaultLimits = append(defaultLimits, fmt.Sprintf("nproc=%d:%d", rlim.Cur, rlim.Max))
-	} else {
-		if err := unix.Setrlimit(unix.RLIMIT_NPROC, &oldrlim); err == nil {
-			defaultLimits = append(defaultLimits, fmt.Sprintf("nproc=%d:%d", oldrlim.Cur, oldrlim.Max))
-		}
+	} else if err := unix.Setrlimit(unix.RLIMIT_NPROC, &oldrlim); err == nil {
+		defaultLimits = append(defaultLimits, fmt.Sprintf("nproc=%d:%d", oldrlim.Cur, oldrlim.Max))
 	}
 	return defaultLimits
 }


### PR DESCRIPTION
The nested elseif `else {if cond {}}` can be replaced with `else if cond {}`.
