### PR TITLE
Change fmt.Errorf calls to be replaced by errors package

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -612,11 +612,11 @@ func (c *ContainersConfig) Validate() error {
 	}
 
 	if c.LogSizeMax >= 0 && c.LogSizeMax < OCIBufSize {
-		return fmt.Errorf("log size max should be negative or >= %d", OCIBufSize)
+		return errors.Errorf("log size max should be negative or >= %d", OCIBufSize)
 	}
 
 	if _, err := units.FromHumanSize(c.ShmSize); err != nil {
-		return fmt.Errorf("invalid --shm-size %s, %q", c.ShmSize, err)
+		return errors.Errorf("invalid --shm-size %s, %q", c.ShmSize, err)
 	}
 
 	return nil
@@ -767,7 +767,7 @@ func Device(device string) (string, string, string, error) {
 	switch len(split) {
 	case 3:
 		if !IsValidDeviceMode(split[2]) {
-			return "", "", "", fmt.Errorf("invalid device mode: %s", split[2])
+			return "", "", "", errors.Errorf("invalid device mode: %s", split[2])
 		}
 		permissions = split[2]
 		fallthrough
@@ -776,18 +776,18 @@ func Device(device string) (string, string, string, error) {
 			permissions = split[1]
 		} else {
 			if len(split[1]) == 0 || split[1][0] != '/' {
-				return "", "", "", fmt.Errorf("invalid device mode: %s", split[1])
+				return "", "", "", errors.Errorf("invalid device mode: %s", split[1])
 			}
 			dst = split[1]
 		}
 		fallthrough
 	case 1:
 		if !strings.HasPrefix(split[0], "/dev/") {
-			return "", "", "", fmt.Errorf("invalid device mode: %s", split[0])
+			return "", "", "", errors.Errorf("invalid device mode: %s", split[0])
 		}
 		src = split[0]
 	default:
-		return "", "", "", fmt.Errorf("invalid device specification: %s", device)
+		return "", "", "", errors.Errorf("invalid device specification: %s", device)
 	}
 
 	if dst == "" {

--- a/pkg/config/config_local.go
+++ b/pkg/config/config_local.go
@@ -3,7 +3,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -11,6 +10,7 @@ import (
 	"syscall"
 
 	units "github.com/docker/go-units"
+	"github.com/pkg/errors"
 )
 
 // isDirectory tests whether the given path exists and is a directory. It
@@ -43,13 +43,13 @@ func (c *EngineConfig) validatePaths() error {
 	// shift between runs or even parts of the program. - The OCI runtime
 	// uses a different working directory than we do, for example.
 	if c.StaticDir != "" && !filepath.IsAbs(c.StaticDir) {
-		return fmt.Errorf("static directory must be an absolute path - instead got %q", c.StaticDir)
+		return errors.Errorf("static directory must be an absolute path - instead got %q", c.StaticDir)
 	}
 	if c.TmpDir != "" && !filepath.IsAbs(c.TmpDir) {
-		return fmt.Errorf("temporary directory must be an absolute path - instead got %q", c.TmpDir)
+		return errors.Errorf("temporary directory must be an absolute path - instead got %q", c.TmpDir)
 	}
 	if c.VolumePath != "" && !filepath.IsAbs(c.VolumePath) {
-		return fmt.Errorf("volume path must be an absolute path - instead got %q", c.VolumePath)
+		return errors.Errorf("volume path must be an absolute path - instead got %q", c.VolumePath)
 	}
 	return nil
 }
@@ -68,7 +68,7 @@ func (c *ContainersConfig) validateUlimits() error {
 	for _, u := range c.DefaultUlimits {
 		ul, err := units.ParseUlimit(u)
 		if err != nil {
-			return fmt.Errorf("unrecognized ulimit %s: %v", u, err)
+			return errors.Wrapf(err, "unrecognized ulimit %s", u)
 		}
 		_, err = ul.GetRlimit()
 		if err != nil {
@@ -96,8 +96,8 @@ func (c *ContainersConfig) validateTZ() error {
 		}
 	}
 
-	return fmt.Errorf(
-		"unable to find timezone %s in paths: %s",
+	return errors.Errorf(
+		"find timezone %s in paths: %s",
 		c.TZ, strings.Join(lookupPaths, ", "),
 	)
 }
@@ -105,7 +105,7 @@ func (c *ContainersConfig) validateTZ() error {
 func (c *ContainersConfig) validateUmask() error {
 	validUmask := regexp.MustCompile(`^[0-7]{1,4}$`)
 	if !validUmask.MatchString(c.Umask) {
-		return fmt.Errorf("Not a valid Umask %s", c.Umask)
+		return errors.Errorf("not a valid umask %s", c.Umask)
 	}
 	return nil
 }

--- a/pkg/config/libpodConfig.go
+++ b/pkg/config/libpodConfig.go
@@ -3,7 +3,6 @@ package config
 /* libpodConfig.go contains deprecated functionality and should not be used any longer */
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -247,7 +246,7 @@ func readLibpodConfigFromFile(path string, config *ConfigFromLibpod) (*ConfigFro
 	logrus.Debugf("Reading configuration file %q", path)
 	_, err := toml.DecodeFile(path, config)
 	if err != nil {
-		return nil, fmt.Errorf("unable to decode configuration %v: %v", path, err)
+		return nil, errors.Wrapf(err, "decode configuration %s", path)
 	}
 
 	return config, err

--- a/pkg/config/util_supported.go
+++ b/pkg/config/util_supported.go
@@ -49,7 +49,7 @@ func getRuntimeDir() (string, error) {
 		if runtimeDir == "" {
 			home := os.Getenv("HOME")
 			if home == "" {
-				rootlessRuntimeDirError = fmt.Errorf("neither XDG_RUNTIME_DIR nor HOME was set non-empty")
+				rootlessRuntimeDirError = errors.New("neither XDG_RUNTIME_DIR nor HOME was set non-empty")
 				return
 			}
 			resolvedHome, err := filepath.EvalSymlinks(home)

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -1,7 +1,6 @@
 package sysinfo
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -9,6 +8,7 @@ import (
 
 	"github.com/containers/common/pkg/cgroupv2"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -16,7 +16,7 @@ import (
 func findCgroupMountpoints() (map[string]string, error) {
 	cgMounts, err := cgroups.GetCgroupMounts(false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse cgroup information: %v", err)
+		return nil, errors.Wrap(err, "parse cgroup information")
 	}
 	mps := make(map[string]string)
 	for _, m := range cgMounts {


### PR DESCRIPTION
We now use wrapped errors instead of indirectly wrapping them by
`fmt.Errorf`. The error messages have also been cleaned-up to reduce
duplicate words like `failed`.


