### PR TITLE
fix windows containers.conf path

### DIFF
--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -6,5 +6,5 @@ func customConfigFile() (string, error) {
 	if path, found := os.LookupEnv("CONTAINERS_CONF"); found {
 		return path, nil
 	}
-	return os.Getenv("LOCALAPPDATA"), nil
+	return os.Getenv("APPDATA") + "\\containers\\containers.conf", nil
 }


### PR DESCRIPTION
customConfigFile() has to return the full path to the file
LOCALAPPDATA only returns a directory.

I also recommend using APPDATA instead of LOCALAPPDATA.
If a domain user would logon to a new computer they would
automatically have their containers.conf from the last
login at a different pc. No manual copy is needed since
windows syncs the APPDATA dir by default in a domain
environment at login.

So the config file path on windows would be:
`C:\Users\<username>\AppData\Roaming\containers\containers.conf`
