### PR TITLE
Add BuildFilter() and ValidateProfile() API

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -109,3 +109,5 @@ linters-settings:
       - typeUnparen
       - unnamedResult
       - unnecessaryBlock
+  gocyclo:
+    min-complexity: 35

--- a/pkg/seccomp/conversion.go
+++ b/pkg/seccomp/conversion.go
@@ -1,25 +1,92 @@
+// NOTE: this package has originally been copied from
+// github.com/opencontainers/runc and modified to work for other use cases
+
 package seccomp
 
-import "fmt"
+import (
+	"fmt"
 
-var goArchToSeccompArchMap = map[string]Arch{
-	"386":         ArchX86,
-	"amd64":       ArchX86_64,
-	"amd64p32":    ArchX32,
-	"arm":         ArchARM,
-	"arm64":       ArchAARCH64,
-	"mips":        ArchMIPS,
-	"mips64":      ArchMIPS64,
-	"mips64le":    ArchMIPSEL64,
-	"mips64p32":   ArchMIPS64N32,
-	"mips64p32le": ArchMIPSEL64N32,
-	"mipsle":      ArchMIPSEL,
-	"ppc":         ArchPPC,
-	"ppc64":       ArchPPC64,
-	"ppc64le":     ArchPPC64LE,
-	"s390":        ArchS390,
-	"s390x":       ArchS390X,
-}
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+)
+
+var (
+	goArchToSeccompArchMap = map[string]Arch{
+		"386":         ArchX86,
+		"amd64":       ArchX86_64,
+		"amd64p32":    ArchX32,
+		"arm":         ArchARM,
+		"arm64":       ArchAARCH64,
+		"mips":        ArchMIPS,
+		"mips64":      ArchMIPS64,
+		"mips64le":    ArchMIPSEL64,
+		"mips64p32":   ArchMIPS64N32,
+		"mips64p32le": ArchMIPSEL64N32,
+		"mipsle":      ArchMIPSEL,
+		"ppc":         ArchPPC,
+		"ppc64":       ArchPPC64,
+		"ppc64le":     ArchPPC64LE,
+		"s390":        ArchS390,
+		"s390x":       ArchS390X,
+	}
+	specArchToLibseccompArchMap = map[specs.Arch]string{
+		specs.ArchX86:         "x86",
+		specs.ArchX86_64:      "amd64",
+		specs.ArchX32:         "x32",
+		specs.ArchARM:         "arm",
+		specs.ArchAARCH64:     "arm64",
+		specs.ArchMIPS:        "mips",
+		specs.ArchMIPS64:      "mips64",
+		specs.ArchMIPS64N32:   "mips64n32",
+		specs.ArchMIPSEL:      "mipsel",
+		specs.ArchMIPSEL64:    "mipsel64",
+		specs.ArchMIPSEL64N32: "mipsel64n32",
+		specs.ArchPPC:         "ppc",
+		specs.ArchPPC64:       "ppc64",
+		specs.ArchPPC64LE:     "ppc64le",
+		specs.ArchS390:        "s390",
+		specs.ArchS390X:       "s390x",
+	}
+	specArchToSeccompArchMap = map[specs.Arch]Arch{
+		specs.ArchX86:         ArchX86,
+		specs.ArchX86_64:      ArchX86_64,
+		specs.ArchX32:         ArchX32,
+		specs.ArchARM:         ArchARM,
+		specs.ArchAARCH64:     ArchAARCH64,
+		specs.ArchMIPS:        ArchMIPS,
+		specs.ArchMIPS64:      ArchMIPS64,
+		specs.ArchMIPS64N32:   ArchMIPS64N32,
+		specs.ArchMIPSEL:      ArchMIPSEL,
+		specs.ArchMIPSEL64:    ArchMIPSEL64,
+		specs.ArchMIPSEL64N32: ArchMIPSEL64N32,
+		specs.ArchPPC:         ArchPPC,
+		specs.ArchPPC64:       ArchPPC64,
+		specs.ArchPPC64LE:     ArchPPC64LE,
+		specs.ArchS390:        ArchS390,
+		specs.ArchS390X:       ArchS390X,
+	}
+	specActionToSeccompActionMap = map[specs.LinuxSeccompAction]Action{
+		specs.ActKill: ActKill,
+		// TODO: wait for this PR to get merged:
+		// https://github.com/opencontainers/runtime-spec/pull/1064
+		// specs.ActKillProcess   ActKillProcess,
+		// specs.ActKillThread   ActKillThread,
+		specs.ActErrno: ActErrno,
+		specs.ActTrap:  ActTrap,
+		specs.ActAllow: ActAllow,
+		specs.ActTrace: ActTrace,
+		specs.ActLog:   ActLog,
+	}
+	specOperatorToSeccompOperatorMap = map[specs.LinuxSeccompOperator]Operator{
+		specs.OpNotEqual:     OpNotEqual,
+		specs.OpLessThan:     OpLessThan,
+		specs.OpLessEqual:    OpLessEqual,
+		specs.OpEqualTo:      OpEqualTo,
+		specs.OpGreaterEqual: OpGreaterEqual,
+		specs.OpGreaterThan:  OpGreaterThan,
+		specs.OpMaskedEqual:  OpMaskedEqual,
+	}
+)
 
 // GoArchToSeccompArch converts a runtime.GOARCH to a seccomp `Arch`. The
 // function returns an error if the architecture conversion is not supported.
@@ -29,4 +96,101 @@ func GoArchToSeccompArch(goArch string) (Arch, error) {
 		return "", fmt.Errorf("unsupported go arch provided: %s", goArch)
 	}
 	return arch, nil
+}
+
+// specToSeccomp converts a `LinuxSeccomp` spec into a `Seccomp` struct.
+func specToSeccomp(spec *specs.LinuxSeccomp) (*Seccomp, error) {
+	res := &Seccomp{
+		Syscalls: []*Syscall{},
+	}
+
+	for _, arch := range spec.Architectures {
+		newArch, err := specArchToSeccompArch(arch)
+		if err != nil {
+			return nil, errors.Wrap(err, "convert spec arch")
+		}
+		res.Architectures = append(res.Architectures, newArch)
+	}
+
+	// Convert default action
+	newDefaultAction, err := specActionToSeccompAction(spec.DefaultAction)
+	if err != nil {
+		return nil, errors.Wrap(err, "convert default action")
+	}
+	res.DefaultAction = newDefaultAction
+
+	// Loop through all syscall blocks and convert them to the internal format
+	for _, call := range spec.Syscalls {
+		newAction, err := specActionToSeccompAction(call.Action)
+		if err != nil {
+			return nil, errors.Wrap(err, "convert action")
+		}
+
+		for _, name := range call.Names {
+			newCall := Syscall{
+				Name:     name,
+				Action:   newAction,
+				ErrnoRet: call.ErrnoRet,
+				Args:     []*Arg{},
+			}
+
+			// Loop through all the arguments of the syscall and convert them
+			for _, arg := range call.Args {
+				newOp, err := specOperatorToSeccompOperator(arg.Op)
+				if err != nil {
+					return nil, errors.Wrap(err, "convert operator")
+				}
+
+				newArg := Arg{
+					Index:    arg.Index,
+					Value:    arg.Value,
+					ValueTwo: arg.ValueTwo,
+					Op:       newOp,
+				}
+
+				newCall.Args = append(newCall.Args, &newArg)
+			}
+			res.Syscalls = append(res.Syscalls, &newCall)
+		}
+	}
+
+	return res, nil
+}
+
+// specArchToLibseccompArch converts a spec arch into a libseccomp one.
+func specArchToLibseccompArch(arch specs.Arch) (string, error) {
+	if res, ok := specArchToLibseccompArchMap[arch]; ok {
+		return res, nil
+	}
+	return "", errors.Errorf(
+		"architecture %q is not valid for libseccomp", arch,
+	)
+}
+
+// specArchToSeccompArch converts a spec arch into an internal one.
+func specArchToSeccompArch(arch specs.Arch) (Arch, error) {
+	if res, ok := specArchToSeccompArchMap[arch]; ok {
+		return res, nil
+	}
+	return "", errors.Errorf("architecture %q is not valid", arch)
+}
+
+// specActionToSeccompAction converts a spec action into a seccomp one.
+func specActionToSeccompAction(action specs.LinuxSeccompAction) (Action, error) {
+	if res, ok := specActionToSeccompActionMap[action]; ok {
+		return res, nil
+	}
+	return "", errors.Errorf(
+		"spec action %q is not valid internal action", action,
+	)
+}
+
+// specOperatorToSeccompOperator converts a spec operator into a seccomp one.
+func specOperatorToSeccompOperator(operator specs.LinuxSeccompOperator) (Operator, error) {
+	if op, ok := specOperatorToSeccompOperatorMap[operator]; ok {
+		return op, nil
+	}
+	return "", errors.Errorf(
+		"spec operator %q is not a valid internal operator", operator,
+	)
 }

--- a/pkg/seccomp/conversion_test.go
+++ b/pkg/seccomp/conversion_test.go
@@ -2,26 +2,213 @@ package seccomp
 
 import (
 	"testing"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGoArchToSeccompArchSuccess(t *testing.T) {
 	for goArch, seccompArch := range goArchToSeccompArchMap {
 		res, err := GoArchToSeccompArch(goArch)
-		if err != nil {
-			t.Fatalf("expected nil, but got error: %v", err)
-		}
-		if seccompArch != res {
-			t.Fatalf("expected %s, but got: %s", seccompArch, res)
-		}
+		require.Nil(t, err)
+		require.Equal(t, seccompArch, res)
 	}
 }
 
 func TestGoArchToSeccompArchFailure(t *testing.T) {
 	res, err := GoArchToSeccompArch("wrong")
-	if err == nil {
-		t.Fatal("expected error, but got nil")
+	require.NotNil(t, err)
+	require.Empty(t, res)
+}
+
+func TestSpecArchToSeccompArchSuccess(t *testing.T) {
+	for specArch, seccompArch := range specArchToSeccompArchMap {
+		res, err := specArchToSeccompArch(specArch)
+		require.Nil(t, err)
+		require.Equal(t, seccompArch, res)
 	}
-	if res != "" {
-		t.Fatalf("expected empty res, but got: %s", res)
+}
+
+func TestSpecArchToSeccompArchFailure(t *testing.T) {
+	res, err := specArchToSeccompArch("wrong")
+	require.NotNil(t, err)
+	require.Empty(t, res)
+}
+
+func TestSpecArchToLibseccompArchSuccess(t *testing.T) {
+	for specArch, libseccompArch := range specArchToLibseccompArchMap {
+		res, err := specArchToLibseccompArch(specArch)
+		require.Nil(t, err)
+		require.Equal(t, libseccompArch, res)
+	}
+}
+
+func TestSpecArchToLibseccompArchFailure(t *testing.T) {
+	res, err := specArchToLibseccompArch("wrong")
+	require.NotNil(t, err)
+	require.Empty(t, res)
+}
+
+func TestSpecActionToSeccompActionSuccess(t *testing.T) {
+	for specAction, seccompAction := range specActionToSeccompActionMap {
+		res, err := specActionToSeccompAction(specAction)
+		require.Nil(t, err)
+		require.Equal(t, seccompAction, res)
+	}
+}
+
+func TestSpecActionToSeccompActionFailure(t *testing.T) {
+	res, err := specActionToSeccompAction("wrong")
+	require.NotNil(t, err)
+	require.Empty(t, res)
+}
+
+func TestSpecOperatorToSeccompOperatorSuccess(t *testing.T) {
+	for specOperator, seccompOperator := range specOperatorToSeccompOperatorMap {
+		res, err := specOperatorToSeccompOperator(specOperator)
+		require.Nil(t, err)
+		require.Equal(t, seccompOperator, res)
+	}
+}
+
+func TestSpecOperatorToSeccompOperatorFailure(t *testing.T) {
+	res, err := specOperatorToSeccompOperator("wrong")
+	require.NotNil(t, err)
+	require.Empty(t, res)
+}
+
+func TestSpecToSeccomp(t *testing.T) {
+	var ret uint = 1
+	for _, tc := range []struct {
+		input    *specs.LinuxSeccomp
+		expected func(*Seccomp, error)
+	}{
+
+		{ // success
+			input: &specs.LinuxSeccomp{
+				DefaultAction: specs.ActKill,
+				Architectures: []specs.Arch{
+					specs.ArchX32,
+					specs.ArchX86,
+				},
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:    []string{"open", "rmdir"},
+						Action:   specs.ActTrap,
+						ErrnoRet: &ret,
+						Args: []specs.LinuxSeccompArg{
+							{
+								Index:    0,
+								Value:    20,
+								ValueTwo: 10,
+								Op:       specs.OpLessThan,
+							},
+							{
+								Index:    1,
+								Value:    10,
+								ValueTwo: 12,
+								Op:       specs.OpEqualTo,
+							},
+						},
+					},
+					{
+						Names:    []string{"bind"},
+						Action:   specs.ActTrap,
+						ErrnoRet: &ret,
+					},
+				},
+			},
+			expected: func(profile *Seccomp, err error) {
+				require.Nil(t, err)
+				require.Equal(t, &Seccomp{
+					DefaultAction: ActKill,
+					Architectures: []Arch{ArchX32, ArchX86},
+					Syscalls: []*Syscall{
+						{
+							Name:     "open",
+							Action:   ActTrap,
+							ErrnoRet: &ret,
+							Args: []*Arg{
+								{
+									Index:    0,
+									Value:    20,
+									ValueTwo: 10,
+									Op:       OpLessThan,
+								},
+								{
+									Index:    1,
+									Value:    10,
+									ValueTwo: 12,
+									Op:       OpEqualTo,
+								},
+							},
+						},
+						{
+							Name:     "rmdir",
+							Action:   ActTrap,
+							ErrnoRet: &ret,
+							Args: []*Arg{
+								{
+									Index:    0,
+									Value:    20,
+									ValueTwo: 10,
+									Op:       OpLessThan,
+								},
+								{
+									Index:    1,
+									Value:    10,
+									ValueTwo: 12,
+									Op:       OpEqualTo,
+								},
+							},
+						},
+						{
+							Name:     "bind",
+							Action:   ActTrap,
+							ErrnoRet: &ret,
+							Args:     []*Arg{},
+						},
+					},
+				}, profile)
+			},
+		},
+		{ // wrong arch
+			input: &specs.LinuxSeccomp{
+				DefaultAction: specs.ActKill,
+				Architectures: []specs.Arch{"wrong"},
+			},
+			expected: func(profile *Seccomp, err error) {
+				require.NotNil(t, err)
+				require.Nil(t, profile)
+			},
+		},
+		{ // wrong op
+			input: &specs.LinuxSeccomp{
+				DefaultAction: specs.ActKill,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:    []string{"rmdir"},
+						Action:   specs.ActTrap,
+						ErrnoRet: &ret,
+						Args: []specs.LinuxSeccompArg{
+							{Op: "wrong"},
+						},
+					},
+				},
+			},
+			expected: func(profile *Seccomp, err error) {
+				require.NotNil(t, err)
+				require.Nil(t, profile)
+			},
+		},
+		{ // wrong default action
+			input: &specs.LinuxSeccomp{},
+			expected: func(profile *Seccomp, err error) {
+				require.NotNil(t, err)
+				require.Nil(t, profile)
+			},
+		},
+	} {
+		tc.expected(specToSeccomp(tc.input))
 	}
 }

--- a/pkg/seccomp/filter.go
+++ b/pkg/seccomp/filter.go
@@ -1,0 +1,237 @@
+// +build seccomp
+
+// NOTE: this package has originally been copied from
+// github.com/opencontainers/runc and modified to work for other use cases
+
+package seccomp
+
+import (
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	libseccomp "github.com/seccomp/libseccomp-golang"
+	"golang.org/x/sys/unix"
+)
+
+// NOTE: this package has originally been copied from
+// github.com/opencontainers/runc and modified to work for other use cases
+
+var (
+	// ErrSpecNil is a possible return error from BuildFilter() and occurs if
+	// the provided spec is nil.
+	ErrSpecNil = errors.New("spec is nil")
+
+	// ErrSpecEmpty is a possible return error from BuildFilter() and occurs if
+	// the provided spec has neither a DefaultAction nor any syscalls.
+	ErrSpecEmpty = errors.New("spec contains neither a default action nor any syscalls")
+)
+
+// BuildFilter does a basic validation for the provided seccomp profile
+// string and returns a filter for it.
+func BuildFilter(spec *specs.LinuxSeccomp) (*libseccomp.ScmpFilter, error) {
+	// Sanity checking to allow consumers to act accordingly
+	if spec == nil {
+		return nil, ErrSpecNil
+	}
+	if spec.DefaultAction == "" && len(spec.Syscalls) == 0 {
+		return nil, ErrSpecEmpty
+	}
+
+	profile, err := specToSeccomp(spec)
+	if err != nil {
+		return nil, errors.Wrap(err, "convert spec to seccomp profile")
+	}
+
+	defaultAction, err := toAction(profile.DefaultAction, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "convert default action %s", profile.DefaultAction)
+	}
+
+	filter, err := libseccomp.NewFilter(defaultAction)
+	if err != nil {
+		return nil, errors.Wrapf(err, "create filter for default action %s", defaultAction)
+	}
+
+	// Add extra architectures
+	for _, arch := range spec.Architectures {
+		libseccompArch, err := specArchToLibseccompArch(arch)
+		if err != nil {
+			return nil, errors.Wrap(err, "convert spec arch")
+		}
+
+		scmpArch, err := libseccomp.GetArchFromString(libseccompArch)
+		if err != nil {
+			return nil, errors.Wrapf(err, "validate Seccomp architecture %s", arch)
+		}
+
+		if err := filter.AddArch(scmpArch); err != nil {
+			return nil, errors.Wrap(err, "add architecture to seccomp filter")
+		}
+	}
+
+	// Unset no new privs bit
+	if err := filter.SetNoNewPrivsBit(false); err != nil {
+		return nil, errors.Wrap(err, "set no new privileges flag")
+	}
+
+	// Add a rule for each syscall
+	for _, call := range profile.Syscalls {
+		if call == nil {
+			return nil, errors.New("encountered nil syscall while initializing seccomp")
+		}
+
+		if err = matchSyscall(filter, call); err != nil {
+			return nil, errors.Wrap(err, "filter matches syscall")
+		}
+	}
+
+	return filter, nil
+}
+
+func matchSyscall(filter *libseccomp.ScmpFilter, call *Syscall) error {
+	if call == nil || filter == nil {
+		return errors.New("cannot use nil as syscall to block")
+	}
+
+	if call.Name == "" {
+		return errors.New("empty string is not a valid syscall")
+	}
+
+	// If we can't resolve the syscall, assume it's not supported on this kernel
+	// Ignore it, don't error out
+	callNum, err := libseccomp.GetSyscallFromName(call.Name)
+	if err != nil {
+		return nil
+	}
+
+	// Convert the call's action to the libseccomp equivalent
+	callAct, err := toAction(call.Action, call.ErrnoRet)
+	if err != nil {
+		return errors.Wrapf(err, "convert action %s", call.Action)
+	}
+
+	// Unconditional match - just add the rule
+	if len(call.Args) == 0 {
+		if err = filter.AddRule(callNum, callAct); err != nil {
+			return errors.Wrapf(err, "add seccomp filter rule for syscall %s", call.Name)
+		}
+	} else {
+		// Linux system calls can have at most 6 arguments
+		const syscallMaxArguments int = 6
+
+		// If two or more arguments have the same condition,
+		// Revert to old behavior, adding each condition as a separate rule
+		argCounts := make([]uint, syscallMaxArguments)
+		conditions := []libseccomp.ScmpCondition{}
+
+		for _, cond := range call.Args {
+			newCond, err := toCondition(cond)
+			if err != nil {
+				return errors.Wrapf(err, "create seccomp syscall condition for syscall %s", call.Name)
+			}
+
+			argCounts[cond.Index] += 1
+
+			conditions = append(conditions, newCond)
+		}
+
+		hasMultipleArgs := false
+		for _, count := range argCounts {
+			if count > 1 {
+				hasMultipleArgs = true
+				break
+			}
+		}
+
+		if hasMultipleArgs {
+			// Revert to old behavior
+			// Add each condition attached to a separate rule
+			for _, cond := range conditions {
+				condArr := []libseccomp.ScmpCondition{cond}
+
+				if err = filter.AddRuleConditional(callNum, callAct, condArr); err != nil {
+					return errors.Wrapf(err, "add seccomp rule for syscall %s", call.Name)
+				}
+			}
+		} else if err = filter.AddRuleConditional(callNum, callAct, conditions); err != nil {
+			// No conditions share same argument
+			// Use new, proper behavior
+			return errors.Wrapf(err, "add seccomp rule for syscall %s", call.Name)
+		}
+	}
+
+	return nil
+}
+
+// toAction converts an internal `Action` type to a `libseccomp.ScmpAction`
+// type.
+func toAction(act Action, errnoRet *uint) (libseccomp.ScmpAction, error) {
+	switch act {
+	case ActKill:
+		return libseccomp.ActKill, nil
+	case ActKillProcess:
+		return libseccomp.ActKillProcess, nil
+	case ActErrno:
+		if errnoRet != nil {
+			return libseccomp.ActErrno.SetReturnCode(int16(*errnoRet)), nil
+		}
+		return libseccomp.ActErrno.SetReturnCode(int16(unix.EPERM)), nil
+	case ActTrap:
+		return libseccomp.ActTrap, nil
+	case ActAllow:
+		return libseccomp.ActAllow, nil
+	case ActTrace:
+		if errnoRet != nil {
+			return libseccomp.ActTrace.SetReturnCode(int16(*errnoRet)), nil
+		}
+		return libseccomp.ActTrace.SetReturnCode(int16(unix.EPERM)), nil
+	case ActLog:
+		return libseccomp.ActLog, nil
+	default:
+		return libseccomp.ActInvalid, errors.Errorf("invalid action %s", act)
+	}
+}
+
+// toCondition converts an internal `Arg` type to a `libseccomp.ScmpCondition`
+// type.
+func toCondition(arg *Arg) (cond libseccomp.ScmpCondition, err error) {
+	if arg == nil {
+		return cond, errors.New("cannot convert nil to syscall condition")
+	}
+
+	op, err := toCompareOp(arg.Op)
+	if err != nil {
+		return cond, errors.Wrap(err, "convert compare operator")
+	}
+
+	condition, err := libseccomp.MakeCondition(
+		arg.Index, op, arg.Value, arg.ValueTwo,
+	)
+	if err != nil {
+		return cond, errors.Wrap(err, "make condition")
+	}
+
+	return condition, nil
+}
+
+// toCompareOp converts an internal `Operator` type to a
+// `libseccomp.ScmpCompareOp`.
+func toCompareOp(op Operator) (libseccomp.ScmpCompareOp, error) {
+	switch op {
+	case OpEqualTo:
+		return libseccomp.CompareEqual, nil
+	case OpNotEqual:
+		return libseccomp.CompareNotEqual, nil
+	case OpGreaterThan:
+		return libseccomp.CompareGreater, nil
+	case OpGreaterEqual:
+		return libseccomp.CompareGreaterEqual, nil
+	case OpLessThan:
+		return libseccomp.CompareLess, nil
+	case OpLessEqual:
+		return libseccomp.CompareLessOrEqual, nil
+	case OpMaskedEqual:
+		return libseccomp.CompareMaskedEqual, nil
+	default:
+		return libseccomp.CompareInvalid, errors.Errorf("invalid operator %s", op)
+	}
+}

--- a/pkg/seccomp/filter_test.go
+++ b/pkg/seccomp/filter_test.go
@@ -1,0 +1,62 @@
+// +build seccomp
+
+package seccomp
+
+import (
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	libseccomp "github.com/seccomp/libseccomp-golang"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildFilter(t *testing.T) {
+	for _, tc := range []struct {
+		given  func() *specs.LinuxSeccomp
+		expect func(*libseccomp.ScmpFilter, error)
+	}{
+		{ // Default profile
+			given: func() *specs.LinuxSeccomp {
+				sut, err := GetDefaultProfile(nil)
+				require.Nil(t, err)
+				return sut
+			},
+			expect: func(filter *libseccomp.ScmpFilter, err error) {
+				require.Nil(t, err)
+				require.NotNil(t, filter)
+			},
+		},
+		{ // Spec nil
+			given: func() *specs.LinuxSeccomp {
+				return nil
+			},
+			expect: func(filter *libseccomp.ScmpFilter, err error) {
+				require.Equal(t, ErrSpecNil, err)
+				require.Nil(t, filter)
+			},
+		},
+		{ // Spec empty
+			given: func() *specs.LinuxSeccomp {
+				return &specs.LinuxSeccomp{}
+			},
+			expect: func(filter *libseccomp.ScmpFilter, err error) {
+				require.Equal(t, ErrSpecEmpty, err)
+				require.Nil(t, filter)
+			},
+		},
+		{ // Spec to seccomp failed
+			given: func() *specs.LinuxSeccomp {
+				sut, err := GetDefaultProfile(nil)
+				require.Nil(t, err)
+				sut.Syscalls[0].Action = "wrong"
+				return sut
+			},
+			expect: func(filter *libseccomp.ScmpFilter, err error) {
+				require.NotNil(t, err)
+				require.Nil(t, filter)
+			},
+		},
+	} {
+		tc.expect(BuildFilter(tc.given()))
+	}
+}

--- a/pkg/seccomp/seccomp_linux.go
+++ b/pkg/seccomp/seccomp_linux.go
@@ -122,7 +122,7 @@ Loop:
 		}
 		if len(call.Excludes.Caps) > 0 {
 			for _, c := range call.Excludes.Caps {
-				if inSlice(rs.Process.Capabilities.Bounding, c) {
+				if rs != nil && rs.Process != nil && rs.Process.Capabilities != nil && inSlice(rs.Process.Capabilities.Bounding, c) {
 					continue Loop
 				}
 			}
@@ -134,7 +134,7 @@ Loop:
 		}
 		if len(call.Includes.Caps) > 0 {
 			for _, c := range call.Includes.Caps {
-				if !inSlice(rs.Process.Capabilities.Bounding, c) {
+				if rs != nil && rs.Process != nil && rs.Process.Capabilities != nil && !inSlice(rs.Process.Capabilities.Bounding, c) {
 					continue Loop
 				}
 			}

--- a/pkg/seccomp/validate.go
+++ b/pkg/seccomp/validate.go
@@ -1,0 +1,29 @@
+// +build seccomp
+
+package seccomp
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+// ValidateProfile does a basic validation for the provided seccomp profile
+// string.
+func ValidateProfile(content string) error {
+	profile := &Seccomp{}
+	if err := json.Unmarshal([]byte(content), &profile); err != nil {
+		return errors.Wrap(err, "decoding seccomp profile")
+	}
+
+	spec, err := setupSeccomp(profile, nil)
+	if err != nil {
+		return errors.Wrap(err, "create seccomp spec")
+	}
+
+	if _, err := BuildFilter(spec); err != nil {
+		return errors.Wrap(err, "build seccomp filter")
+	}
+
+	return nil
+}

--- a/pkg/seccomp/validate_test.go
+++ b/pkg/seccomp/validate_test.go
@@ -1,0 +1,36 @@
+// +build seccomp
+
+package seccomp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateProfile(t *testing.T) {
+	for _, tc := range []struct {
+		input     string
+		shouldErr bool
+	}{
+		{ // success
+			input:     `{"defaultAction": "SCMP_ACT_KILL"}`,
+			shouldErr: false,
+		},
+		{ // Unmarshal failed
+			input:     "wrong",
+			shouldErr: true,
+		},
+		{ // setupSeccomp failed
+			input:     `{"defaultAction": "SCMP_ACT_KILL", "architectures": ["SCMP_ARCH_X86"], "archMap": [{"architecture": "SCMP_ARCH_X86"}]}`,
+			shouldErr: true,
+		},
+	} {
+		err := ValidateProfile(tc.input)
+		if tc.shouldErr {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+		}
+	}
+}


### PR DESCRIPTION
The new `BuildFilter()` API can be used by runc/libcontainer to build
a libseccomp filter from the spec. This means that they also do not need
any internal structures any more because we indirectly build it from the
internal `Seccomp` type.

The new `ValidateProfile()` API can be used by higher level consumers,
which want to ensure that a seccomp profile string can be transferred
into a libseccomp filter.

Refers to https://github.com/opencontainers/runc/issues/2565

---

Short summary of the back and forth conversion between types: Right now it works like this:

1. CRI-O receives the profile as path and unmarshals it into the `Seccomp` type (formerly from seccom/containers-golang, now in this library)
2. CRI-O uses this library to convert the `Seccomp` type in to the runtime spec seccomp type
3. The runtime spec seccomp type will be pushed to the lower level runtime, like runc
4. Runc takes the runtime spec seccomp type and converts it into the libcontainer seccomp type
5. The libcontainer seccomp type will be converted into the seccomp/libseccomp-golang type
6. The libseccomp-golang type will be compiled into the kernel.

The big plan is now to get rid of (at least some) of those conversions by having no need that runc defines it's own types any more. Afterwards, we could think about further refactorings to re-use the spec types in the internal `Seccomp` type.
