### PR TITLE
Add seccomp validation unit test for failing BuildProfile()

### DIFF
--- a/pkg/seccomp/validate_test.go
+++ b/pkg/seccomp/validate_test.go
@@ -25,6 +25,10 @@ func TestValidateProfile(t *testing.T) {
 			input:     `{"defaultAction": "SCMP_ACT_KILL", "architectures": ["SCMP_ARCH_X86"], "archMap": [{"architecture": "SCMP_ARCH_X86"}]}`,
 			shouldErr: true,
 		},
+		{ // BuildFilter failed
+			input:     `{"defaultAction": "SCMP_ACT_KILL", "architectures": ["SCMP_ARCH_X86"], "syscalls": [{ "name": "open" }]}`,
+			shouldErr: true,
+		},
 	} {
 		err := ValidateProfile(tc.input)
 		if tc.shouldErr {


### PR DESCRIPTION
This tests the last failure branch of the profile validation.
