### PR TITLE
WIP: Split seccomp BuildFilter into FilterFromSpec and addRules

### DIFF
--- a/pkg/seccomp/validate.go
+++ b/pkg/seccomp/validate.go
@@ -21,7 +21,7 @@ func ValidateProfile(content string) error {
 		return errors.Wrap(err, "create seccomp spec")
 	}
 
-	if _, err := BuildFilter(spec); err != nil {
+	if _, _, err := FilterFromSpec(spec); err != nil {
 		return errors.Wrap(err, "build seccomp filter")
 	}
 


### PR DESCRIPTION
The reason for this slight API enhancement is to avoid possible seccomp
filter rule applications by calling libseccomps `AddRule` nor setting
the privileged bit.
