### PR TITLE
Allow pidfd_getfd by default in seccomp.json

### DIFF
--- a/pkg/seccomp/default_linux.go
+++ b/pkg/seccomp/default_linux.go
@@ -221,6 +221,7 @@ func DefaultProfile() *Seccomp {
 				"openat",
 				"openat2",
 				"pause",
+				"pidfd_getfd",
 				"pipe",
 				"pipe2",
 				"pivot_root",

--- a/pkg/seccomp/seccomp.json
+++ b/pkg/seccomp/seccomp.json
@@ -223,6 +223,7 @@
 				"openat",
 				"openat2",
 				"pause",
+				"pidfd_getfd",
 				"pipe",
 				"pipe2",
 				"pivot_root",


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
