### PR TITLE
Allow users to specify the default format for image builds

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -268,6 +268,9 @@ Path to the directory where CNI configuration files are located.
 ## ENGINE TABLE
 The `engine` table contains configuration options used to set up container engines such as Podman and Buildah.
 
+**image_build_format**="oci"
+The default image format to building container images. Valid values are "oci" (default) or "docker".
+
 **cgroup_check**=false
 
 CgroupCheck indicates the configuration has been rewritten after an upgrade to Fedora 31 to change the default OCI runtime for cgroupsv2.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -183,6 +183,10 @@ type ContainersConfig struct {
 
 // EngineConfig contains configuration options used to set up a engine runtime
 type EngineConfig struct {
+	// ImageBuildFormat indicates the default image format to building
+	// container images.  Valid values are "oci" (default) or "docker".
+	ImageBuildFormat string `toml:"image_build_format,omitempty"`
+
 	// CgroupCheck indicates the configuration has been rewritten after an
 	// upgrade to Fedora 31 to change the default OCI runtime for cgroupv2v2.
 	CgroupCheck bool `toml:"cgroup_check,omitempty"`

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -243,6 +243,9 @@
 # network_config_dir = "/etc/cni/net.d/"
 
 [engine]
+# ImageBuildFormat indicates the default image format to building
+# container images. Valid values are "oci" (default) or "docker".
+# image_build_format = "oci"
 
 # Cgroup management implementation used for the runtime.
 # Valid options "systemd" or "cgroupfs"

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -250,6 +250,8 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	if cgroup2, _ := cgroupv2.Enabled(); cgroup2 {
 		c.OCIRuntime = "crun"
 	}
+	c.ImageBuildFormat = "oci"
+
 	c.CgroupManager = defaultCgroupManager()
 	c.StopTimeout = uint(10)
 


### PR DESCRIPTION
Some users want to stick to "docker" format especially since some older
container registries don't properly support OCI images.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
