### PR TITLE
remove fchmodat2 from seccomp.json file

### DIFF
--- a/pkg/seccomp/default_linux.go
+++ b/pkg/seccomp/default_linux.go
@@ -99,7 +99,6 @@ func DefaultProfile() *Seccomp {
 				"fchdir",
 				"fchmod",
 				"fchmodat",
-				"fchmodat2",
 				"fchown",
 				"fchown32",
 				"fchownat",

--- a/pkg/seccomp/seccomp.json
+++ b/pkg/seccomp/seccomp.json
@@ -101,7 +101,6 @@
 				"fchdir",
 				"fchmod",
 				"fchmodat",
-				"fchmodat2",
 				"fchown",
 				"fchown32",
 				"fchownat",


### PR DESCRIPTION
This syscall is proposed for the kernel but does not exists yet.  Having it in
the default syscall table is causing crun to print warning messages.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
