### PR TITLE
Specify the recommended defaults for security

### DIFF
--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -59,29 +59,28 @@
 # List of default capabilities for containers. If it is empty or commented out,
 # the default capabilities defined in the container engine will be added.
 #
-# default_capabilities = [
-#    "AUDIT_WRITE",
-#    "CHOWN",
-#    "DAC_OVERRIDE",
-#    "FOWNER",
-#    "FSETID",
-#    "KILL",
-#    "MKNOD",
-#    "NET_BIND_SERVICE",
-#    "NET_RAW",
-#    "SETGID",
-#    "SETPCAP",
-#    "SETUID",
-#    "SYS_CHROOT",
-# ]
+default_capabilities = [
+    "CHOWN",
+    "DAC_OVERRIDE",
+    "FOWNER",
+    "FSETID",
+    "KILL",
+    "NET_BIND_SERVICE",
+    "SETFCAP",
+    "SETGID",
+    "SETPCAP",
+    "SETUID",
+    "SYS_CHROOT"
+]
+
 
 # A list of sysctls to be set in containers by default,
 # specified as "name=value",
-# for example:"net.ipv4.ping_group_range = 0 1000".
+# for example:"net.ipv4.ping_group_range = 0 1".
 #
-# default_sysctls = [
-#  "net.ipv4.ping_group_range=0 1000",
-# ]
+default_sysctls = [
+ "net.ipv4.ping_group_range=0 1",
+]
 
 # A list of ulimits to be set in containers by default, specified as
 # "<ulimit name>=<soft limit>:<hard limit>", for example:


### PR DESCRIPTION
In Fedora Rawhide, I have eliminated some CAPABILITIES from the
default list to make containers more secure. The containers.conf
should be listed here as well.  The default list in code is still
the Docker defaults, but I have eliminated three from the default
list

AUDIT_WRITE, MKNOD, NET_RAW

In Fedora 33 we have eliminated just MKNOD and NET_RAW.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
