### PR TITLE
Fix description of no-common options for cgroups

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -76,7 +76,7 @@ Determines  whether  the  container will create CGroups.
 Options are:
   `enabled`   Enable cgroup support within container
   `disabled`  Disable cgroup support, will inherit cgroups from parent
-  `no-conmon` Container engine runs run without conmon
+  `no-conmon` Do not create a cgroup dedicated to conmon.
 
 **default_capabilities**=[]
 

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -52,7 +52,7 @@
 # Options are:
 # `enabled`   Enable cgroup support within container
 # `disabled`  Disable cgroup support, will inherit cgroups from parent
-# `no-conmon` Container engine runs run without conmon
+# `no-conmon` Do not create a cgroup dedicated to conmon.
 #
 # cgroups = "enabled"
 


### PR DESCRIPTION
The current description is wrong it says that no-common does
not use cgrous, when it should say there is no cgroup
created for the conmon process.

Fixes: https://github.com/containers/common/issues/321

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
