### PR TITLE
Fix --format corner cases

### DIFF
--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -41,10 +41,6 @@ func NormalizeFormat(format string) string {
 		f = escapedReplacer.Replace(format)
 	}
 
-	if !strings.HasSuffix(f, "\n") {
-		f += "\n"
-	}
-
 	return f
 }
 
@@ -96,7 +92,14 @@ func NewTemplate(name string) *Template {
 func (t *Template) Parse(text string) (*Template, error) {
 	if strings.HasPrefix(text, "table ") {
 		t.isTable = true
-		text = "{{range .}}" + NormalizeFormat(text) + "{{end}}"
+
+		text = NormalizeFormat(text)
+		if !strings.HasSuffix(text, "\n") {
+			text += "\n"
+		}
+		text = "{{range .}}" + text + "{{end}}"
+	} else {
+		text = NormalizeFormat(text)
 	}
 
 	tt, err := t.Template.Parse(text)

--- a/pkg/report/template_test.go
+++ b/pkg/report/template_test.go
@@ -51,8 +51,8 @@ func TestNormalizeFormat(t *testing.T) {
 		{"{{.ID}}\t{{.ID}}\n", "{{.ID}}\t{{.ID}}\n"},
 		{`{{.ID}}\t{{.ID}}\n`, "{{.ID}}\t{{.ID}}\n"},
 		{`{{.ID}} {{.ID}}\n`, "{{.ID}} {{.ID}}\n"},
-		{`table {{.ID}}\t{{.ID}}`, "{{.ID}}\t{{.ID}}\n"},
-		{`table {{.ID}} {{.ID}}`, "{{.ID}}\t{{.ID}}\n"},
+		{`table {{.ID}}\t{{.ID}}`, "{{.ID}}\t{{.ID}}"},
+		{`table {{.ID}} {{.ID}}`, "{{.ID}}\t{{.ID}}"},
 	}
 
 	for _, tc := range testCase {
@@ -68,7 +68,10 @@ func TestTemplate_Parse(t *testing.T) {
 	testCase := []string{
 		"table {{.ID}}",
 		"table {{ .ID}}",
+		`table {{ .ID}}\n`,
+		"table {{ .ID}}\n",
 		"{{range .}}{{.ID}}\n{{end}}",
+		`{{range .}}{{.ID}}\n{{end}}`,
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
* Always Normalize --format value
* Additionaly fixed case where {{range}} with embedded \n caused
  double \n\n on output
* Updated tests to cover these cases

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
