### PR TITLE
Set storage path correctly

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -224,14 +224,12 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 
 	c.EventsLogFilePath = filepath.Join(c.TmpDir, "events", "events.log")
 
-	var storeOpts storage.StoreOptions
 	if path, ok := os.LookupEnv("CONTAINERS_STORAGE_CONF"); ok {
-		storage.ReloadConfigurationFile(path, &storeOpts)
-	} else {
-		storeOpts, err = storage.DefaultStoreOptions(unshare.IsRootless(), unshare.GetRootlessUID())
-		if err != nil {
-			return nil, err
-		}
+		storage.SetDefaultConfigFilePath(path)
+	}
+	storeOpts, err := storage.DefaultStoreOptions(unshare.IsRootless(), unshare.GetRootlessUID())
+	if err != nil {
+		return nil, err
 	}
 
 	if storeOpts.GraphRoot == "" {


### PR DESCRIPTION
Fix handling of storage.conf path, so that we can use it when testing podman.
Currently the Environment variable is not handled correctly.

There is a matching patches in containers/storage and eventually
containers/podman to allow the user of alternative storage.conf files in testing.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
