### PR TITLE
Fix NormalizeFormat

### DIFF
--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -41,6 +41,10 @@ func NormalizeFormat(format string) string {
 		f = escapedReplacer.Replace(format)
 	}
 
+	if !strings.HasSuffix(f, "\n") {
+		f += "\n"
+	}
+
 	return f
 }
 
@@ -90,16 +94,11 @@ func NewTemplate(name string) *Template {
 
 // Parse parses text as a template body for t
 func (t *Template) Parse(text string) (*Template, error) {
+	text = NormalizeFormat(text)
 	if strings.HasPrefix(text, "table ") {
 		t.isTable = true
 
-		text = NormalizeFormat(text)
-		if !strings.HasSuffix(text, "\n") {
-			text += "\n"
-		}
 		text = "{{range .}}" + text + "{{end}}"
-	} else {
-		text = NormalizeFormat(text)
 	}
 
 	tt, err := t.Template.Parse(text)


### PR DESCRIPTION
The previous change which removed always adding \n to format lines
that did not contain one is breaking lots of format testing in Podman.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
