### PR TITLE
Don't check for timezone, unless user specified one

### DIFF
--- a/pkg/config/config_local.go
+++ b/pkg/config/config_local.go
@@ -79,7 +79,7 @@ func (c *ContainersConfig) validateUlimits() error {
 }
 
 func (c *ContainersConfig) validateTZ() error {
-	if c.TZ == "local" {
+	if c.TZ == "local" || c.TZ == "" {
 		return nil
 	}
 


### PR DESCRIPTION
Certain systems do not include

"/usr/share/zoneinfo",
"/etc/zoneinfo",

Which is causing failures to verify timzeones set to "", which is
the default.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
