### PR TITLE
Enabled the remote flag to be accessible by users

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -414,6 +414,10 @@ Pull image before running or creating a container. The default is **missing**.
 - **always**: pull the image from the first registry it is found in as listed in registries.conf. Raise an error if not found in the registries, even if the image is present locally.
 - **never**: do not pull the image from the registry, use only the local version. Raise an error if the image is not present locally.
 
+**remote** = false
+Indicates whether the application should be running in remote mode. This flag modifies the
+--remote option on container engines. Setting the flag to true will default `podman --remote=true` for access to the remote Podman service.
+
 **runtime**="crun"
 
 Default OCI specific runtime in runtimes that will be used by default. Must

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -282,7 +282,7 @@ type EngineConfig struct {
 	PullPolicy string `toml:"pull_policy,omitempty"`
 
 	// Indicates whether the application should be running in Remote mode
-	Remote bool `toml:"-"`
+	Remote bool `toml:"remote,omitempty"`
 
 	// RemoteURI is deprecated, see ActiveService
 	// RemoteURI containers connection information used to connect to remote system.

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -357,6 +357,11 @@ default_sysctls = [
 # Whether to pull new image before running a container
 # pull_policy = "missing"
 
+# Indicates whether the application should be running in remote mode. This flag modifies the
+# --remote option on container engines. Setting the flag to true will default
+# `podman --remote=true` for access to the remote Podman service.
+# remote = false
+
 # Directory for persistent engine files (database, etc)
 # By default, this will be configured relative to where the containers/storage
 # stores containers


### PR DESCRIPTION
This flag would allow users to run the podman command
in podman-remote mode by default. If you are primarily using
podman to access a remote server, you might want to enable this
flag and not have to install podman-remote as well as podman command.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
