### PR TITLE
fix: Set `ping_group_range` to `0 0` by default

### DIFF
--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -76,10 +76,10 @@ default_capabilities = [
 
 # A list of sysctls to be set in containers by default,
 # specified as "name=value",
-# for example:"net.ipv4.ping_group_range = 0 1".
+# for example:"net.ipv4.ping_group_range = 0 0".
 #
 default_sysctls = [
- "net.ipv4.ping_group_range=0 1",
+ "net.ipv4.ping_group_range=0 0",
 ]
 
 # A list of ulimits to be set in containers by default, specified as


### PR DESCRIPTION
This sysctl is an inclusive range and since the intention is to only
allow ping for root, setting it to `0 0` is adequate. This change
ensures that if a container is run from a user namespace where GID 1
isn't mapped, we won't get an EINVAL back when attempting to write this
sysctl value which would then cause an OCI runtime error.

Fixes #345

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
