### PR TITLE
Move some volume and device parsing from buildah to common

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -1,0 +1,157 @@
+package parse
+
+// this package contains functions that parse and validate
+// user input and is shared either amongst container engine subcommands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// ValidateVolumeOpts validates a volume's options
+func ValidateVolumeOpts(options []string) ([]string, error) {
+	var foundRootPropagation, foundRWRO, foundLabelChange, bindType, foundExec, foundDev, foundSuid int
+	finalOpts := make([]string, 0, len(options))
+	for _, opt := range options {
+		switch opt {
+		case "noexec", "exec":
+			foundExec++
+			if foundExec > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'noexec' or 'exec' option", strings.Join(options, ", "))
+			}
+		case "nodev", "dev":
+			foundDev++
+			if foundDev > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'nodev' or 'dev' option", strings.Join(options, ", "))
+			}
+		case "nosuid", "suid":
+			foundSuid++
+			if foundSuid > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'nosuid' or 'suid' option", strings.Join(options, ", "))
+			}
+		case "rw", "ro":
+			foundRWRO++
+			if foundRWRO > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'rw' or 'ro' option", strings.Join(options, ", "))
+			}
+		case "z", "Z", "O":
+			foundLabelChange++
+			if foundLabelChange > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'z', 'Z', or 'O' option", strings.Join(options, ", "))
+			}
+		case "private", "rprivate", "shared", "rshared", "slave", "rslave", "unbindable", "runbindable":
+			foundRootPropagation++
+			if foundRootPropagation > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 '[r]shared', '[r]private', '[r]slave' or '[r]unbindable' option", strings.Join(options, ", "))
+			}
+		case "bind", "rbind":
+			bindType++
+			if bindType > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 '[r]bind' option", strings.Join(options, ", "))
+			}
+		case "cached", "delegated":
+			// The discarded ops are OS X specific volume options
+			// introduced in a recent Docker version.
+			// They have no meaning on Linux, so here we silently
+			// drop them. This matches Docker's behavior (the options
+			// are intended to be always safe to use, even not on OS
+			// X).
+			continue
+		default:
+			return nil, errors.Errorf("invalid option type %q", opt)
+		}
+		finalOpts = append(finalOpts, opt)
+	}
+	return finalOpts, nil
+}
+
+// Device parses device mapping string to a src, dest & permissions string
+// Valid values for device looklike:
+//    '/dev/sdc"
+//    '/dev/sdc:/dev/xvdc"
+//    '/dev/sdc:/dev/xvdc:rwm"
+//    '/dev/sdc:rm"
+func Device(device string) (src, dest, permissions string, err error) {
+	permissions = "rwm"
+	arr := strings.Split(device, ":")
+	switch len(arr) {
+	case 3:
+		if !isValidDeviceMode(arr[2]) {
+			return "", "", "", errors.Errorf("invalid device mode: %s", arr[2])
+		}
+		permissions = arr[2]
+		fallthrough
+	case 2:
+		if isValidDeviceMode(arr[1]) {
+			permissions = arr[1]
+		} else {
+			if arr[1] == "" || arr[1][0] != '/' {
+				return "", "", "", errors.Errorf("invalid device mode: %s", arr[1])
+			}
+			dest = arr[1]
+		}
+		fallthrough
+	case 1:
+		if len(arr[0]) > 0 {
+			src = arr[0]
+			break
+		}
+		fallthrough
+	default:
+		return "", "", "", errors.Errorf("invalid device specification: %s", device)
+	}
+
+	if dest == "" {
+		dest = src
+	}
+	return src, dest, permissions, nil
+}
+
+// isValidDeviceMode checks if the mode for device is valid or not.
+// isValid mode is a composition of r (read), w (write), and m (mknod).
+func isValidDeviceMode(mode string) bool {
+	var legalDeviceMode = map[rune]bool{
+		'r': true,
+		'w': true,
+		'm': true,
+	}
+	if mode == "" {
+		return false
+	}
+	for _, c := range mode {
+		if !legalDeviceMode[c] {
+			return false
+		}
+		legalDeviceMode[c] = false
+	}
+	return true
+}
+
+// ValidateVolumeHostDir validates a volume mount's source directory
+func ValidateVolumeHostDir(hostDir string) error {
+	if hostDir == "" {
+		return errors.Errorf("host directory cannot be empty")
+	}
+	if filepath.IsAbs(hostDir) {
+		if _, err := os.Stat(hostDir); err != nil {
+			return errors.Wrapf(err, "error checking path %q", hostDir)
+		}
+	}
+	// If hostDir is not an absolute path, that means the user wants to create a
+	// named volume. This will be done later on in the code.
+	return nil
+}
+
+// ValidateVolumeCtrDir validates a volume mount's destination directory.
+func ValidateVolumeCtrDir(ctrDir string) error {
+	if ctrDir == "" {
+		return errors.Errorf("container directory cannot be empty")
+	}
+	if !filepath.IsAbs(ctrDir) {
+		return errors.Errorf("invalid container path %q, must be an absolute path", ctrDir)
+	}
+	return nil
+}

--- a/pkg/parse/parse_test.go
+++ b/pkg/parse/parse_test.go
@@ -1,0 +1,95 @@
+package parse
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDeviceParser verifies the given device strings is parsed correctly
+func TestDeviceParser(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Devices is only supported on Linux")
+	}
+
+	// Test defaults
+	src, dest, permissions, err := Device("/dev/foo")
+	assert.NoError(t, err)
+	assert.Equal(t, src, "/dev/foo")
+	assert.Equal(t, dest, "/dev/foo")
+	assert.Equal(t, permissions, "rwm")
+
+	// Test defaults, different dest
+	src, dest, permissions, err = Device("/dev/foo:/dev/bar")
+	assert.NoError(t, err)
+	assert.Equal(t, src, "/dev/foo")
+	assert.Equal(t, dest, "/dev/bar")
+	assert.Equal(t, permissions, "rwm")
+
+	// Test fully specified
+	src, dest, permissions, err = Device("/dev/foo:/dev/bar:rm")
+	assert.NoError(t, err)
+	assert.Equal(t, src, "/dev/foo")
+	assert.Equal(t, dest, "/dev/bar")
+	assert.Equal(t, permissions, "rm")
+
+	// Test device, permissions
+	src, dest, permissions, err = Device("/dev/foo:rm")
+	assert.NoError(t, err)
+	assert.Equal(t, src, "/dev/foo")
+	assert.Equal(t, dest, "/dev/foo")
+	assert.Equal(t, permissions, "rm")
+
+	// test bogus permissions
+	_, _, _, err = Device("/dev/fuse1:BOGUS") //nolint
+	assert.Error(t, err)
+
+	_, _, _, err = Device("") //nolint
+	assert.Error(t, err)
+
+	_, _, _, err = Device("/dev/foo:/dev/bar:rm:") //nolint
+	assert.Error(t, err)
+
+	_, _, _, err = Device("/dev/foo::rm") //nolint
+	assert.Error(t, err)
+}
+
+func TestIsValidDeviceMode(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Devices is only supported on Linux")
+	}
+	assert.False(t, isValidDeviceMode("BOGUS"))
+	assert.False(t, isValidDeviceMode("rwx"))
+	assert.True(t, isValidDeviceMode("r"))
+	assert.True(t, isValidDeviceMode("rw"))
+	assert.True(t, isValidDeviceMode("rm"))
+	assert.True(t, isValidDeviceMode("rwm"))
+}
+
+func TestDeviceFromPath(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Devices is only supported on Linux")
+	}
+	// Path is valid
+	dev, err := DeviceFromPath("/dev/null")
+	assert.NoError(t, err)
+	assert.Equal(t, len(dev), 1)
+	assert.Equal(t, dev[0].Major, int64(1))
+	assert.Equal(t, dev[0].Minor, int64(3))
+	assert.Equal(t, string(dev[0].Permissions), "rwm")
+	assert.Equal(t, dev[0].Uid, uint32(0))
+	assert.Equal(t, dev[0].Gid, uint32(0))
+
+	// Path does not exists
+	_, err = DeviceFromPath("/dev/BOGUS")
+	assert.Error(t, err)
+
+	// Path is a directory of devices
+	_, err = DeviceFromPath("/dev/pts")
+	assert.NoError(t, err)
+
+	// path of directory has no device
+	_, err = DeviceFromPath("/etc/passwd")
+	assert.Error(t, err)
+}

--- a/pkg/parse/parse_unix.go
+++ b/pkg/parse/parse_unix.go
@@ -1,0 +1,51 @@
+// +build linux darwin
+
+package parse
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/containers/storage/pkg/unshare"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/devices"
+	"github.com/pkg/errors"
+)
+
+func DeviceFromPath(device string) ([]configs.Device, error) {
+	var devs []configs.Device
+	src, dst, permissions, err := Device(device)
+	if err != nil {
+		return nil, err
+	}
+	if unshare.IsRootless() && src != dst {
+		return nil, errors.Errorf("Renaming device %s to %s is not supported in rootless containers", src, dst)
+	}
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting info of source device %s", src)
+	}
+
+	if !srcInfo.IsDir() {
+
+		dev, err := devices.DeviceFromPath(src, permissions)
+		if err != nil {
+			return nil, errors.Wrapf(err, "%s is not a valid device", src)
+		}
+		dev.Path = dst
+		devs = append(devs, *dev)
+		return devs, nil
+	}
+
+	// If source device is a directory
+	srcDevices, err := devices.GetDevices(src)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting source devices from directory %s", src)
+	}
+	for _, d := range srcDevices {
+		d.Path = filepath.Join(dst, filepath.Base(d.Path))
+		d.Permissions = configs.DevicePermissions(permissions)
+		devs = append(devs, *d)
+	}
+	return devs, nil
+}

--- a/pkg/seccomp/supported.go
+++ b/pkg/seccomp/supported.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package seccomp
 
 import (

--- a/vendor/github.com/opencontainers/runc/libcontainer/devices/devices.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/devices/devices.go
@@ -1,0 +1,110 @@
+package devices
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	// ErrNotADevice denotes that a file is not a valid linux device.
+	ErrNotADevice = errors.New("not a device node")
+)
+
+// Testing dependencies
+var (
+	unixLstat     = unix.Lstat
+	ioutilReadDir = ioutil.ReadDir
+)
+
+// Given the path to a device and its cgroup_permissions(which cannot be easily queried) look up the
+// information about a linux device and return that information as a Device struct.
+func DeviceFromPath(path, permissions string) (*configs.Device, error) {
+	var stat unix.Stat_t
+	err := unixLstat(path, &stat)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		devType   configs.DeviceType
+		mode      = stat.Mode
+		devNumber = uint64(stat.Rdev)
+		major     = unix.Major(devNumber)
+		minor     = unix.Minor(devNumber)
+	)
+	switch {
+	case mode&unix.S_IFBLK == unix.S_IFBLK:
+		devType = configs.BlockDevice
+	case mode&unix.S_IFCHR == unix.S_IFCHR:
+		devType = configs.CharDevice
+	case mode&unix.S_IFIFO == unix.S_IFIFO:
+		devType = configs.FifoDevice
+	default:
+		return nil, ErrNotADevice
+	}
+	return &configs.Device{
+		DeviceRule: configs.DeviceRule{
+			Type:        devType,
+			Major:       int64(major),
+			Minor:       int64(minor),
+			Permissions: configs.DevicePermissions(permissions),
+		},
+		Path:     path,
+		FileMode: os.FileMode(mode),
+		Uid:      stat.Uid,
+		Gid:      stat.Gid,
+	}, nil
+}
+
+// HostDevices returns all devices that can be found under /dev directory.
+func HostDevices() ([]*configs.Device, error) {
+	return GetDevices("/dev")
+}
+
+// GetDevices recursively traverses a directory specified by path
+// and returns all devices found there.
+func GetDevices(path string) ([]*configs.Device, error) {
+	files, err := ioutilReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	var out []*configs.Device
+	for _, f := range files {
+		switch {
+		case f.IsDir():
+			switch f.Name() {
+			// ".lxc" & ".lxd-mounts" added to address https://github.com/lxc/lxd/issues/2825
+			// ".udev" added to address https://github.com/opencontainers/runc/issues/2093
+			case "pts", "shm", "fd", "mqueue", ".lxc", ".lxd-mounts", ".udev":
+				continue
+			default:
+				sub, err := GetDevices(filepath.Join(path, f.Name()))
+				if err != nil {
+					return nil, err
+				}
+
+				out = append(out, sub...)
+				continue
+			}
+		case f.Name() == "console":
+			continue
+		}
+		device, err := DeviceFromPath(filepath.Join(path, f.Name()), "rwm")
+		if err != nil {
+			if err == ErrNotADevice {
+				continue
+			}
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		out = append(out, device)
+	}
+	return out, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -224,6 +224,7 @@ github.com/opencontainers/image-spec/specs-go/v1
 github.com/opencontainers/runc/libcontainer/apparmor
 github.com/opencontainers/runc/libcontainer/cgroups
 github.com/opencontainers/runc/libcontainer/configs
+github.com/opencontainers/runc/libcontainer/devices
 github.com/opencontainers/runc/libcontainer/system
 github.com/opencontainers/runc/libcontainer/user
 github.com/opencontainers/runc/libcontainer/utils


### PR DESCRIPTION
We want to split out buildah/pkg/parse for components other
containers/engines are using without pulling in the buildah library.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
