### PR TITLE
Print the error to log info

### DIFF
--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -30,7 +30,7 @@ func RetryIfNecessary(ctx context.Context, operation func() error, retryOptions 
 		if retryOptions.Delay != 0 {
 			delay = retryOptions.Delay
 		}
-		logrus.Infof("Warning: failed, retrying in %s ... (%d/%d)", delay, attempt+1, retryOptions.MaxRetry)
+		logrus.Infof("Warning: failed, retrying in %s ... (%d/%d). Error: %v", delay, attempt+1, retryOptions.MaxRetry, err)
 		select {
 		case <-time.After(delay):
 			break


### PR DESCRIPTION
When retry with retryable error, add the error to the log meassage providing more info for debugging.

Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
