### PR TITLE
We should not be setting a default infra command.

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -46,8 +46,6 @@ var (
 	DefaultInitPath = "/usr/libexec/podman/catatonit"
 	// DefaultInfraImage to use for infra container
 	DefaultInfraImage = "k8s.gcr.io/pause:3.2"
-	// DefaultInfraCommand to be run in an infra container
-	DefaultInfraCommand = "/pause"
 	// DefaultRootlessSHMLockPath is the default path for rootless SHM locks
 	DefaultRootlessSHMLockPath = "/libpod_rootless_lock"
 	// DefaultDetachKeys is the default keys sequence for detaching a
@@ -308,7 +306,6 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	c.InitPath = DefaultInitPath
 	c.NoPivotRoot = false
 
-	c.InfraCommand = DefaultInfraCommand
 	c.InfraImage = DefaultInfraImage
 	c.EnablePortReservation = true
 	c.NumLocks = 2048


### PR DESCRIPTION
We should be sourcing from the image CMD/ENTRYPOINT by default. Having a default prevents us from doing that - we should only be using this for user-configured values that do not come from the image.

Beginning of the fix for https://bugzilla.redhat.com/show_bug.cgi?id=1853455
<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
