### PR TITLE
Fix Function names to not stutter

### DIFF
--- a/pkg/subscriptions/subscriptions.go
+++ b/pkg/subscriptions/subscriptions.go
@@ -147,7 +147,7 @@ func getMountsMap(path string) (string, string, error) { //nolint
 	return "", "", errors.Errorf("unable to get host and container dir from path: %s", path)
 }
 
-// SubscriptionMountsWithUIDGID copies, adds, and mounts the subscriptions to the container root filesystem
+// MountsWithUIDGID copies, adds, and mounts the subscriptions to the container root filesystem
 // mountLabel: MAC/SELinux label for container content
 // containerWorkingDir: Private data for storing subscriptions on the host mounted in container.
 // mountFile: Additional mount points required for the container.
@@ -156,7 +156,7 @@ func getMountsMap(path string) (string, string, error) { //nolint
 // gid: to assign to content created for subscriptions
 // rootless: indicates whether container is running in rootless mode
 // disableFips: indicates whether system should ignore fips mode
-func SubscriptionMountsWithUIDGID(mountLabel, containerWorkingDir, mountFile, mountPoint string, uid, gid int, rootless, disableFips bool) []rspec.Mount {
+func MountsWithUIDGID(mountLabel, containerWorkingDir, mountFile, mountPoint string, uid, gid int, rootless, disableFips bool) []rspec.Mount {
 	var (
 		subscriptionMounts []rspec.Mount
 		mountFiles         []string
@@ -240,8 +240,8 @@ func addSubscriptionsFromMountsFile(filePath, mountLabel, containerWorkingDir st
 			}
 
 			// Don't let the umask have any influence on the file and directory creation
-			oldUmask := umask.SetUmask(0)
-			defer umask.SetUmask(oldUmask)
+			oldUmask := umask.Set(0)
+			defer umask.Set(oldUmask)
 
 			switch mode := fileInfo.Mode(); {
 			case mode.IsDir():

--- a/pkg/umask/umask_unix.go
+++ b/pkg/umask/umask_unix.go
@@ -8,13 +8,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func CheckUmask() {
+func Check() {
 	oldUmask := syscall.Umask(0022) //nolint
 	if (oldUmask & ^0022) != 0 {
 		logrus.Debugf("umask value too restrictive.  Forcing it to 022")
 	}
 }
 
-func SetUmask(value int) int {
+func Set(value int) int {
 	return syscall.Umask(value)
 }

--- a/pkg/umask/umask_unsupported.go
+++ b/pkg/umask/umask_unsupported.go
@@ -2,6 +2,6 @@
 
 package umask
 
-func CheckUmask() {}
+func Check() {}
 
-func SetUmask(int) int { return 0 }
+func Set(int) int { return 0 }


### PR DESCRIPTION
Currently callers to the pkg/umask and /pkg/subscriptions
have to make calls lib umask.SetUmask and subscriptions.Subscription
This PR removes the stutter, before people actually use the API.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
