### PR TITLE
Add a volume plugins field to containers.conf

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -475,6 +475,13 @@ By default this will be configured relative to where containers/storage store
 containers. This convention is followed by the default volume driver, but may
 not be by other drivers.
 
+**[engine.volume_plugins]**
+
+A table of all the enabled volume plugins on the system. Volume plugins can be
+used as the backend for Podman named volumes. Individual plugins are specified
+below, as a map of the plugin name (what the plugin will be called) to its path
+(filepath of the plugin's unix socket).
+
 # FILES
 
 **containers.conf**

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -363,6 +363,12 @@ type EngineConfig struct {
 	// under. This convention is followed by the default volume driver, but
 	// may not be by other drivers.
 	VolumePath string `toml:"volume_path,omitempty"`
+
+	// VolumePlugins is a set of plugins that can be used as the backend for
+	// Podman named volumes. Each volume is specified as a name (what Podman
+	// will refer to the plugin as) mapped to a path, which must point to a
+	// Unix socket that conforms to the Volume Plugin specification.
+	VolumePlugins map[string]string `toml:"volume_plugins,omitempty"`
 }
 
 // SetOptions contains a subset of options in a Config. It's used to indicate if

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -458,8 +458,11 @@ default_sysctls = [
 #            "/usr/bin/kata-fc",
 # ]
 
-# The [engine.runtimes] table MUST be the last entry in this file.
+[engine.volume_plugins]
+# testplugin = "/run/podman/plugins/test.sock"
+
+# The [engine.volume_plugins] table MUST be the last entry in this file.
 # (Unless another table is added)
 # TOML does not provide a way to end a table other than a further table being
-# defined, so every key hereafter will be part of [runtimes] and not the main
-# config.
+# defined, so every key hereafter will be part of [volume_plugins] and not the
+# main config.


### PR DESCRIPTION
We decided that making users explicitly list plugins they wanted to use was not a bad thing, and greatly simplifies our implementation. As such, we need a place to do that, and `containers.conf` is the logical location.
