### PR TITLE
Add mask_paths and unmask_paths options

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -188,6 +188,10 @@ that no size limit is imposed. If it is positive, it must be >= 8192 to
 match/exceed conmon's read buffer. The file is truncated and re-opened so the
 limit is never exceeded.
 
+**mask_paths**=""
+
+Additional paths to mask in the container. Multiple paths can be set by `/path/1:/path/2`
+
 **netns**="private"
 
 Default way to to create a NET namespace for the container.
@@ -239,6 +243,12 @@ Examples:
 **umask**="0022"
 
 Sets umask inside the container.
+
+**unmask_paths**=""
+
+Paths to unmask in the container. Multiple paths can be set by `/path/1:/path/2`. If set to `ALL`, it will unmask all the paths that are masked or made read only by default.
+The default masked paths are /proc/acpi, /proc/kcore, /proc/keys, /proc/latency_stats, /proc/sched_debug, /proc/scsi, /proc/timer_list, /proc/timer_stats, /sys/firmware, and /sys/fs/selinux.
+The default paths that are read only are /proc/asound, /proc/bus, /proc/fs, /proc/irq, /proc/sys, /proc/sysrq-trigger.
 
 **utsns**="private"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -149,6 +149,9 @@ type ContainersConfig struct {
 	// Negative values indicate that the log file won't be truncated.
 	LogSizeMax int64 `toml:"log_size_max,omitempty"`
 
+	// MaskPaths is the additional paths to mask in the container.
+	MaskPaths string `toml:"mask_paths,omitempty"`
+
 	// NetNS indicates how to create a network namespace for the container
 	NetNS string `toml:"netns,omitempty"`
 
@@ -174,6 +177,9 @@ type ContainersConfig struct {
 
 	// Umask is the umask inside the container.
 	Umask string `toml:"umask,omitempty"`
+
+	// UnmaskPaths is the paths to unmask in the container.
+	UnmaskPaths string `toml:"unmask_paths,omitempty"`
 
 	// UTSNS indicates how to create a UTS namespace for the container
 	UTSNS string `toml:"utsns,omitempty"`

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -167,6 +167,11 @@ default_sysctls = [
 #
 # log_size_max = -1
 
+# mask_paths are the addiitional paths to mask in the container. The paths to
+# mask can be set in the form of `/path/1:/path/2`.
+#
+# mask_paths = ""
+
 # Default way to to create a Network namespace for the container
 # Options are:
 # `private` Create private Network Namespace for the container.
@@ -211,6 +216,15 @@ default_sysctls = [
 # Set umask inside the container
 #
 # umask="0022"
+
+# unmask_paths are the paths to unmask in the container. The paths to unmask
+# can be set by `/path/1:/path/2`.
+# If set to `ALL`, it will unmask all the paths that are masked or made read only by default.
+# The default masked paths are /proc/acpi, /proc/kcore, /proc/keys, /proc/latency_stats, /proc/sched_debug,
+# /proc/scsi, /proc/timer_list, /proc/timer_stats, /sys/firmware, and /sys/fs/selinux.
+# The default paths that are read only are /proc/asound, /proc/bus, /proc/fs, /proc/irq, /proc/sys, /proc/sysrq-trigger.
+# 
+# unmask_paths = ""
 
 # Default way to to create a UTS namespace for the container
 # Options are:


### PR DESCRIPTION
We enabled the mask and unmask option for the
--security-opt flag. Add those options to the
containers.conf as well.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
