### PR TITLE
Find ociruntime instead of hard coding default

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -435,10 +435,11 @@ Pull image before running or creating a container. The default is **missing**.
 Indicates whether the application should be running in remote mode. This flag modifies the
 --remote option on container engines. Setting the flag to true will default `podman --remote=true` for access to the remote Podman service.
 
-**runtime**="crun"
+**runtime**=""
 
 Default OCI specific runtime in runtimes that will be used by default. Must
-refer to a member of the runtimes table.
+refer to a member of the runtimes table. Default runtime will be searched for
+on the system using the priority: "crun", "runc", "kata".
 
 **runtime_supports_json**=["crun", "runc", "kata"]
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -586,6 +586,22 @@ func (c *Config) Validate() error {
 	return nil
 }
 
+func (c *EngineConfig) findRuntime() string {
+	// Search for crun first followed by runc and kata
+	for _, name := range []string{"crun", "runc", "kata"} {
+		for _, v := range c.OCIRuntimes[name] {
+			if _, err := os.Stat(v); err == nil {
+				return name
+			}
+		}
+		if path, err := exec.LookPath(name); err == nil {
+			logrus.Warningf("Found default OCIruntime %s path which is missing from [engine.runtimes] in containers.conf", path)
+			return name
+		}
+	}
+	return ""
+}
+
 // Validate is the main entry point for Engine configuration validation
 // It returns an `error` on validation failure, otherwise
 // `nil`.

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -425,18 +425,8 @@ default_sysctls = [
 #     Path to file containing ssh identity key
 #     identity = "~/.ssh/id_rsa"
 
-# Paths to look for a valid OCI runtime (runc, runv, kata, etc)
+# Paths to look for a valid OCI runtime (crun, runc, kata, etc)
 [engine.runtimes]
-# runc = [
-#        "/usr/bin/runc",
-#        "/usr/sbin/runc",
-#        "/usr/local/bin/runc",
-#        "/usr/local/sbin/runc",
-#        "/sbin/runc",
-#        "/bin/runc",
-#        "/usr/lib/cri-o-runc/sbin/runc",
-# ]
-
 # crun = [
 #            "/usr/bin/crun",
 #            "/usr/sbin/crun",
@@ -445,6 +435,16 @@ default_sysctls = [
 #            "/sbin/crun",
 #            "/bin/crun",
 #            "/run/current-system/sw/bin/crun",
+# ]
+
+# runc = [
+#        "/usr/bin/runc",
+#        "/usr/sbin/runc",
+#        "/usr/local/bin/runc",
+#        "/usr/local/sbin/runc",
+#        "/sbin/runc",
+#        "/bin/runc",
+#        "/usr/lib/cri-o-runc/sbin/runc",
 # ]
 
 # kata = [

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -242,7 +242,6 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	c.ImageDefaultTransport = _defaultTransport
 	c.StateType = BoltDBStateStore
 
-	c.OCIRuntime = "crun"
 	c.ImageBuildFormat = "oci"
 
 	c.CgroupManager = defaultCgroupManager()
@@ -250,6 +249,15 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 
 	c.Remote = isRemote()
 	c.OCIRuntimes = map[string][]string{
+		"crun": {
+			"/usr/bin/crun",
+			"/usr/sbin/crun",
+			"/usr/local/bin/crun",
+			"/usr/local/sbin/crun",
+			"/sbin/crun",
+			"/bin/crun",
+			"/run/current-system/sw/bin/crun",
+		},
 		"runc": {
 			"/usr/bin/runc",
 			"/usr/sbin/runc",
@@ -259,15 +267,6 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 			"/bin/runc",
 			"/usr/lib/cri-o-runc/sbin/runc",
 			"/run/current-system/sw/bin/runc",
-		},
-		"crun": {
-			"/usr/bin/crun",
-			"/usr/sbin/crun",
-			"/usr/local/bin/crun",
-			"/usr/local/sbin/crun",
-			"/sbin/crun",
-			"/bin/crun",
-			"/run/current-system/sw/bin/crun",
 		},
 		"kata": {
 			"/usr/bin/kata-runtime",
@@ -280,6 +279,9 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 			"/usr/bin/kata-fc",
 		},
 	}
+	// Needs to be called after populating c.OCIRuntimes
+	c.OCIRuntime = c.findRuntime()
+
 	c.ConmonEnvVars = []string{
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 	}


### PR DESCRIPTION
Users could have any one of the OCI runtimes installed,
code will search for default.  This way they do not need
to modify defaults if they have "crun" installed.

Search order will be crun, runc, kata

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
