### PR TITLE
Switch references of /var/run -> /run

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -463,7 +463,7 @@ stores containers.
 
 Number of seconds to wait for container to exit before sending kill signal.
 
-**tmp_dir**="/var/run/libpod"
+**tmp_dir**="/run/libpod"
 
 The path to a temporary directory to store per-boot container.
 Must be a tmpfs (wiped after reboot).

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -380,7 +380,7 @@ default_sysctls = [
 
 # Directory for temporary files. Must be tmpfs (wiped after reboot)
 #
-# tmp_dir = "/var/run/libpod"
+# tmp_dir = "/run/libpod"
 
 # Directory for libpod named volumes.
 # By default, this will be configured relative to where containers/storage

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -320,7 +320,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 
 func defaultTmpDir() (string, error) {
 	if !unshare.IsRootless() {
-		return "/var/run/libpod", nil
+		return "/run/libpod", nil
 	}
 
 	runtimeDir, err := getRuntimeDir()

--- a/pkg/config/testdata/containers_comment.conf
+++ b/pkg/config/testdata/containers_comment.conf
@@ -133,7 +133,7 @@
 #static_dir = "/var/lib/containers/storage/libpod"
 
 # Directory for temporary files. Must be tmpfs (wiped after reboot)
-# tmp_dir = "/var/run/libpod"
+# tmp_dir = "/run/libpod"
 
 
 # Whether to use chroot instead of pivot_root in the runtime

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -143,7 +143,7 @@ env = ["http_proxy=internal.proxy.company.com", "foo=bar"]
 #static_dir = "/var/lib/containers/storage/libpod"
 
 # Directory for temporary files. Must be tmpfs (wiped after reboot)
-tmp_dir = "/var/run/libpod"
+tmp_dir = "/run/libpod"
 
 
 # Whether to use chroot instead of pivot_root in the runtime

--- a/pkg/config/testdata/containers_invalid.conf
+++ b/pkg/config/testdata/containers_invalid.conf
@@ -128,7 +128,7 @@ conmon_path = [
 #static_dir = "/var/lib/containers/storage/libpod"
 
 # Directory for temporary files. Must be tmpfs (wiped after reboot)
-tmp_dir = "/var/run/libpod"
+tmp_dir = "/run/libpod"
 
 # Path to OCI hooks directories for automatically executed hooks.
 hooks_dir = [


### PR DESCRIPTION
Systemd is now complaining or mentioning /var/run as a legacy directory.
It has been many years where /var/run is a symlink to /run on all
most distributions, make the change to the default.

Partial fix for https://github.com/containers/podman/issues/8369

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
