### PR TITLE
Add support for DOCKER_CONFIG

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -16,10 +16,17 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-// GetDefaultAuthFile returns env value REGISTRY_AUTH_FILE as default --authfile path
-// used in multiple --authfile flag definitions
+// GetDefaultAuthFile returns env value REGISTRY_AUTH_FILE as default
+// --authfile path used in multiple --authfile flag definitions
+// Will fail over to DOCKER_CONFIG if REGISTRY_AUTH_FILE environment is not set
 func GetDefaultAuthFile() string {
-	return os.Getenv("REGISTRY_AUTH_FILE")
+	authfile := os.Getenv("REGISTRY_AUTH_FILE")
+	if authfile == "" {
+		if authfile, ok := os.LookupEnv("DOCKER_CONFIG"); ok {
+			logrus.Infof("Using DOCKER_CONFIG environment variable for authfile path %s", authfile)
+		}
+	}
+	return authfile
 }
 
 // CheckAuthFile validates filepath given by --authfile

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,0 +1,65 @@
+package auth
+
+import (
+	"io/ioutil"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+var _ = Describe("Config", func() {
+
+	Describe("ValidateAuth", func() {
+		It("validate GetDefaultAuthFile", func() {
+			// Given
+			oldDockerConf, envDockerSet := os.LookupEnv("DOCKER_CONFIG")
+			os.Setenv("DOCKER_CONFIG", "/tmp/docker.file")
+			oldConf, envSet := os.LookupEnv("REGISTRY_AUTH_FILE")
+			os.Setenv("REGISTRY_AUTH_FILE", "/tmp/registry.file")
+			// When			// When
+			authFile := GetDefaultAuthFile()
+			// Then
+			gomega.Expect(authFile).To(gomega.BeEquivalentTo("/tmp/registry.file"))
+			os.Unsetenv("REGISTRY_AUTH_FILE")
+
+			// Fall back to DOCKER_CONFIG
+			authFile = GetDefaultAuthFile()
+			// Then
+			gomega.Expect(authFile).To(gomega.BeEquivalentTo("/tmp/docker.file"))
+			os.Unsetenv("DOCKER_CONFIG")
+
+			// Fall back to DOCKER_CONFIG
+			authFile = GetDefaultAuthFile()
+			// Then
+			gomega.Expect(authFile).To(gomega.BeEquivalentTo(""))
+
+			// Undo that
+			if envSet {
+				os.Setenv("REGISTRY_AUTH_FILE", oldConf)
+			}
+			if envDockerSet {
+				os.Setenv("DOCKER_CONFIG", oldDockerConf)
+			}
+		})
+	})
+
+	It("validate CheckAuthFile", func() {
+		// When			// When
+		err := CheckAuthFile("")
+		// Then
+		gomega.Expect(err).To(gomega.BeNil())
+
+		conf, _ := ioutil.TempFile("", "authfile")
+		defer os.Remove(conf.Name())
+		// When			// When
+		err = CheckAuthFile(conf.Name())
+		// Then
+		gomega.Expect(err).To(gomega.BeNil())
+
+		// When			// When
+		err = CheckAuthFile(conf.Name() + "missing")
+		// Then
+		gomega.Expect(err).ShouldNot(gomega.BeNil())
+	})
+})


### PR DESCRIPTION
DOCKER_CONFIG environment variable is sometimes used to point
to the config.json.  The container engines use REGISTRY_AUTH_FILE
for similar functionality.  This PR causes programs that use
GetAuthFile to use DOCKER_CONFIG if it set and REGISTRY_AUTH_FILE
is not.

Begins fixing: https://github.com/containers/podman/issues/8796

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
