### PR TITLE
Do not retry on most syscall failures

### DIFF
--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -30,7 +30,7 @@ func RetryIfNecessary(ctx context.Context, operation func() error, retryOptions 
 		if retryOptions.Delay != 0 {
 			delay = retryOptions.Delay
 		}
-		logrus.Infof("Warning: failed, retrying in %s ... (%d/%d). Error: %v", delay, attempt+1, retryOptions.MaxRetry, err)
+		logrus.Warnf("failed, retrying in %s ... (%d/%d). Error: %v", delay, attempt+1, retryOptions.MaxRetry, err)
 		select {
 		case <-time.After(delay):
 			break
@@ -69,7 +69,12 @@ func isRetryable(err error) bool {
 		}
 		return isRetryable(e.Err)
 	case syscall.Errno:
-		return e != syscall.ECONNREFUSED
+		switch e {
+		case syscall.ECONNREFUSED, syscall.EINTR, syscall.ERESTART, syscall.EAGAIN, syscall.EBUSY, syscall.ENETDOWN, syscall.ENETUNREACH, syscall.ENETRESET, syscall.ECONNABORTED, syscall.ECONNRESET, syscall.ETIMEDOUT, syscall.EHOSTDOWN, syscall.EHOSTUNREACH:
+			return true
+		default:
+			return false
+		}
 	case errcode.Errors:
 		// if this error is a group of errors, process them all in turn
 		for i := range e {


### PR DESCRIPTION
Also we now log at Warning level, so we should see the warnings on retries.

The current code retries on all failures except ECONNREFUSED.  We believe
this was a mistake, and should have been retrying on ECONNREFUSED, since this
could change on a retry.  On the other hand there are many other errno that
should not be ignored. This PR attempts to use the ERNNO that we assume might
be retryable and not retry on the others.

Fixes: https://github.com/containers/podman/issues/7963

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
