### PR TITLE
http_proxy is supposed to default to true.

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -142,7 +142,7 @@ environment variables to the container.
 
 Pass all host environment variables into the container.
 
-**http_proxy**=false
+**http_proxy**=true
 
 Default proxy environment variables will be passed into the container.
 The environment variables passed in include:

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -85,15 +85,9 @@ var _ = Describe("Config", func() {
 		})
 
 		It("Check SELinux settings", func() {
-			if selinux.GetEnabled() {
-				sut.Containers.EnableLabeling = true
-				gomega.Expect(sut.Containers.Validate()).To(gomega.BeNil())
-				gomega.Expect(selinux.GetEnabled()).To(gomega.BeTrue())
-
-				sut.Containers.EnableLabeling = false
-				gomega.Expect(sut.Containers.Validate()).To(gomega.BeNil())
-				gomega.Expect(selinux.GetEnabled()).To(gomega.BeFalse())
-			}
+			defaultConfig, _ := NewConfig("")
+			// EnableLabeling should match whether or not SELinux is enabled on the host
+			gomega.Expect(defaultConfig.Containers.EnableLabeling).To(gomega.Equal(selinux.GetEnabled()))
 
 		})
 
@@ -115,6 +109,9 @@ var _ = Describe("Config", func() {
 			// Given
 			// When
 			defaultConfig, _ := DefaultConfig()
+			// prior to reading local config, shows hard coded defaults
+			gomega.Expect(defaultConfig.Containers.HTTPProxy).To(gomega.Equal(true))
+
 			err := readConfigFromFile("testdata/containers_default.conf", defaultConfig)
 
 			OCIRuntimeMap := map[string][]string{
@@ -164,6 +161,7 @@ var _ = Describe("Config", func() {
 			gomega.Expect(defaultConfig.Network.CNIPluginDirs).To(gomega.Equal(pluginDirs))
 			gomega.Expect(defaultConfig.Engine.NumLocks).To(gomega.BeEquivalentTo(2048))
 			gomega.Expect(defaultConfig.Engine.OCIRuntimes).To(gomega.Equal(OCIRuntimeMap))
+			gomega.Expect(defaultConfig.Containers.HTTPProxy).To(gomega.Equal(false))
 		})
 
 		It("should succeed with commented out configuration", func() {

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -184,7 +184,7 @@ func DefaultConfig() (*Config, error) {
 				"TERM=xterm",
 			},
 			EnvHost:        false,
-			HTTPProxy:      false,
+			HTTPProxy:      true,
 			Init:           false,
 			InitPath:       "",
 			IPCNS:          "private",


### PR DESCRIPTION
In the containers.conf we default to true, but in code and man page
it is defaulted to false. Since Podman wants it defaulted to true
we need to change default and man page to match.

Also fixed the testing for SELinux, which would never succeed on an SELinux box.

Helps fix: https://github.com/containers/podman/pull/8844

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
