### PR TITLE
Current code fails to compile on Darwin no syscall.ERESTART

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ build-cross:
 	$(call go-build,linux,arm64,${BUILDTAGS})
 	$(call go-build,linux,ppc64le,${BUILDTAGS})
 	$(call go-build,linux,s390x,${BUILDTAGS})
+	$(call go-build,darwin,amd64,${BUILDTAGS})
 	$(call go-build,windows,amd64,remote ${BUILDTAGS})
 	$(call go-build,windows,386,remote ${BUILDTAGS})
 

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -69,12 +69,7 @@ func isRetryable(err error) bool {
 		}
 		return isRetryable(e.Err)
 	case syscall.Errno:
-		switch e {
-		case syscall.ECONNREFUSED, syscall.EINTR, syscall.ERESTART, syscall.EAGAIN, syscall.EBUSY, syscall.ENETDOWN, syscall.ENETUNREACH, syscall.ENETRESET, syscall.ECONNABORTED, syscall.ECONNRESET, syscall.ETIMEDOUT, syscall.EHOSTDOWN, syscall.EHOSTUNREACH:
-			return true
-		default:
-			return false
-		}
+		return shouldRestart(e)
 	case errcode.Errors:
 		// if this error is a group of errors, process them all in turn
 		for i := range e {
@@ -97,4 +92,12 @@ func isRetryable(err error) bool {
 	}
 
 	return false
+}
+
+func shouldRestart(e error) bool {
+	switch e {
+	case syscall.ECONNREFUSED, syscall.EINTR, syscall.EAGAIN, syscall.EBUSY, syscall.ENETDOWN, syscall.ENETUNREACH, syscall.ENETRESET, syscall.ECONNABORTED, syscall.ECONNRESET, syscall.ETIMEDOUT, syscall.EHOSTDOWN, syscall.EHOSTUNREACH:
+		return true
+	}
+	return shouldRestartPlatform(e)
 }

--- a/pkg/retry/retry_linux.go
+++ b/pkg/retry/retry_linux.go
@@ -1,0 +1,9 @@
+package retry
+
+import (
+	"syscall"
+)
+
+func shouldRestartPlatform(e error) bool {
+	return e == syscall.ERESTART
+}

--- a/pkg/retry/retry_unsupported.go
+++ b/pkg/retry/retry_unsupported.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package retry
+
+func shouldRestartPlatform(e error) bool {
+	return false
+}


### PR DESCRIPTION
syscall.ERESTART is not defined on Darwin, so move to
an unsupported package. While this would work on Windows
this code most likey never will, so rather then complicate
code, I just left ERESTART on Windows as not supported.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
