### PR TITLE
seccomp: drop 'vmsplice' from the allowed list

### DIFF
--- a/pkg/seccomp/default_linux.go
+++ b/pkg/seccomp/default_linux.go
@@ -378,7 +378,6 @@ func DefaultProfile() *Seccomp {
 				"utimensat_time64",
 				"utimes",
 				"vfork",
-				"vmsplice",
 				"wait4",
 				"waitid",
 				"waitpid",

--- a/pkg/seccomp/seccomp.json
+++ b/pkg/seccomp/seccomp.json
@@ -378,7 +378,6 @@
 				"utimensat_time64",
 				"utimes",
 				"vfork",
-				"vmsplice",
 				"wait4",
 				"waitid",
 				"waitpid",


### PR DESCRIPTION
More details: https://lore.kernel.org/linux-mm/X+PoXCizo392PBX7@redhat.com/

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
