### PR TITLE
Rename internal functions to make them easier to understand

### DIFF
--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -69,7 +69,7 @@ func isRetryable(err error) bool {
 		}
 		return isRetryable(e.Err)
 	case syscall.Errno:
-		return shouldRestart(e)
+		return isErrnoRetryable(e)
 	case errcode.Errors:
 		// if this error is a group of errors, process them all in turn
 		for i := range e {
@@ -94,10 +94,10 @@ func isRetryable(err error) bool {
 	return false
 }
 
-func shouldRestart(e error) bool {
+func isErrnoRetryable(e error) bool {
 	switch e {
 	case syscall.ECONNREFUSED, syscall.EINTR, syscall.EAGAIN, syscall.EBUSY, syscall.ENETDOWN, syscall.ENETUNREACH, syscall.ENETRESET, syscall.ECONNABORTED, syscall.ECONNRESET, syscall.ETIMEDOUT, syscall.EHOSTDOWN, syscall.EHOSTUNREACH:
 		return true
 	}
-	return shouldRestartPlatform(e)
+	return isErrnoERESTART(e)
 }

--- a/pkg/retry/retry_linux.go
+++ b/pkg/retry/retry_linux.go
@@ -4,6 +4,6 @@ import (
 	"syscall"
 )
 
-func shouldRestartPlatform(e error) bool {
+func isErrnoERESTART(e error) bool {
 	return e == syscall.ERESTART
 }

--- a/pkg/retry/retry_unsupported.go
+++ b/pkg/retry/retry_unsupported.go
@@ -2,6 +2,6 @@
 
 package retry
 
-func shouldRestartPlatform(e error) bool {
+func isErrnoERESTART(e error) bool {
 	return false
 }


### PR DESCRIPTION
Currently the difference between isRetryable and shouldRestart
is not clear in the function names, this simply makes them
more understandable.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
