### PR TITLE
Fix name validation and dir mode in secrets

### DIFF
--- a/pkg/secrets/filedriver/filedriver.go
+++ b/pkg/secrets/filedriver/filedriver.go
@@ -33,6 +33,11 @@ type Driver struct {
 func NewDriver(rootPath string) (*Driver, error) {
 	fileDriver := new(Driver)
 	fileDriver.secretsDataFilePath = filepath.Join(rootPath, secretsDataFile)
+	// the lockfile functions requre that the rootPath dir is executable
+	if err := os.MkdirAll(rootPath, 0700); err != nil {
+		return nil, err
+	}
+
 	lock, err := lockfile.GetLockfile(filepath.Join(rootPath, "secretsdata.lock"))
 	if err != nil {
 		return nil, err

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -65,6 +65,10 @@ func TestAddSecretName(t *testing.T) {
 	// invalid chars
 	_, err = manager.Store("??", []byte("mydata"), drivertype, opts)
 	require.Error(t, err)
+	_, err = manager.Store("-a", []byte("mydata"), drivertype, opts)
+	require.Error(t, err)
+	_, err = manager.Store("a-", []byte("mydata"), drivertype, opts)
+	require.Error(t, err)
 }
 
 func TestAddMultipleSecrets(t *testing.T) {


### PR DESCRIPTION
fix name validation to reject secret names that end with "-"
Create filedriver dir with proper permissions

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
