### PR TITLE
Fix secret name validation

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -263,7 +263,7 @@ func (s *SecretsManager) LookupSecretData(nameOrID string) (*Secret, []byte, err
 
 // validateSecretName checks if the secret name is valid.
 func validateSecretName(name string) error {
-	if !secretNameRegexp.MatchString(name) || len(name) > 64 || strings.HasSuffix(name, "-") {
+	if !secretNameRegexp.MatchString(name) || len(name) > 64 || strings.HasSuffix(name, "-") || strings.HasSuffix(name, ".") {
 		return errors.Wrapf(errInvalidSecretName, "only 64 [a-zA-Z0-9-_.] characters allowed, and the start and end character must be [a-zA-Z0-9]: %s", name)
 	}
 	return nil

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -69,6 +69,10 @@ func TestAddSecretName(t *testing.T) {
 	require.Error(t, err)
 	_, err = manager.Store("a-", []byte("mydata"), drivertype, opts)
 	require.Error(t, err)
+	_, err = manager.Store(".a", []byte("mydata"), drivertype, opts)
+	require.Error(t, err)
+	_, err = manager.Store("a.", []byte("mydata"), drivertype, opts)
+	require.Error(t, err)
 }
 
 func TestAddMultipleSecrets(t *testing.T) {


### PR DESCRIPTION
Secret names should not end with "."

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
