### PR TITLE
Add image_parallel_copies engine config

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -361,6 +361,11 @@ pod, we start a `pause` process in a container to hold open the namespaces
 associated with the  pod.  This container does nothing other then sleep,
 reserving the pods resources for the lifetime of the pod.
 
+**image_parallel_copies**=0
+
+Maximum number of image layers to be copied (pulled/pushed) simultaneously.
+Not setting this field will fall back to containers/image defaults. (6)
+
 **lock_type**="shm"
 
 Specify the locking mechanism to use; valid values are "shm" and "file".

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -191,6 +191,11 @@ type EngineConfig struct {
 	// container images.  Valid values are "oci" (default) or "docker".
 	ImageBuildFormat string `toml:"image_build_format,omitempty"`
 
+	// ImageParallelCopies indicates the maximum number of image layers
+	// to be copied simultaneously. If this is zero, container engines
+	// will fall back to containers/image defaults.
+	ImageParallelCopies uint `toml:"image_parallel_copies,omitempty"`
+
 	// CgroupCheck indicates the configuration has been rewritten after an
 	// upgrade to Fedora 31 to change the default OCI runtime for cgroupv2v2.
 	CgroupCheck bool `toml:"cgroup_check,omitempty"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -302,6 +302,7 @@ var _ = Describe("Config", func() {
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(config).ToNot(gomega.BeNil())
 			gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal("overridden-default"))
+			gomega.Expect(config.Engine.ImageParallelCopies).To(gomega.Equal(uint(10)))
 		})
 
 		It("should fail with invalid value", func() {

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -321,6 +321,10 @@ default_sysctls = [
 #
 # infra_image = "k8s.gcr.io/pause:3.2"
 
+# Maximum number of image layers to be copied (pulled/pushed) simultaneously.
+# Not setting this field, or setting it to zero, will fall back to containers/image defaults.
+# image_parallel_copies=0
+
 # Specify the locking mechanism to use; valid values are "shm" and "file".
 # Change the default only if you are sure of what you are doing, in general
 # "file" is useful only on platforms where cgo is not available for using the

--- a/pkg/config/testdata/containers_override.conf
+++ b/pkg/config/testdata/containers_override.conf
@@ -1,3 +1,6 @@
 [containers]
 
 apparmor_profile = "overridden-default"
+
+[engine]
+image_parallel_copies=10


### PR DESCRIPTION
This will allow users to configure the amount of parallel copiess that
the container engines are allowed to do. This allows users to configure
their systems to match their available network settings.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
