### PR TITLE
Fix secret create prefix

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -133,7 +133,7 @@ func (s *SecretsManager) Store(name string, data []byte, driverType string, driv
 	s.lockfile.Lock()
 	defer s.lockfile.Unlock()
 
-	exist, err := s.secretExists(name)
+	exist, err := s.exactSecretExists(name)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -117,6 +117,20 @@ func TestAddSecretDupName(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestAddSecretPrefix(t *testing.T) {
+	manager, testpath, err := setup()
+	require.NoError(t, err)
+	defer cleanup(testpath)
+
+	// If the randomly generated secret id is something like "abcdeiuoergnadufigh"
+	// we should still allow someone to store a secret with the name "abcd" or "a"
+	secretID, err := manager.Store("mysecret", []byte("mydata"), drivertype, opts)
+	require.NoError(t, err)
+
+	_, err = manager.Store(secretID[0:5], []byte("mydata"), drivertype, opts)
+	require.NoError(t, err)
+}
+
 func TestRemoveSecret(t *testing.T) {
 	manager, testpath, err := setup()
 	require.NoError(t, err)


### PR DESCRIPTION
Fix a bug where if the secret name was a prefix of an existing id, secrets would reject the new name
Now, you can use the secret name as expected

Example: if a secret with id "abcdefg" already exists:
Previously, it would error if you tried to create a secret with name "abc"
Now it allows you to do so

Signed-off-by: Ashley Cui <acui@redhat.com>
