### PR TITLE
Add accessor for log-driver

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -518,3 +518,9 @@ func (c *Config) TZ() string {
 func (c *Config) Umask() string {
 	return c.Containers.Umask
 }
+
+// LogDriver returns the logging driver to be used
+// currently k8s-file or journald
+func (c *Config) LogDriver() string {
+	return c.Containers.LogDriver
+}


### PR DESCRIPTION
For podman, we need to be able to get the log driver from common config.

Signed-off-by: baude <bbaude@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
