### PR TITLE
Add image_default_format

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -278,8 +278,12 @@ Path to the directory where CNI configuration files are located.
 ## ENGINE TABLE
 The `engine` table contains configuration options used to set up container engines such as Podman and Buildah.
 
-**image_build_format**="oci"
-The default image format to building container images. Valid values are "oci" (default) or "docker".
+**image_default_format**="oci"|"v2s2"|"v2s1"
+
+Manifest Type (oci, v2s2, or v2s1) to use when pulling, pushing, building
+container images. By default images pulled and pushed match the format of the
+source image. Building/committing defaults to OCI.
+Note: **image_build_format** is deprecated.
 
 **cgroup_check**=false
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -187,15 +187,6 @@ type ContainersConfig struct {
 
 // EngineConfig contains configuration options used to set up a engine runtime
 type EngineConfig struct {
-	// ImageBuildFormat indicates the default image format to building
-	// container images.  Valid values are "oci" (default) or "docker".
-	ImageBuildFormat string `toml:"image_build_format,omitempty"`
-
-	// ImageParallelCopies indicates the maximum number of image layers
-	// to be copied simultaneously. If this is zero, container engines
-	// will fall back to containers/image defaults.
-	ImageParallelCopies uint `toml:"image_parallel_copies,omitempty"`
-
 	// CgroupCheck indicates the configuration has been rewritten after an
 	// upgrade to Fedora 31 to change the default OCI runtime for cgroupv2v2.
 	CgroupCheck bool `toml:"cgroup_check,omitempty"`
@@ -240,9 +231,24 @@ type EngineConfig struct {
 	// this slice takes precedence.
 	HooksDir []string `toml:"hooks_dir,omitempty"`
 
+	// ImageBuildFormat (DEPRECATED) indicates the default image format to
+	// building container images. Should use ImageDefaultFormat
+	ImageBuildFormat string `toml:"image_build_format,omitempty"`
+
 	// ImageDefaultTransport is the default transport method used to fetch
 	// images.
 	ImageDefaultTransport string `toml:"image_default_transport,omitempty"`
+
+	// ImageParallelCopies indicates the maximum number of image layers
+	// to be copied simultaneously. If this is zero, container engines
+	// will fall back to containers/image defaults.
+	ImageParallelCopies uint `toml:"image_parallel_copies,omitempty"`
+
+	// ImageDefaultFormat sepecified the manifest Type (oci, v2s2, or v2s1)
+	// to use when pulling, pushing, building container images. By default
+	// image pulled and pushed match the format of the source image.
+	// Building/committing defaults to OCI.
+	ImageDefaultFormat string `toml:"image_default_format,omitempty"`
 
 	// InfraCommand is the command run to start up a pod infra container.
 	InfraCommand string `toml:"infra_command,omitempty"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -306,6 +306,7 @@ var _ = Describe("Config", func() {
 			gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal("overridden-default"))
 			gomega.Expect(config.Containers.LogDriver).To(gomega.BeEquivalentTo("k8s-file"))
 			gomega.Expect(config.Engine.ImageParallelCopies).To(gomega.Equal(uint(10)))
+			gomega.Expect(config.Engine.ImageDefaultFormat).To(gomega.Equal("v2s2"))
 		})
 
 		It("should fail with invalid value", func() {

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -246,9 +246,14 @@ default_sysctls = [
 # network_config_dir = "/etc/cni/net.d/"
 
 [engine]
-# ImageBuildFormat indicates the default image format to building
-# container images. Valid values are "oci" (default) or "docker".
-# image_build_format = "oci"
+# Maximum number of image layers to be copied (pulled/pushed) simultaneously.
+# Not setting this field, or setting it to zero, will fall back to containers/image defaults.
+# image_parallel_copies=0
+
+# Manifest Type (oci, v2s2, or v2s1) to use when pulling, pushing, building
+# container images. By default image pulled and pushed match the format of the
+# source image. Building/commiting defaults to OCI.
+# image_default_format = ""
 
 # Cgroup management implementation used for the runtime.
 # Valid options "systemd" or "cgroupfs"
@@ -320,10 +325,6 @@ default_sysctls = [
 # reserving the pods resources for the lifetime of the pod.
 #
 # infra_image = "k8s.gcr.io/pause:3.2"
-
-# Maximum number of image layers to be copied (pulled/pushed) simultaneously.
-# Not setting this field, or setting it to zero, will fall back to containers/image defaults.
-# image_parallel_copies=0
 
 # Specify the locking mechanism to use; valid values are "shm" and "file".
 # Change the default only if you are sure of what you are doing, in general

--- a/pkg/config/testdata/containers_override.conf
+++ b/pkg/config/testdata/containers_override.conf
@@ -5,3 +5,4 @@ log_driver = "k8s-file"
 
 [engine]
 image_parallel_copies=10
+image_default_format="v2s2"


### PR DESCRIPTION
Currently when pushing images we default to the format
of the source image.  Customers have asked us to allow them
to force a specific image type when pushing to a registry.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
