### PR TITLE
Add compatible template functions

### DIFF
--- a/pkg/report/doc.go
+++ b/pkg/report/doc.go
@@ -38,7 +38,17 @@ Helpers:
 		... process JSON and output
 	}
 
-and
+Template Functions:
+
+The following template functions are added to the template when parsed:
+	- join  strings.Join, {{join .Field separator}}
+	- lower strings.ToLower {{ .Field | lower }}
+	- split strings.Split {{ .Field | split }}
+	- title strings.Title {{ .Field | title }}
+	- upper strings.ToUpper {{ .Field | upper }}
+
+report.Funcs() may be used to add additional template functions.
+Adding an existing function will replace that function for the life of that template.
 
 
 Note: Your code should not ignore errors


### PR DESCRIPTION
Add compatible template functions

  "join":  strings.Join,
  "lower": strings.ToLower,
  "split": strings.Split,
  "title": strings.Title,
  "upper": strings.ToUpper,

Add and update tests to exercise these additions.
Update go doc with details of usage.

Fixes #8773
Closes https://bugzilla.redhat.com/show_bug.cgi?id=1915383

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
