### PR TITLE
Updated report.template to be more compatible

### DIFF
--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -1,6 +1,8 @@
 package report
 
 import (
+	"bytes"
+	"encoding/json"
 	"reflect"
 	"strings"
 	"text/template"
@@ -21,22 +23,30 @@ type FuncMap template.FuncMap
 var tableReplacer = strings.NewReplacer(
 	"table ", "",
 	`\t`, "\t",
-	`\n`, "\n",
 	" ", "\t",
 )
 
 // escapedReplacer will clean up escaped characters from CLI
 var escapedReplacer = strings.NewReplacer(
 	`\t`, "\t",
-	`\n`, "\n",
 )
 
-var defaultFuncs = FuncMap{
-	"join":  strings.Join,
-	"lower": strings.ToLower,
-	"split": strings.Split,
-	"title": strings.Title,
-	"upper": strings.ToUpper,
+var DefaultFuncs = FuncMap{
+	"join": strings.Join,
+	"json": func(v interface{}) string {
+		buf := &bytes.Buffer{}
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		enc.Encode(v)
+		// Remove the trailing new line added by the encoder
+		return strings.TrimSpace(buf.String())
+	},
+	"lower":    strings.ToLower,
+	"pad":      padWithSpace,
+	"split":    strings.Split,
+	"title":    strings.Title,
+	"truncate": truncateWithLength,
+	"upper":    strings.ToUpper,
 }
 
 // NormalizeFormat reads given go template format provided by CLI and munges it into what we need
@@ -53,6 +63,22 @@ func NormalizeFormat(format string) string {
 		f += "\n"
 	}
 	return f
+}
+
+// padWithSpace adds spaces*prefix and spaces*suffix to the input when it is non-empty
+func padWithSpace(source string, prefix, suffix int) string {
+	if source == "" {
+		return source
+	}
+	return strings.Repeat(" ", prefix) + source + strings.Repeat(" ", suffix)
+}
+
+// truncateWithLength truncates the source string up to the length provided by the input
+func truncateWithLength(source string, length int) string {
+	if len(source) < length {
+		return source
+	}
+	return source[:length]
 }
 
 // Headers queries the interface for field names.
@@ -96,7 +122,7 @@ func Headers(object interface{}, overrides map[string]string) []map[string]strin
 
 // NewTemplate creates a new template object
 func NewTemplate(name string) *Template {
-	return &Template{Template: template.New(name).Funcs(template.FuncMap(defaultFuncs))}
+	return &Template{Template: template.New(name).Funcs(template.FuncMap(DefaultFuncs))}
 }
 
 // Parse parses text as a template body for t
@@ -108,7 +134,7 @@ func (t *Template) Parse(text string) (*Template, error) {
 		text = NormalizeFormat(text)
 	}
 
-	tt, err := t.Template.Funcs(template.FuncMap(defaultFuncs)).Parse(text)
+	tt, err := t.Template.Funcs(template.FuncMap(DefaultFuncs)).Parse(text)
 	return &Template{tt, t.isTable}, err
 }
 
@@ -116,7 +142,7 @@ func (t *Template) Parse(text string) (*Template, error) {
 // A default template function will be replace if there is a key collision.
 func (t *Template) Funcs(funcMap FuncMap) *Template {
 	m := make(FuncMap)
-	for k, v := range defaultFuncs {
+	for k, v := range DefaultFuncs {
 		m[k] = v
 	}
 	for k, v := range funcMap {


### PR DESCRIPTION
Previous code and tests did not reflect actual users input and expected
output.

Add remaining compatibilty golang template funcs

- json
- pad
- truncate

https://bugzilla.redhat.com/show_bug.cgi?id=1922077
Fixes #8702

Signed-off-by: Jhon Honce <jhonce@redhat.com>

