### PR TITLE
Revert "Change default log driver to journald"

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -177,7 +177,7 @@ the container.
 
 Indicates whether the container engine uses MAC(SELinux) container separation via labeling. This option is ignored on disabled systems.
 
-**log_driver**="journald"
+**log_driver**="k8s-file"
 
 Logging driver for the container. Available options: `k8s-file` and `journald`.
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -26,7 +26,6 @@ var _ = Describe("Config", func() {
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(defaultConfig.Containers.ApparmorProfile).To(gomega.Equal(apparmor.Profile))
 			gomega.Expect(defaultConfig.Containers.PidsLimit).To(gomega.BeEquivalentTo(2048))
-			gomega.Expect(defaultConfig.Containers.LogDriver).To(gomega.BeEquivalentTo("journald"))
 		})
 
 		It("should succeed with devices", func() {
@@ -47,7 +46,6 @@ var _ = Describe("Config", func() {
 		It("should fail wrong max log size", func() {
 			// Given
 			sut.Containers.LogSizeMax = 1
-			sut.Containers.LogDriver = "k8s-file"
 
 			// When
 			err := sut.Validate()
@@ -304,7 +302,6 @@ var _ = Describe("Config", func() {
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(config).ToNot(gomega.BeNil())
 			gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal("overridden-default"))
-			gomega.Expect(config.Containers.LogDriver).To(gomega.BeEquivalentTo("k8s-file"))
 			gomega.Expect(config.Engine.ImageParallelCopies).To(gomega.Equal(uint(10)))
 			gomega.Expect(config.Engine.ImageDefaultFormat).To(gomega.Equal("v2s2"))
 		})

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -158,7 +158,7 @@ default_sysctls = [
 
 # Logging driver for the container. Available options: k8s-file and journald.
 #
-# log_driver = "journald"
+# log_driver = "k8s-file"
 
 # Maximum size allowed for the container log file. Negative numbers indicate
 # that no size limit is imposed. If positive, it must be >= 8192 to match or

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -102,7 +102,7 @@ const (
 	// SystemdCgroupsManager represents systemd native cgroup manager
 	SystemdCgroupsManager = "systemd"
 	// DefaultLogDriver is the default type of log files
-	DefaultLogDriver = "journald"
+	DefaultLogDriver = "k8s-file"
 	// DefaultLogSizeMax is the default value for the maximum log size
 	// allowed for a container. Negative values mean that no limit is imposed.
 	DefaultLogSizeMax = -1

--- a/pkg/config/testdata/containers_override.conf
+++ b/pkg/config/testdata/containers_override.conf
@@ -1,7 +1,6 @@
 [containers]
 
 apparmor_profile = "overridden-default"
-log_driver = "k8s-file"
 
 [engine]
 image_parallel_copies=10


### PR DESCRIPTION
This reverts commit da196fb0f743a90a486aa6eb31df6807f4e67765.

Journald is not yet passing Podman CI.  We need to temporarily revert
the commit to unblock secrets work.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
