### PR TITLE
update pause image to 3.4.1

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -358,7 +358,7 @@ Default transport method for pulling and pushing images.
 
 Command to run the infra container.
 
-**infra_image**="k8s.gcr.io/pause:3.2"
+**infra_image**="k8s.gcr.io/pause:3.4.1"
 
 Infra (pause) container image name for pod infra containers.  When running a
 pod, we start a `pause` process in a container to hold open the namespaces

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -324,7 +324,7 @@ default_sysctls = [
 # associated with the  pod.  This container does nothing other then sleep,
 # reserving the pods resources for the lifetime of the pod.
 #
-# infra_image = "k8s.gcr.io/pause:3.2"
+# infra_image = "k8s.gcr.io/pause:3.4.1"
 
 # Specify the locking mechanism to use; valid values are "shm" and "file".
 # Change the default only if you are sure of what you are doing, in general

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -45,7 +45,7 @@ var (
 	// DefaultInitPath is the default path to the container-init binary
 	DefaultInitPath = "/usr/libexec/podman/catatonit"
 	// DefaultInfraImage to use for infra container
-	DefaultInfraImage = "k8s.gcr.io/pause:3.2"
+	DefaultInfraImage = "k8s.gcr.io/pause:3.4.1"
 	// DefaultRootlessSHMLockPath is the default path for rootless SHM locks
 	DefaultRootlessSHMLockPath = "/libpod_rootless_lock"
 	// DefaultDetachKeys is the default keys sequence for detaching a

--- a/pkg/config/testdata/containers_comment.conf
+++ b/pkg/config/testdata/containers_comment.conf
@@ -148,7 +148,7 @@
 #namespace = ""
 
 # Default infra (pause) image name for pod infra containers
-# infra_image = "k8s.gcr.io/pause:3.2"
+# infra_image = "k8s.gcr.io/pause:3.4.1"
 
 # Default command to run the infra container
 # infra_command = "/pause"

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -162,7 +162,7 @@ hooks_dir = [
 ]
 
 # Default infra (pause) image name for pod infra containers
-infra_image = "k8s.gcr.io/pause:3.2"
+infra_image = "k8s.gcr.io/pause:3.4.1"
 
 # Default command to run the infra container
 infra_command = "/pause"

--- a/pkg/config/testdata/containers_invalid.conf
+++ b/pkg/config/testdata/containers_invalid.conf
@@ -146,7 +146,7 @@ no_pivot_root = false
 #namespace = ""
 
 # Default infra (pause) image name for pod infra containers
-infra_image = "k8s.gcr.io/pause:3.2"
+infra_image = "k8s.gcr.io/pause:3.4.1"
 
 # Default command to run the infra container
 infra_command = "/pause"


### PR DESCRIPTION
cri-o https://github.com/cri-o/cri-o/pull/4550 depends on this PR to update vendor.

part of https://github.com/kubernetes/kubernetes/pull/98205 for cri-o 
