### PR TITLE
Add missing values to containers.conf man page

### DIFF
--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -73,7 +73,6 @@ default_capabilities = [
     "SYS_CHROOT"
 ]
 
-
 # A list of sysctls to be set in containers by default,
 # specified as "name=value",
 # for example:"net.ipv4.ping_group_range = 0 0".
@@ -240,6 +239,9 @@ default_sysctls = [
 # Path to directory where CNI plugin binaries are located.
 #
 # cni_plugin_dirs = ["/usr/libexec/cni"]
+
+# The network name of the default CNI network to attach pods to.
+# default_network = "podman"
 
 # Path to the directory where CNI configuration files are located.
 #


### PR DESCRIPTION
Fix some alphabetic sorting.

Add missing default_network setting to containers.conf

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
