### PR TITLE
Move EnforceRange and HasTable out of Podman and into common

### DIFF
--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"reflect"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -154,4 +155,19 @@ func (t *Template) Funcs(funcMap FuncMap) *Template {
 // IsTable returns true if format string defines a "table"
 func (t *Template) IsTable() bool {
 	return t.isTable
+}
+
+var rangeRegex = regexp.MustCompile(`{{\s*range\s*\.\s*}}.*{{\s*end\s*}}`)
+
+// EnforceRange ensures that the format string contains a range
+func EnforceRange(format string) string {
+	if !rangeRegex.MatchString(format) {
+		return "{{range .}}" + format + "{{end}}"
+	}
+	return format
+}
+
+// HasTable returns whether the format is a table
+func HasTable(format string) bool {
+	return strings.HasPrefix(format, "table ")
 }

--- a/pkg/report/template_test.go
+++ b/pkg/report/template_test.go
@@ -151,3 +151,15 @@ func TestTemplate_json(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, `["ident1","ident2","ident3"]`+"\n", buf.String())
 }
+
+func TestTemplate_HasTable(t *testing.T) {
+	assert.True(t, HasTable("table foobar"))
+	assert.False(t, HasTable("foobar"))
+}
+
+func TestTemplate_EnforceRange(t *testing.T) {
+	testRange := `{{range .}}foobar was here{{end}}`
+	assert.Equal(t, testRange, EnforceRange(testRange))
+	assert.Equal(t, testRange, EnforceRange("foobar was here"))
+	assert.NotEqual(t, testRange, EnforceRange("foobar"))
+}


### PR DESCRIPTION
These functions were in podman but used with the report template.
They need to be used with Buildah secrets, so moving into common.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
