### PR TITLE
Export error constants from pkg/secrets

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -19,36 +19,38 @@ const maxSecretSize = 512000
 // secretIDLength is the character length of a secret ID - 25
 const secretIDLength = 25
 
-// errInvalidPath indicates that the secrets path is invalid
-var errInvalidPath = errors.New("invalid secrets path")
+var (
+	// ErrInvalidPath indicates that the secrets path is invalid
+	ErrInvalidPath = errors.New("invalid secrets path")
 
-// errNoSuchSecret indicates that the secret does not exist
-var errNoSuchSecret = errors.New("no such secret")
+	// ErrNoSuchSecret indicates that the secret does not exist
+	ErrNoSuchSecret = errors.New("no such secret")
 
-// errSecretNameInUse indicates that the secret name is already in use
-var errSecretNameInUse = errors.New("secret name in use")
+	// ErrSecretNameInUse indicates that the secret name is already in use
+	ErrSecretNameInUse = errors.New("secret name in use")
 
-// errInvalidSecretName indicates that the secret name is invalid
-var errInvalidSecretName = errors.New("invalid secret name")
+	// ErrInvalidSecretName indicates that the secret name is invalid
+	ErrInvalidSecretName = errors.New("invalid secret name")
 
-// errInvalidDriver indicates that the driver type is invalid
-var errInvalidDriver = errors.New("invalid driver")
+	// ErrInvalidDriver indicates that the driver type is invalid
+	ErrInvalidDriver = errors.New("invalid driver")
 
-// errInvalidDriverOpt indicates that a driver option is invalid
-var errInvalidDriverOpt = errors.New("invalid driver option")
+	// ErrInvalidDriverOpt indicates that a driver option is invalid
+	ErrInvalidDriverOpt = errors.New("invalid driver option")
 
-// errAmbiguous indicates that a secret is ambiguous
-var errAmbiguous = errors.New("secret is ambiguous")
+	// ErrAmbiguous indicates that a secret is ambiguous
+	ErrAmbiguous = errors.New("secret is ambiguous")
 
-// errDataSize indicates that the secret data is too large or too small
-var errDataSize = errors.New("secret data must be larger than 0 and less than 512000 bytes")
+	// ErrDataSize indicates that the secret data is too large or too small
+	ErrDataSize = errors.New("secret data must be larger than 0 and less than 512000 bytes")
 
-// secretsFile is the name of the file that the secrets database will be stored in
-var secretsFile = "secrets.json"
+	// secretsFile is the name of the file that the secrets database will be stored in
+	secretsFile = "secrets.json"
 
-// secretNameRegexp matches valid secret names
-// Allowed: 64 [a-zA-Z0-9-_.] characters, and the start and end character must be [a-zA-Z0-9]
-var secretNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`)
+	// secretNameRegexp matches valid secret names
+	// Allowed: 64 [a-zA-Z0-9-_.] characters, and the start and end character must be [a-zA-Z0-9]
+	secretNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`)
+)
 
 // SecretsManager holds information on handling secrets
 type SecretsManager struct {
@@ -97,7 +99,7 @@ func NewManager(rootPath string) (*SecretsManager, error) {
 	manager := new(SecretsManager)
 
 	if !filepath.IsAbs(rootPath) {
-		return nil, errors.Wrapf(errInvalidPath, "path must be absolute: %s", rootPath)
+		return nil, errors.Wrapf(ErrInvalidPath, "path must be absolute: %s", rootPath)
 	}
 	// the lockfile functions requre that the rootPath dir is executable
 	if err := os.MkdirAll(rootPath, 0700); err != nil {
@@ -127,7 +129,7 @@ func (s *SecretsManager) Store(name string, data []byte, driverType string, driv
 	}
 
 	if !(len(data) > 0 && len(data) < maxSecretSize) {
-		return "", errDataSize
+		return "", ErrDataSize
 	}
 
 	s.lockfile.Lock()
@@ -138,7 +140,7 @@ func (s *SecretsManager) Store(name string, data []byte, driverType string, driv
 		return "", err
 	}
 	if exist {
-		return "", errors.Wrapf(errSecretNameInUse, name)
+		return "", errors.Wrapf(ErrSecretNameInUse, name)
 	}
 
 	secr := new(Secret)
@@ -150,7 +152,7 @@ func (s *SecretsManager) Store(name string, data []byte, driverType string, driv
 		newID = newID[0:secretIDLength]
 		_, err := s.lookupSecret(newID)
 		if err != nil {
-			if errors.Cause(err) == errNoSuchSecret {
+			if errors.Cause(err) == ErrNoSuchSecret {
 				secr.ID = newID
 				break
 			} else {
@@ -264,7 +266,7 @@ func (s *SecretsManager) LookupSecretData(nameOrID string) (*Secret, []byte, err
 // validateSecretName checks if the secret name is valid.
 func validateSecretName(name string) error {
 	if !secretNameRegexp.MatchString(name) || len(name) > 64 || strings.HasSuffix(name, "-") || strings.HasSuffix(name, ".") {
-		return errors.Wrapf(errInvalidSecretName, "only 64 [a-zA-Z0-9-_.] characters allowed, and the start and end character must be [a-zA-Z0-9]: %s", name)
+		return errors.Wrapf(ErrInvalidSecretName, "only 64 [a-zA-Z0-9-_.] characters allowed, and the start and end character must be [a-zA-Z0-9]: %s", name)
 	}
 	return nil
 }
@@ -275,8 +277,8 @@ func getDriver(name string, opts map[string]string) (SecretsDriver, error) {
 		if path, ok := opts["path"]; ok {
 			return filedriver.NewDriver(path)
 		} else {
-			return nil, errors.Wrap(errInvalidDriverOpt, "need path for filedriver")
+			return nil, errors.Wrap(ErrInvalidDriverOpt, "need path for filedriver")
 		}
 	}
-	return nil, errInvalidDriver
+	return nil, ErrInvalidDriver
 }

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,12 +60,15 @@ func TestAddSecretName(t *testing.T) {
 	// name too short
 	_, err = manager.Store("", []byte("mydata"), drivertype, opts)
 	require.Error(t, err)
+	require.Equal(t, errors.Cause(err), ErrInvalidSecretName)
 	// name too long
 	_, err = manager.Store("uatqsbssrapurkuqoapubpifvsrissslzjehalxcesbhpxcvhsozlptrmngrivaiz", []byte("mydata"), drivertype, opts)
 	require.Error(t, err)
+	require.Equal(t, errors.Cause(err), ErrInvalidSecretName)
 	// invalid chars
 	_, err = manager.Store("??", []byte("mydata"), drivertype, opts)
 	require.Error(t, err)
+	require.Equal(t, errors.Cause(err), ErrInvalidSecretName)
 	_, err = manager.Store("-a", []byte("mydata"), drivertype, opts)
 	require.Error(t, err)
 	_, err = manager.Store("a-", []byte("mydata"), drivertype, opts)
@@ -119,6 +123,7 @@ func TestAddSecretDupName(t *testing.T) {
 
 	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, opts)
 	require.Error(t, err)
+	require.Equal(t, errors.Cause(err), ErrSecretNameInUse)
 }
 
 func TestAddSecretPrefix(t *testing.T) {
@@ -151,6 +156,7 @@ func TestRemoveSecret(t *testing.T) {
 
 	_, err = manager.lookupSecret("mysecret")
 	require.Error(t, err)
+	require.Equal(t, errors.Cause(err), ErrNoSuchSecret)
 
 	_, _, err = manager.LookupSecretData("mysecret")
 	require.Error(t, err)
@@ -163,6 +169,7 @@ func TestRemoveSecretNoExist(t *testing.T) {
 
 	_, err = manager.Delete("mysecret")
 	require.Error(t, err)
+	require.Equal(t, errors.Cause(err), ErrNoSuchSecret)
 }
 
 func TestLookupAllSecrets(t *testing.T) {
@@ -209,6 +216,7 @@ func TestInspectSecretBogus(t *testing.T) {
 
 	_, err = manager.Lookup("bogus")
 	require.Error(t, err)
+	require.Equal(t, errors.Cause(err), ErrNoSuchSecret)
 }
 
 func TestSecretList(t *testing.T) {

--- a/pkg/secrets/secretsdb.go
+++ b/pkg/secrets/secretsdb.go
@@ -71,21 +71,21 @@ func (s *SecretsManager) getNameAndID(nameOrID string) (name, id string, err err
 	name, id, err = s.getExactNameAndID(nameOrID)
 	if err == nil {
 		return name, id, nil
-	} else if errors.Cause(err) != errNoSuchSecret {
+	} else if errors.Cause(err) != ErrNoSuchSecret {
 		return "", "", err
 	}
 
 	// ID prefix may have been given, iterate through all IDs.
 	// ID and partial ID has a max lenth of 25, so we return if its greater than that.
 	if len(nameOrID) > secretIDLength {
-		return "", "", errors.Wrapf(errNoSuchSecret, "no secret with name or id %q", nameOrID)
+		return "", "", errors.Wrapf(ErrNoSuchSecret, "no secret with name or id %q", nameOrID)
 	}
 	exists := false
 	var foundID, foundName string
 	for id, name := range s.db.IDToName {
 		if strings.HasPrefix(id, nameOrID) {
 			if exists {
-				return "", "", errors.Wrapf(errAmbiguous, "more than one result secret with prefix %s", nameOrID)
+				return "", "", errors.Wrapf(ErrAmbiguous, "more than one result secret with prefix %s", nameOrID)
 			}
 			exists = true
 			foundID = id
@@ -96,7 +96,7 @@ func (s *SecretsManager) getNameAndID(nameOrID string) (name, id string, err err
 	if exists {
 		return foundName, foundID, nil
 	}
-	return "", "", errors.Wrapf(errNoSuchSecret, "no secret with name or id %q", nameOrID)
+	return "", "", errors.Wrapf(ErrNoSuchSecret, "no secret with name or id %q", nameOrID)
 }
 
 // getExactNameAndID takes a secret's name or ID and returns both its name and full ID.
@@ -115,7 +115,7 @@ func (s *SecretsManager) getExactNameAndID(nameOrID string) (name, id string, er
 		return name, id, nil
 	}
 
-	return "", "", errors.Wrapf(errNoSuchSecret, "no secret with name or id %q", nameOrID)
+	return "", "", errors.Wrapf(ErrNoSuchSecret, "no secret with name or id %q", nameOrID)
 }
 
 // exactSecretExists checks if the secret exists, given a name or ID
@@ -123,7 +123,7 @@ func (s *SecretsManager) getExactNameAndID(nameOrID string) (name, id string, er
 func (s *SecretsManager) exactSecretExists(nameOrID string) (bool, error) {
 	_, _, err := s.getExactNameAndID(nameOrID)
 	if err != nil {
-		if errors.Cause(err) == errNoSuchSecret {
+		if errors.Cause(err) == ErrNoSuchSecret {
 			return false, nil
 		}
 		return false, err
@@ -158,7 +158,7 @@ func (s *SecretsManager) lookupSecret(nameOrID string) (*Secret, error) {
 		return &secret, nil
 	}
 
-	return nil, errors.Wrapf(errNoSuchSecret, "no secret with name or id %q", nameOrID)
+	return nil, errors.Wrapf(ErrNoSuchSecret, "no secret with name or id %q", nameOrID)
 }
 
 // Store creates a new secret in the secrets database.


### PR DESCRIPTION
We want to be able to use these secrets constants from Buildah to
handle errors properly.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
