### PR TITLE
Stop logging messages about using DOCKER_CONFIG

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -22,9 +22,7 @@ import (
 func GetDefaultAuthFile() string {
 	authfile := os.Getenv("REGISTRY_AUTH_FILE")
 	if authfile == "" {
-		if authfile, ok := os.LookupEnv("DOCKER_CONFIG"); ok {
-			logrus.Infof("Using DOCKER_CONFIG environment variable for authfile path %s", authfile)
-		}
+		authfile = os.Getenv("DOCKER_CONFIG")
 	}
 	return authfile
 }


### PR DESCRIPTION
Since the GetDefaultAuthFile() is caused during podman init
it ends up logging the same info line multiple times, with
no way for the user to quiet the output.

Fixes https://github.com/containers/podman/issues/9473

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
