### PR TITLE
Remove `vendor` from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
 version: 2
 updates:
 - package-ecosystem: gomod
-  vendor: true
   directory: "/"
   schedule:
     interval: daily


### PR DESCRIPTION
The current config is marked as invalid by dependabot:

```
Dependabot encountered the following error when parsing your .github/dependabot.yml:

The property '#/updates/0/' contains additional properties ["vendor"] outside of the schema when none are allowed

Please update the config file to conform with Dependabot's specification.
```

The docs state something different, so I assume that there is a
implementation mismatch between the currently deployed version and the
docs.

In any case, the vendoring should work automagically.

Ref: https://github.com/containers/common/pull/474/checks?check_run_id=2076798700