### PR TITLE
capabilities: add new method BoundingSet()

### DIFF
--- a/pkg/capabilities/capabilities_test.go
+++ b/pkg/capabilities/capabilities_test.go
@@ -14,6 +14,12 @@ func TestAllCapabilities(t *testing.T) {
 	require.Nil(t, err)
 }
 
+func TestBoundingCapabilities(t *testing.T) {
+	caps, err := BoundingSet()
+	require.Nil(t, err)
+	assert.True(t, len(caps) > 0)
+}
+
 func TestMergeCapabilitiesDropVerify(t *testing.T) {
 	adds := []string{"CAP_SYS_ADMIN", "CAP_SETUID"}
 	drops := []string{"CAP_NET_ADMIN", "cap_chown"}

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.35.3-dev"
+const Version = "0.35.3"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.35.3"
+const Version = "0.35.4-dev"


### PR DESCRIPTION
add a new public function to retrieve all the capabilities in the
current bounding set.

This is useful for Podman to use only these capabilities when running
with --privileged as it can break running in a container where the
available capabilities can be a subset of the ones available in the
kernel.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
