### PR TITLE
capabilities: ALL returns the bounding set

### DIFF
--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -27,7 +27,7 @@ var (
 	ContainerImageLabels = []string{"io.containers.capabilities"}
 )
 
-// All is a special value used to add/drop all known capababilities.
+// All is a special value used to add/drop all known capabilities.
 // Useful on the CLI for `--cap-add=all` etc.
 const All = "ALL"
 
@@ -116,7 +116,7 @@ func ValidateCapabilities(caps []string) error {
 	return nil
 }
 
-// MergeCapabilities computes a set of capabilities by adding capapbitilities
+// MergeCapabilities computes a set of capabilities by adding capabilities
 // to or dropping them from base.
 //
 // Note that:
@@ -150,7 +150,7 @@ func MergeCapabilities(base, adds, drops []string) ([]string, error) {
 
 	if stringInSlice(All, capAdd) {
 		// "Add" all capabilities;
-		return capabilityList, nil
+		return BoundingSet()
 	}
 
 	for _, add := range capAdd {

--- a/pkg/capabilities/capabilities_test.go
+++ b/pkg/capabilities/capabilities_test.go
@@ -61,7 +61,9 @@ func TestMergeCapabilitiesAddAll(t *testing.T) {
 	drops := []string{}
 	caps, err := MergeCapabilities(base, adds, drops)
 	require.Nil(t, err)
-	assert.Equal(t, caps, AllCapabilities())
+	allCaps, err := BoundingSet()
+	require.Nil(t, err)
+	assert.Equal(t, caps, allCaps)
 }
 
 func TestNormalizeCapabilities(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -334,7 +334,9 @@ var _ = Describe("Config", func() {
 			caps, err = config.Capabilities("root", addcaps, dropcaps)
 			gomega.Expect(err).To(gomega.BeNil())
 			sort.Strings(caps)
-			gomega.Expect(caps).To(gomega.BeEquivalentTo(capabilities.AllCapabilities()))
+			boundingSet, err := capabilities.BoundingSet()
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(caps).To(gomega.BeEquivalentTo(boundingSet))
 
 			// Drop all caps
 			dropcaps = []string{"all"}


### PR DESCRIPTION
follow up to "capabilities: add new method BoundingSet()".

When ALL is used, limit it to the known capabilities in the bounding
set instead of ALL the known capabilities.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
