### PR TITLE
[NO TESTS NEEDED] Remove some stuttering on return errors

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -34,7 +34,7 @@ func CheckAuthFile(authfile string) error {
 		return nil
 	}
 	if _, err := os.Stat(authfile); err != nil {
-		return errors.Wrapf(err, "error checking authfile path %s", authfile)
+		return errors.Wrap(err, "checking authfile")
 	}
 	return nil
 }
@@ -70,11 +70,11 @@ func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginO
 		err    error
 	)
 	if len(args) > 1 {
-		return errors.Errorf("login accepts only one registry to login to")
+		return errors.New("login accepts only one registry to login to")
 	}
 	if len(args) == 0 {
 		if !opts.AcceptUnspecifiedRegistry {
-			return errors.Errorf("please provide a registry to login to")
+			return errors.New("please provide a registry to login to")
 		}
 		if server, err = defaultRegistryWhenUnspecified(systemContext); err != nil {
 			return err
@@ -85,7 +85,7 @@ func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginO
 	}
 	authConfig, err := config.GetCredentials(systemContext, server)
 	if err != nil {
-		return errors.Wrapf(err, "error reading auth file")
+		return errors.Wrap(err, "reading auth file")
 	}
 	if opts.GetLoginSet {
 		if authConfig.Username == "" {
@@ -95,17 +95,17 @@ func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginO
 		return nil
 	}
 	if authConfig.IdentityToken != "" {
-		return errors.Errorf("currently logged in, auth file contains an Identity token")
+		return errors.New("currently logged in, auth file contains an Identity token")
 	}
 
 	password := opts.Password
 	if opts.StdinPassword {
 		var stdinPasswordStrBuilder strings.Builder
 		if opts.Password != "" {
-			return errors.Errorf("Can't specify both --password-stdin and --password")
+			return errors.New("Can't specify both --password-stdin and --password")
 		}
 		if opts.Username == "" {
-			return errors.Errorf("Must provide --username with --password-stdin")
+			return errors.New("Must provide --username with --password-stdin")
 		}
 		scanner := bufio.NewScanner(opts.Stdin)
 		for scanner.Scan() {
@@ -126,7 +126,7 @@ func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginO
 
 	username, password, err := getUserAndPass(opts, password, authConfig.Username)
 	if err != nil {
-		return errors.Wrapf(err, "error getting username and password")
+		return errors.Wrap(err, "getting username and password")
 	}
 
 	if err = docker.CheckAuth(ctx, systemContext, username, password, server); err == nil {
@@ -143,7 +143,7 @@ func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginO
 		logrus.Debugf("error logging into %q: %v", server, unauthorized)
 		return errors.Errorf("error logging into %q: invalid username/password", server)
 	}
-	return errors.Wrapf(err, "error authenticating creds for %q", server)
+	return errors.Wrapf(err, "authenticating creds for %q", server)
 }
 
 // getRegistryName scrubs and parses the input to get the server name
@@ -172,7 +172,7 @@ func getUserAndPass(opts *LoginOptions, password, userFromAuthFile string) (user
 		}
 		username, err = reader.ReadString('\n')
 		if err != nil {
-			return "", "", errors.Wrapf(err, "error reading username")
+			return "", "", errors.Wrap(err, "reading username")
 		}
 		// If the user just hit enter, use the displayed user from the
 		// the authentication file.  This allows to do a lazy
@@ -186,7 +186,7 @@ func getUserAndPass(opts *LoginOptions, password, userFromAuthFile string) (user
 		fmt.Fprint(opts.Stdout, "Password: ")
 		pass, err := terminal.ReadPassword(0)
 		if err != nil {
-			return "", "", errors.Wrapf(err, "error reading password")
+			return "", "", errors.Wrap(err, "reading password")
 		}
 		password = string(pass)
 		fmt.Fprintln(opts.Stdout)
@@ -206,11 +206,11 @@ func Logout(systemContext *types.SystemContext, opts *LogoutOptions, args []stri
 		err    error
 	)
 	if len(args) > 1 {
-		return errors.Errorf("logout accepts only one registry to logout from")
+		return errors.New("logout accepts only one registry to logout from")
 	}
 	if len(args) == 0 && !opts.All {
 		if !opts.AcceptUnspecifiedRegistry {
-			return errors.Errorf("please provide a registry to logout from")
+			return errors.New("please provide a registry to logout from")
 		}
 		if server, err = defaultRegistryWhenUnspecified(systemContext); err != nil {
 			return err
@@ -219,7 +219,7 @@ func Logout(systemContext *types.SystemContext, opts *LogoutOptions, args []stri
 	}
 	if len(args) != 0 {
 		if opts.All {
-			return errors.Errorf("--all takes no arguments")
+			return errors.New("--all takes no arguments")
 		}
 		server = getRegistryName(args[0])
 	}
@@ -240,7 +240,7 @@ func Logout(systemContext *types.SystemContext, opts *LogoutOptions, args []stri
 	case config.ErrNotLoggedIn:
 		authConfig, err := config.GetCredentials(systemContext, server)
 		if err != nil {
-			return errors.Wrapf(err, "error reading auth file")
+			return errors.Wrap(err, "reading auth file")
 		}
 		authInvalid := docker.CheckAuth(context.Background(), systemContext, authConfig.Username, authConfig.Password, server)
 		if authConfig.Username != "" && authConfig.Password != "" && authInvalid == nil {
@@ -249,7 +249,7 @@ func Logout(systemContext *types.SystemContext, opts *LogoutOptions, args []stri
 		}
 		return errors.Errorf("Not logged into %s\n", server)
 	default:
-		return errors.Wrapf(err, "error logging out of %q", server)
+		return errors.Wrapf(err, "logging out of %q", server)
 	}
 }
 
@@ -258,10 +258,10 @@ func Logout(systemContext *types.SystemContext, opts *LogoutOptions, args []stri
 func defaultRegistryWhenUnspecified(systemContext *types.SystemContext) (string, error) {
 	registriesFromFile, err := sysregistriesv2.UnqualifiedSearchRegistries(systemContext)
 	if err != nil {
-		return "", errors.Wrapf(err, "error getting registry from registry.conf, please specify a registry")
+		return "", errors.Wrap(err, "getting registry from registry.conf, please specify a registry")
 	}
 	if len(registriesFromFile) == 0 {
-		return "", errors.Errorf("no registries found in registries.conf, a registry must be provided")
+		return "", errors.New("no registries found in registries.conf, a registry must be provided")
 	}
 	return registriesFromFile[0], nil
 }

--- a/pkg/chown/chown_unix.go
+++ b/pkg/chown/chown_unix.go
@@ -16,7 +16,7 @@ func ChangeHostPathOwnership(path string, recursive bool, uid, gid int) error {
 	// Validate if host path can be chowned
 	isDangerous, err := DangerousHostPath(path)
 	if err != nil {
-		return errors.Wrapf(err, "failed to validate if host path is dangerous")
+		return errors.Wrap(err, "failed to validate if host path is dangerous")
 	}
 
 	if isDangerous {
@@ -42,13 +42,13 @@ func ChangeHostPathOwnership(path string, recursive bool, uid, gid int) error {
 		})
 
 		if err != nil {
-			return errors.Wrapf(err, "failed to chown recursively host path")
+			return errors.Wrap(err, "failed to chown recursively host path")
 		}
 	} else {
 		// Get host path info
 		f, err := os.Lstat(path)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get host path information")
+			return errors.Wrap(err, "failed to get host path information")
 		}
 
 		// Get current ownership
@@ -57,7 +57,7 @@ func ChangeHostPathOwnership(path string, recursive bool, uid, gid int) error {
 
 		if uid != currentUID || gid != currentGID {
 			if err := os.Lchown(path, uid, gid); err != nil {
-				return errors.Wrapf(err, "failed to chown host path")
+				return errors.Wrap(err, "failed to chown host path")
 			}
 		}
 	}

--- a/pkg/chown/chown_windows.go
+++ b/pkg/chown/chown_windows.go
@@ -7,5 +7,5 @@ import (
 // ChangeHostPathOwnership changes the uid and gid ownership of a directory or file within the host.
 // This is used by the volume U flag to change source volumes ownership
 func ChangeHostPathOwnership(path string, recursive bool, uid, gid int) error {
-	return errors.Errorf("windows not supported")
+	return errors.New("windows not supported")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -465,14 +465,14 @@ func NewConfig(userConfigPath string) (*Config, error) {
 	// Now, gather the system configs and merge them as needed.
 	configs, err := systemConfigs()
 	if err != nil {
-		return nil, errors.Wrapf(err, "error finding config on system")
+		return nil, errors.Wrap(err, "finding config on system")
 	}
 	for _, path := range configs {
 		// Merge changes in later configs with the previous configs.
 		// Each config file that specified fields, will override the
 		// previous fields.
 		if err = readConfigFromFile(path, config); err != nil {
-			return nil, errors.Wrapf(err, "error reading system config %q", path)
+			return nil, errors.Wrapf(err, "reading system config %q", path)
 		}
 		logrus.Debugf("Merged system config %q: %+v", path, config)
 	}
@@ -484,7 +484,7 @@ func NewConfig(userConfigPath string) (*Config, error) {
 		// readConfigFromFile reads in container config in the specified
 		// file and then merge changes with the current default.
 		if err = readConfigFromFile(userConfigPath, config); err != nil {
-			return nil, errors.Wrapf(err, "error reading user config %q", userConfigPath)
+			return nil, errors.Wrapf(err, "reading user config %q", userConfigPath)
 		}
 		logrus.Debugf("Merged user config %q: %+v", userConfigPath, config)
 	}
@@ -504,7 +504,7 @@ func NewConfig(userConfigPath string) (*Config, error) {
 func readConfigFromFile(path string, config *Config) error {
 	logrus.Debugf("Reading configuration file %q", path)
 	if _, err := toml.DecodeFile(path, config); err != nil {
-		return errors.Wrapf(err, "unable to decode configuration %v", path)
+		return errors.Wrapf(err, "decode configuration %v", path)
 	}
 	return nil
 }
@@ -517,7 +517,7 @@ func systemConfigs() ([]string, error) {
 	path := os.Getenv("CONTAINERS_CONF")
 	if path != "" {
 		if _, err := os.Stat(path); err != nil {
-			return nil, errors.Wrapf(err, "failed to stat of %s from CONTAINERS_CONF environment variable", path)
+			return nil, errors.Wrap(err, "CONTAINERS_CONF file")
 		}
 		return append(configs, path), nil
 	}
@@ -579,7 +579,7 @@ func (c *Config) addCAPPrefix() {
 func (c *Config) Validate() error {
 
 	if err := c.Containers.Validate(); err != nil {
-		return errors.Wrapf(err, " error validating containers config")
+		return errors.Wrap(err, "validating containers config")
 	}
 
 	if !c.Containers.EnableLabeling {
@@ -587,11 +587,11 @@ func (c *Config) Validate() error {
 	}
 
 	if err := c.Engine.Validate(); err != nil {
-		return errors.Wrapf(err, "error validating engine configs")
+		return errors.Wrap(err, "validating engine configs")
 	}
 
 	if err := c.Network.Validate(); err != nil {
-		return errors.Wrapf(err, "error validating network configs")
+		return errors.Wrap(err, "validating network configs")
 	}
 
 	return nil
@@ -1001,7 +1001,7 @@ func (c *Config) Write() error {
 	}
 	configFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0600)
 	if err != nil {
-		return errors.Wrapf(err, "cannot open %s", path)
+		return err
 	}
 	defer configFile.Close()
 	enc := toml.NewEncoder(configFile)

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -331,10 +331,10 @@ func defaultTmpDir() (string, error) {
 
 	if err := os.Mkdir(libpodRuntimeDir, 0700|os.ModeSticky); err != nil {
 		if !os.IsExist(err) {
-			return "", errors.Wrapf(err, "cannot mkdir %s", libpodRuntimeDir)
+			return "", err
 		} else if err := os.Chmod(libpodRuntimeDir, 0700|os.ModeSticky); err != nil {
 			// The directory already exist, just set the sticky bit
-			return "", errors.Wrapf(err, "could not set sticky bit on %s", libpodRuntimeDir)
+			return "", errors.Wrap(err, "set sticky bit on")
 		}
 	}
 	return filepath.Join(libpodRuntimeDir, "tmp"), nil

--- a/pkg/config/util_supported.go
+++ b/pkg/config/util_supported.go
@@ -40,7 +40,7 @@ func getRuntimeDir() (string, error) {
 		if runtimeDir == "" {
 			tmpDir := filepath.Join("/run", "user", uid)
 			if err := os.MkdirAll(tmpDir, 0700); err != nil {
-				logrus.Debugf("unable to make temp dir %s", tmpDir)
+				logrus.Debugf("unable to make temp dir: %v", err)
 			}
 			st, err := os.Stat(tmpDir)
 			if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Geteuid() && st.Mode().Perm() == 0700 {
@@ -50,7 +50,7 @@ func getRuntimeDir() (string, error) {
 		if runtimeDir == "" {
 			tmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("run-%s", uid))
 			if err := os.MkdirAll(tmpDir, 0700); err != nil {
-				logrus.Debugf("unable to make temp dir %s", tmpDir)
+				logrus.Debugf("unable to make temp dir %v", err)
 			}
 			st, err := os.Stat(tmpDir)
 			if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Geteuid() && st.Mode().Perm() == 0700 {
@@ -65,7 +65,7 @@ func getRuntimeDir() (string, error) {
 			}
 			resolvedHome, err := filepath.EvalSymlinks(home)
 			if err != nil {
-				rootlessRuntimeDirError = errors.Wrapf(err, "cannot resolve %s", home)
+				rootlessRuntimeDirError = errors.Wrap(err, "cannot resolve home")
 				return
 			}
 			runtimeDir = filepath.Join(resolvedHome, "rundir")

--- a/pkg/formats/formats.go
+++ b/pkg/formats/formats.go
@@ -98,7 +98,7 @@ func (t StdoutTemplateArray) Out() error {
 		t.Template = strings.ReplaceAll(strings.TrimSpace(t.Template[5:]), " ", "\t")
 		headerTmpl, err := template.New("header").Funcs(headerFunctions).Parse(t.Template)
 		if err != nil {
-			return errors.Wrapf(err, parsingErrorStr)
+			return errors.Wrap(err, parsingErrorStr)
 		}
 		err = headerTmpl.Execute(w, t.Fields)
 		if err != nil {
@@ -109,12 +109,12 @@ func (t StdoutTemplateArray) Out() error {
 	t.Template = strings.ReplaceAll(t.Template, " ", "\t")
 	tmpl, err := template.New("image").Funcs(basicFunctions).Parse(t.Template)
 	if err != nil {
-		return errors.Wrapf(err, parsingErrorStr)
+		return errors.Wrap(err, parsingErrorStr)
 	}
 	for _, raw := range t.Output {
 		basicTmpl := tmpl.Funcs(basicFunctions)
 		if err := basicTmpl.Execute(w, raw); err != nil {
-			return errors.Wrapf(err, parsingErrorStr)
+			return errors.Wrap(err, parsingErrorStr)
 		}
 		fmt.Fprintln(w, "")
 	}
@@ -136,7 +136,7 @@ func (j JSONStruct) Out() error {
 func (t StdoutTemplate) Out() error {
 	tmpl, err := template.New("image").Parse(t.Template)
 	if err != nil {
-		return errors.Wrapf(err, "template parsing error")
+		return errors.Wrap(err, "template parsing error")
 	}
 	err = tmpl.Execute(os.Stdout, t.Output)
 	if err != nil {

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -138,11 +138,11 @@ func isValidDeviceMode(mode string) bool {
 // ValidateVolumeHostDir validates a volume mount's source directory
 func ValidateVolumeHostDir(hostDir string) error {
 	if hostDir == "" {
-		return errors.Errorf("host directory cannot be empty")
+		return errors.New("host directory cannot be empty")
 	}
 	if filepath.IsAbs(hostDir) {
 		if _, err := os.Stat(hostDir); err != nil {
-			return errors.Wrapf(err, "error checking path %q", hostDir)
+			return err
 		}
 	}
 	// If hostDir is not an absolute path, that means the user wants to create a
@@ -153,7 +153,7 @@ func ValidateVolumeHostDir(hostDir string) error {
 // ValidateVolumeCtrDir validates a volume mount's destination directory.
 func ValidateVolumeCtrDir(ctrDir string) error {
 	if ctrDir == "" {
-		return errors.Errorf("container directory cannot be empty")
+		return errors.New("container directory cannot be empty")
 	}
 	if !filepath.IsAbs(ctrDir) {
 		return errors.Errorf("invalid container path %q, must be an absolute path", ctrDir)

--- a/pkg/parse/parse_unix.go
+++ b/pkg/parse/parse_unix.go
@@ -22,7 +22,7 @@ func DeviceFromPath(device string) ([]devices.Device, error) {
 	}
 	srcInfo, err := os.Stat(src)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting info of source device %s", src)
+		return nil, err
 	}
 
 	if !srcInfo.IsDir() {


### PR DESCRIPTION
golang builtin OS functions, include the path to the object being used,
no reason for us to wrap these errors with an object for a second time.

This just causes stuttering, and looks bad at the CLI level.

Existing tests should catch any errors.

Also stop adding "error" to something that is obviusly an error when it
shows up to the user.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
