### PR TITLE
Add setns to default seccomp.json

### DIFF
--- a/pkg/seccomp/default_linux.go
+++ b/pkg/seccomp/default_linux.go
@@ -299,6 +299,7 @@ func DefaultProfile() *Seccomp {
 				"sendmmsg",
 				"sendmsg",
 				"sendto",
+				"setns",
 				"set_robust_list",
 				"set_thread_area",
 				"set_tid_address",

--- a/pkg/seccomp/seccomp.json
+++ b/pkg/seccomp/seccomp.json
@@ -303,6 +303,7 @@
 				"sendmmsg",
 				"sendmsg",
 				"sendto",
+				"setns",
 				"set_robust_list",
 				"set_thread_area",
 				"set_tid_address",


### PR DESCRIPTION
In order to run containers within containers via podman
and do a podman exec, we need to allow setns syscalls.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
