### PR TITLE
pkg/auth: Ensure DOCKER_CONFIG refers to config.json

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/containers/image/v5/docker"
@@ -20,11 +21,13 @@ import (
 // --authfile path used in multiple --authfile flag definitions
 // Will fail over to DOCKER_CONFIG if REGISTRY_AUTH_FILE environment is not set
 func GetDefaultAuthFile() string {
-	authfile := os.Getenv("REGISTRY_AUTH_FILE")
-	if authfile == "" {
-		authfile = os.Getenv("DOCKER_CONFIG")
+	if authfile := os.Getenv("REGISTRY_AUTH_FILE"); authfile != "" {
+		return authfile
 	}
-	return authfile
+	if auth_env := os.Getenv("DOCKER_CONFIG"); auth_env != "" {
+		return filepath.Join(auth_env, "config.json")
+	}
+	return ""
 }
 
 // CheckAuthFile validates filepath given by --authfile

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Config", func() {
 		It("validate GetDefaultAuthFile", func() {
 			// Given
 			oldDockerConf, envDockerSet := os.LookupEnv("DOCKER_CONFIG")
-			os.Setenv("DOCKER_CONFIG", "/tmp/docker.file")
+			os.Setenv("DOCKER_CONFIG", "/tmp")
 			oldConf, envSet := os.LookupEnv("REGISTRY_AUTH_FILE")
 			os.Setenv("REGISTRY_AUTH_FILE", "/tmp/registry.file")
 			// When			// When
@@ -26,7 +26,7 @@ var _ = Describe("Config", func() {
 			// Fall back to DOCKER_CONFIG
 			authFile = GetDefaultAuthFile()
 			// Then
-			gomega.Expect(authFile).To(gomega.BeEquivalentTo("/tmp/docker.file"))
+			gomega.Expect(authFile).To(gomega.BeEquivalentTo("/tmp/config.json"))
 			os.Unsetenv("DOCKER_CONFIG")
 
 			// Fall back to DOCKER_CONFIG


### PR DESCRIPTION
`REGISTRY_AUTH_FILE` expects a complete path to the authentication file,
however `DOCKER_CONFIG` only refers to a configuration directory. The
function would only return the directory itself and cause confusing
errors when passed onwards to `container/image`.

    $ DOCKER_CONFIG="/home/fox/.config/docker" podman pull docker.io/alpine
    Trying to pull docker.io/library/alpine:latest...
      read /home/fox/.config/docker: is a directory
    [...]
    $ DOCKER_CONFIG="/home/fox/.config/docker/config.json" podman pull docker.io/alpine
    Trying to pull docker.io/library/alpine:latest...
      open /home/fox/.config/docker/config.json/config.json: not a directory
    [...]

Signed-off-by: Morten Linderud <morten@linderud.pw>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
