### PR TITLE
Change log message in findRuntime()

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -608,7 +608,7 @@ func (c *EngineConfig) findRuntime() string {
 			}
 		}
 		if path, err := exec.LookPath(name); err == nil {
-			logrus.Warningf("Found default OCIruntime %s path which is missing from [engine.runtimes] in containers.conf", path)
+			logrus.Debugf("Found default OCI runtime %s path via PATH environment variable", path)
 			return name
 		}
 	}


### PR DESCRIPTION
Rephrase the log message and change the log level from
"warning" to "debug".

My comment https://github.com/containers/podman/issues/9389#issuecomment-782888578
explains why the log message
```
logrus.Warningf("Found default OCIruntime %s path which is missing from [engine.runtimes] in containers.conf", path)
```

 does not make sense.

(I don't know if it should be %s or %q in the format string. It was %s before so I left it like that)

Fixes: https://github.com/containers/podman/issues/9389

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
