### PR TITLE
config: suggest enable-linger only if euid != 0

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -556,7 +556,7 @@ func (c *Config) CheckCgroupsAndAdjustConfig() {
 		hasSession = err == nil
 	}
 
-	if !hasSession {
+	if !hasSession && unshare.GetRootlessUID() != 0 {
 		logrus.Warningf("The cgroupv2 manager is set to systemd but there is no systemd user session available")
 		logrus.Warningf("For using systemd, you may need to login using an user session")
 		logrus.Warningf("Alternatively, you can enable lingering with: `loginctl enable-linger %d` (possibly as root)", unshare.GetRootlessUID())


### PR DESCRIPTION
avoid an unuseful warning message when running Podman as root without
enough capabilities.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
