### PR TITLE
Add support for machine_enabled in containers.conf

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -388,6 +388,12 @@ Change the default only if you are sure of what you are doing, in general
 faster "shm" lock type.  You may need to run "podman system renumber" after you
 change the lock type.
 
+**machine_enabled**=false
+
+Indicates if Podman is running inside a VM via Podman Machine.
+Podman uses this value to do extra setup around networking from the
+container inside the VM to to host.
+
 **multi_image_archive**=false
 
 Allows for creating archives (e.g., tarballs) with more than one image.  Some container engines, such as Podman, interpret additional arguments as tags for one image and hence do not store more than one image.  The default behavior can be altered with this option.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -263,6 +263,9 @@ type EngineConfig struct {
 	// LockType is the type of locking to use.
 	LockType string `toml:"lock_type,omitempty"`
 
+	// MachineEnabled indicates if Podman is running in a podman-machine VM
+	MachineEnabled bool `toml:"machine_enabled,omitempty"`
+
 	// MultiImageArchive - if true, the container engine allows for storing
 	// archives (e.g., of the docker-archive transport) with multiple
 	// images.  By default, Podman creates single-image archives.

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -304,4 +304,16 @@ var _ = Describe("Config Local", func() {
 		// Then
 		gomega.Expect(err).NotTo(gomega.BeNil())
 	})
+
+	It("Set Machine Enabled", func() {
+		// Given
+		config, err := NewConfig("")
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config.Engine.MachineEnabled).To(gomega.Equal(false))
+		// When
+		config2, err := NewConfig("testdata/containers_default.conf")
+		// Then
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config2.Engine.MachineEnabled).To(gomega.Equal(true))
+	})
 })

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -336,6 +336,11 @@ default_sysctls = [
 #
 # lock_type** = "shm"
 
+# Indicates if Podman is running inside a VM via Podman Machine.
+# Podman uses this value to do extra setup around networking from the
+# container inside the VM to to host.
+# machine_enabled=false
+
 # MultiImageArchive - if true, the container engine allows for storing archives
 # (e.g., of the docker-archive transport) with multiple images.  By default,
 # Podman creates single-image archives.

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -314,6 +314,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	// TODO - ideally we should expose a `type LockType string` along with
 	// constants.
 	c.LockType = "shm"
+	c.MachineEnabled = false
 
 	return c, nil
 }
@@ -523,4 +524,8 @@ func (c *Config) Umask() string {
 // currently k8s-file or journald
 func (c *Config) LogDriver() string {
 	return c.Containers.LogDriver
+}
+
+func (c *Config) MachineEnabled() bool {
+	return c.Engine.MachineEnabled
 }

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -145,6 +145,7 @@ env = ["http_proxy=internal.proxy.company.com", "foo=bar"]
 # Directory for temporary files. Must be tmpfs (wiped after reboot)
 tmp_dir = "/run/libpod"
 
+machine_enabled = true
 
 # Whether to use chroot instead of pivot_root in the runtime
 no_pivot_root = false


### PR DESCRIPTION
machine_enabled is a bool that indicates if Podman is running in a
podman-machine VM

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
