### PR TITLE
add passdriver for secrets.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,6 +34,20 @@ testing_task:
     image: "${FEDORA_CONTAINER_FQIN}"
 
   test_script:
+    - apt-get update && apt-get -qq install libdevmapper-dev libbtrfs-dev libseccomp-dev
+    - |
+      cat >keyspec <<EOF
+      %echo Generating a default key
+      %no-protection
+      Key-Type: default
+      Subkey-Type: default
+      Name-Real: Tester
+      Name-Email: tester@localhost
+      Expire-Date: 0
+      %commit
+      %echo done
+      EOF
+    - gpg --batch --gen-key keyspec
     - make vendor
     - make build
     - make install.tools

--- a/pkg/secrets/passdriver/passdriver.go
+++ b/pkg/secrets/passdriver/passdriver.go
@@ -1,0 +1,173 @@
+package passdriver
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// errNoSecretData indicates that there is not data associated with an id
+	errNoSecretData = errors.New("no secret data with ID")
+
+	// errNoSecretData indicates that there is secret data already associated with an id
+	errSecretIDExists = errors.New("secret data with ID already exists")
+
+	// errInvalidKey indicates that something about your key is wrong
+	errInvalidKey = errors.New("invalid key")
+)
+
+type driverConfig struct {
+	// Root contains the root directory where the secrets are stored
+	Root string
+	// KeyID contains the key id that will be used for encryption (i.e. user@domain.tld)
+	KeyID string
+}
+
+func (cfg *driverConfig) ParseOpts(opts map[string]string) {
+	if val, ok := opts["root"]; ok {
+		cfg.Root = val
+		cfg.findGpgID() // try to find a .gpg-id in the parent directories of Root
+	}
+	if val, ok := opts["key"]; ok {
+		cfg.KeyID = val
+	}
+}
+
+func defaultDriverConfig() *driverConfig {
+	cfg := &driverConfig{}
+
+	if home, err := os.UserHomeDir(); err == nil {
+		defaultLocations := []string{
+			filepath.Join(home, ".password-store"),
+			filepath.Join(home, ".local/share/gopass/stores/root"),
+		}
+		for _, path := range defaultLocations {
+			if stat, err := os.Stat(path); err != nil || stat.IsDir() {
+				continue
+			}
+			cfg.Root = path
+			bs, err := ioutil.ReadFile(filepath.Join(path, ".gpg-id"))
+			if err != nil {
+				continue
+			}
+			cfg.KeyID = string(bs)
+			break
+		}
+	}
+
+	return cfg
+}
+
+func (cfg *driverConfig) findGpgID() {
+	path := cfg.Root
+	for len(path) > 1 {
+		if _, err := os.Stat(filepath.Join(path, ".gpg-id")); err == nil {
+			bs, err := ioutil.ReadFile(filepath.Join(path, ".gpg-id"))
+			if err != nil {
+				continue
+			}
+			cfg.KeyID = string(bs)
+			break
+		}
+		path = filepath.Dir(path)
+	}
+}
+
+// Driver is the passdriver object
+type Driver struct {
+	driverConfig
+}
+
+// NewDriver creates a new secret driver.
+func NewDriver(opts map[string]string) (*Driver, error) {
+	cfg := defaultDriverConfig()
+	cfg.ParseOpts(opts)
+
+	driver := &Driver{
+		driverConfig: *cfg,
+	}
+
+	return driver, nil
+}
+
+// List returns all secret IDs
+func (d *Driver) List() (secrets []string, err error) {
+	files, err := ioutil.ReadDir(d.Root)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read secret directory")
+	}
+	for _, f := range files {
+		secrets = append(secrets, f.Name())
+	}
+	sort.Strings(secrets)
+	return secrets, nil
+}
+
+// Lookup returns the bytes associated with a secret ID
+func (d *Driver) Lookup(id string) ([]byte, error) {
+	out := &bytes.Buffer{}
+	key, err := d.getPath(id)
+	if err != nil {
+		return nil, err
+	}
+	if err := d.gpg(context.TODO(), nil, out, "--decrypt", key); err != nil {
+		return nil, errors.Wrapf(errNoSecretData, id)
+	}
+	if out.Len() == 0 {
+		return nil, errors.Wrapf(errNoSecretData, id)
+	}
+	return out.Bytes(), nil
+}
+
+// Store saves the bytes associated with an ID. An error is returned if the ID already exists
+func (d *Driver) Store(id string, data []byte) error {
+	if _, err := d.Lookup(id); err == nil {
+		return errors.Wrap(errSecretIDExists, id)
+	}
+	in := bytes.NewReader(data)
+	key, err := d.getPath(id)
+	if err != nil {
+		return err
+	}
+	return d.gpg(context.TODO(), in, nil, "--encrypt", "-r", d.KeyID, "-o", key)
+}
+
+// Delete removes the secret associated with the specified ID.  An error is returned if no matching secret is found.
+func (d *Driver) Delete(id string) error {
+	key, err := d.getPath(id)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(key); err != nil {
+		return errors.Wrap(errNoSecretData, id)
+	}
+	return nil
+}
+
+func (d *Driver) gpg(ctx context.Context, in io.Reader, out io.Writer, args ...string) error {
+	cmd := exec.CommandContext(ctx, "gpg", args...)
+	cmd.Stdin = in
+	cmd.Stdout = out
+	cmd.Stderr = io.Discard
+	return cmd.Run()
+}
+
+func (d *Driver) getPath(id string) (string, error) {
+	path, err := filepath.Abs(filepath.Join(d.Root, id))
+	if err != nil {
+		return "", errInvalidKey
+	}
+	if !strings.HasPrefix(path, d.Root) {
+		return "", errInvalidKey
+	}
+	return path, nil
+}

--- a/pkg/secrets/passdriver/passdriver_test.go
+++ b/pkg/secrets/passdriver/passdriver_test.go
@@ -1,0 +1,174 @@
+package passdriver
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+const gpgTestID = "tester@localhost"
+
+func setupDriver(t *testing.T) (driver *Driver, cleanup func()) {
+	base, err := ioutil.TempDir(os.TempDir(), "pass-test")
+	require.NoError(t, err)
+	driver, err = NewDriver(map[string]string{
+		"root": base,
+		"key":  gpgTestID,
+	})
+	require.NoError(t, err)
+	return driver, func() { os.RemoveAll(base) }
+}
+
+func TestStoreAndLookup(t *testing.T) {
+	cases := []struct {
+		name         string
+		key          string
+		value        []byte
+		expStoreErr  error
+		expLookupErr error
+	}{
+		{
+			name:  "store and lookup work for a simple key",
+			key:   "simple",
+			value: []byte("abc"),
+		},
+		{
+			name:  "store and lookup work for a multiline string",
+			key:   "long",
+			value: []byte("abc\n123\ndef\n"),
+		},
+		{
+			name:  "store and lookup work for non-utf8 data",
+			key:   "long",
+			value: []byte{0, 1, 2, 3, 0, 1, 2, 3},
+		},
+		{
+			name:        "storing into a sneaky key fails",
+			key:         "../../../sneaky",
+			value:       []byte("abc"),
+			expStoreErr: errInvalidKey,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			driver, cleanup := setupDriver(t)
+			defer cleanup()
+			err := driver.Store(tc.key, tc.value)
+			if tc.expStoreErr != nil {
+				require.Error(t, err)
+				require.Equal(t, tc.expStoreErr.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+				val, err := driver.Lookup(tc.key)
+				if tc.expLookupErr != nil {
+					require.Error(t, err)
+					require.Equal(t, tc.expLookupErr.Error(), err.Error())
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, tc.value, val)
+				}
+			}
+		})
+	}
+}
+
+func TestLookup(t *testing.T) {
+	driver, cleanup := setupDriver(t)
+	defer cleanup()
+
+	// prepare a valid lookup target
+	err := driver.Store("valid", []byte("abc"))
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		key      string
+		expValue []byte
+		expErr   error
+	}{
+		{
+			name:     "lookup of an existing key works",
+			key:      "valid",
+			expValue: []byte("abc"),
+		},
+		{
+			name:   "lookup of a non-existing key fails",
+			key:    "invalid",
+			expErr: errors.Wrap(errNoSecretData, "invalid"),
+		},
+		{
+			name:   "lookup of a sneaky key fails",
+			key:    "../../../etc/shadow",
+			expErr: errInvalidKey,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			val, err := driver.Lookup(tc.key)
+			if tc.expErr == nil {
+				require.Equal(t, tc.expValue, val)
+			} else {
+				require.EqualError(t, err, tc.expErr.Error())
+			}
+		})
+	}
+}
+
+func TestList(t *testing.T) {
+	driver, cleanup := setupDriver(t)
+	defer cleanup()
+	require.NoError(t, driver.Store("a", []byte("abc")))
+	require.NoError(t, driver.Store("b", []byte("abc")))
+	require.NoError(t, driver.Store("c", []byte("abc")))
+
+	list, err := driver.List()
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b", "c"}, list)
+}
+
+func TestDelete(t *testing.T) {
+	driver, cleanup := setupDriver(t)
+	defer cleanup()
+	require.NoError(t, driver.Store("a", []byte("abc")))
+
+	cases := []struct {
+		name   string
+		key    string
+		expErr error
+	}{
+		{
+			name: "deleting an existing item works",
+			key:  "a",
+		},
+		{
+			name:   "deleting an non-existing item fails",
+			key:    "wrong",
+			expErr: errors.Wrap(errNoSecretData, "wrong"),
+		},
+		{
+			name:   "using a sneaky path fails",
+			key:    "../../../etc/shadow",
+			expErr: errInvalidKey,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := driver.Delete(tc.key)
+			if tc.expErr != nil {
+				require.EqualError(t, err, tc.expErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/containers/common/pkg/secrets/filedriver"
+	"github.com/containers/common/pkg/secrets/passdriver"
 	"github.com/containers/storage/pkg/lockfile"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/pkg/errors"
@@ -271,12 +272,15 @@ func validateSecretName(name string) error {
 
 // getDriver creates a new driver.
 func getDriver(name string, opts map[string]string) (SecretsDriver, error) {
-	if name == "file" {
+	switch name {
+	case "file":
 		if path, ok := opts["path"]; ok {
 			return filedriver.NewDriver(path)
 		} else {
 			return nil, errors.Wrap(errInvalidDriverOpt, "need path for filedriver")
 		}
+	case "pass":
+		return passdriver.NewDriver(opts)
 	}
 	return nil, errInvalidDriver
 }


### PR DESCRIPTION
This adds a `passdriver` subpackage to the secrets management package. It is compatible with `gopass`or `pass`to store and retrieve secrets.

`pass`and `gopass`are two small command line based password managers. `pass` is the original one and is just a shell script which makes it easy to store and retrieve passwords from gpg encrypted local files. `gopass`is a rewrite of it in go which adds some nice features (like integrating git)

Here is the website of the `pass`project: https://www.passwordstore.org/
And here for `gopath`:  https://github.com/gopasspw/gopass

This driver can be configured by two options `root`and `key`.
`root`specifies the directory where the secrets are stored. If it is a subdirectory of or directly a already initialized password store, the `key`is automatically set to the key of that password store. The `key`is a gpg key identifier, so it can be either the fingerprint of the key (for example `A69FF8CE27511970CF35B6A9E326C094E58DE77F`) or an email address.

When storing a secret the driver creates a gpg encrypted file for the receiver `key`in `root`.

These config options allow us to do different things:
a) have a totally seperate secret store for containers, even if the user is not using `pass`or `gopass`
b) specify `root` in a subdirectory of the users password store, so the user can manage the secrets using its favorite tools
c) specify `root`as the password store, so even pre-existing secrets can be reused

A problem with c) is that the current validation for secret keys forbids `/`and therefore it wouldn't be possible to get secrets from subdirectories of the password store. 

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
