### PR TITLE
Swap default logging to journald

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -175,7 +175,7 @@ the container.
 
 Indicates whether the container engine uses MAC(SELinux) container separation via labeling. This option is ignored on disabled systems.
 
-**log_driver**="k8s-file"
+**log_driver**="journald"
 
 Logging driver for the container. Available options: `k8s-file` and `journald`.
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -283,6 +283,7 @@ var _ = Describe("Config", func() {
 			gomega.Expect(config.Network.CNIPluginDirs).To(gomega.Equal(pluginDirs))
 			gomega.Expect(config.Engine.NumLocks).To(gomega.BeEquivalentTo(2048))
 			gomega.Expect(config.Engine.OCIRuntimes["runc"]).To(gomega.Equal(OCIRuntimeMap["runc"]))
+			gomega.Expect(config.LogDriver()).To(gomega.Equal("journald"))
 		})
 
 		It("should success with valid user file path", func() {

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -157,7 +157,7 @@ default_sysctls = [
 
 # Logging driver for the container. Available options: k8s-file and journald.
 #
-# log_driver = "k8s-file"
+# log_driver = "journald"
 
 # Maximum size allowed for the container log file. Negative numbers indicate
 # that no size limit is imposed. If positive, it must be >= 8192 to match or

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -102,7 +102,7 @@ const (
 	// SystemdCgroupsManager represents systemd native cgroup manager
 	SystemdCgroupsManager = "systemd"
 	// DefaultLogDriver is the default type of log files
-	DefaultLogDriver = "k8s-file"
+	DefaultLogDriver = "journald"
 	// DefaultLogSizeMax is the default value for the maximum log size
 	// allowed for a container. Negative values mean that no limit is imposed.
 	DefaultLogSizeMax = -1


### PR DESCRIPTION
This eliminates the concern of log files growing infinitely and also
records all containers for posterity rather then allowing the removal
of a container to destroy the record.

Partially fixes: https://github.com/containers/podman/issues/9158

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
