### PR TITLE
Add support for creating default CNI network

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -270,6 +270,11 @@ List of paths to directories where CNI plugin binaries are located.
 
 The network name of the default CNI network to attach pods to.
 
+**default_subnet**="10.88.0.0/16"
+
+The subnet to use for the default CNI network (named above in **default_network**).
+If the default network does not exist, it will be automatically created the first time a tool is run using this subnet.
+
 **network_config_dir**="/etc/cni/net.d/"
 
 Path to the directory where CNI configuration files are located.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -425,6 +425,12 @@ type NetworkConfig struct {
 	// to attach pods to.
 	DefaultNetwork string `toml:"default_network,omitempty"`
 
+	// DefaultSubnet is the subnet to be used for the default CNI network.
+	// If a network with the name given in DefaultNetwork is not present
+	// then a new network using this subnet will be created.
+	// Must be a valid IPv4 CIDR block.
+	DefaultSubnet string `toml:"default_subnet,omitempty"`
+
 	// NetworkConfigDir is where CNI network configuration files are stored.
 	NetworkConfigDir string `toml:"network_config_dir,omitempty"`
 }

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -243,6 +243,12 @@ default_sysctls = [
 # The network name of the default CNI network to attach pods to.
 # default_network = "podman"
 
+# The default subnet for the default CNI network given in default_network.
+# If a network with that name does not exist, a new network using that name and
+# this subnet will be created.
+# Must be a valid IPv4 CIDR prefix.
+#default_subnet = "10.88.0.0/16"
+
 # Path to the directory where CNI configuration files are located.
 #
 # network_config_dir = "/etc/cni/net.d/"

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -114,6 +114,9 @@ const (
 	// DefaultSignaturePolicyPath is the default value for the
 	// policy.json file.
 	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
+	// DefaultSubnet is the subnet that will be used for the default CNI
+	// network.
+	DefaultSubnet = "10.88.0.0/16"
 	// DefaultRootlessSignaturePolicyPath is the location within
 	// XDG_CONFIG_HOME of the rootless policy.json file.
 	DefaultRootlessSignaturePolicyPath = "containers/policy.json"
@@ -204,6 +207,7 @@ func DefaultConfig() (*Config, error) {
 		},
 		Network: NetworkConfig{
 			DefaultNetwork:   "podman",
+			DefaultSubnet:    DefaultSubnet,
 			NetworkConfigDir: cniConfig,
 			CNIPluginDirs:    cniBinDir,
 		},

--- a/pkg/defaultnet/default_network.go
+++ b/pkg/defaultnet/default_network.go
@@ -1,0 +1,207 @@
+package defaultnet
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"text/template"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// TODO: A smarter implementation would make sure cni-podman0 was unused before
+// making the default, and adjust if necessary
+const networkTemplate = `{
+  "cniVersion": "0.4.0",
+  "name": "{{{{.Name}}}}",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni-podman0",
+      "isGateway": true,
+      "ipMasq": true,
+      "hairpinMode": true,
+      "ipam": {
+        "type": "host-local",
+        "routes": [{ "dst": "0.0.0.0/0" }],
+        "ranges": [
+          [
+            {
+              "subnet": "{{{{.Subnet}}}}",
+              "gateway": "{{{{.Gateway}}}}"
+            }
+          ]
+        ]
+      }
+    },
+{{{{- if (eq .Machine true) }}}}
+    {
+      "type": "podman-machine",
+      "capabilities": {
+        "portMappings": true
+      }
+    },
+{{{{- end}}}}
+    {
+      "type": "portmap",
+      "capabilities": {
+        "portMappings": true
+      }
+    },
+    {
+      "type": "firewall"
+    },
+    {
+      "type": "tuning"
+    }
+  ]
+}
+`
+
+var (
+	// Borrowed from Podman, modified to remove dashes and periods.
+	nameRegex = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_]*$")
+)
+
+// Used to pass info into the template engine
+type networkInfo struct {
+	Name    string
+	Subnet  string
+	Gateway string
+	Machine bool
+}
+
+// The most trivial definition of a CNI network possible for our use here.
+// We need the name, and nothing else.
+type network struct {
+	Name string `json:"name"`
+}
+
+// Create makes the CNI default network, if necessary.
+// Accepts the name and subnet of the network to create (a standard template
+// will be used, with these values plugged in), the configuration directory
+// where CNI configs are stored (to verify if a named configuration already
+// exists), an exists directory (where a sentinel file will be stored, to ensure
+// the network is only made once), and an isMachine bool (to determine whether
+// the machine block will be added to the config).
+// Create first checks if a default network has already been created via the
+// presence of a sentinel file. If it does exist, it returns immediately without
+// error.
+// It next checks if a CNI network with the given name already exists. In that
+// case, it creates the sentinel file and returns without error.
+// If neither of these are true, the default network is created.
+func Create(name, subnet, configDir, existsDir string, isMachine bool) error {
+	// TODO: Should probably regex name to make sure it's valid.
+	if name == "" || subnet == "" || configDir == "" || existsDir == "" {
+		return errors.Errorf("must provide values for all arguments to MakeDefaultNetwork")
+	}
+	if !nameRegex.MatchString(name) {
+		return errors.Errorf("invalid default network name %s - letters, numbers, and underscores only", name)
+	}
+
+	sentinelFile := filepath.Join(existsDir, "defaultCNINetExists")
+
+	// Check if sentinel file exists, return immediately if it does.
+	if _, err := os.Stat(sentinelFile); err == nil {
+		return nil
+	}
+
+	// Create the sentinel file if it doesn't exist, so subsequent checks
+	// don't need to go further.
+	file, err := os.Create(sentinelFile)
+	if err != nil {
+		return err
+	}
+	file.Close()
+
+	// Check all networks in the CNI conflist.
+	files, err := ioutil.ReadDir(configDir)
+	if err != nil {
+		return errors.Wrapf(err, "error reading CNI configuration directory")
+	}
+	if len(files) > 0 {
+		configPaths := make([]string, 0, len(files))
+		for _, path := range files {
+			if !path.IsDir() && filepath.Ext(path.Name()) == ".conflist" {
+				configPaths = append(configPaths, filepath.Join(configDir, path.Name()))
+			}
+		}
+		for _, config := range configPaths {
+			configName, err := getConfigName(config)
+			if err != nil {
+				logrus.Errorf("Error reading CNI configuration file: %v", err)
+				continue
+			}
+			if configName == name {
+				return nil
+			}
+		}
+	}
+
+	// We need to make the config.
+	// Get subnet and gateway.
+	gw, ipNet, err := net.ParseCIDR(subnet)
+	if err != nil {
+		return errors.Wrapf(err, "default network subnet %s is invalid", subnet)
+	}
+
+	netInfo := new(networkInfo)
+	netInfo.Name = name
+	netInfo.Gateway = gw.String()
+	netInfo.Subnet = ipNet.String()
+	netInfo.Machine = isMachine
+
+	templ, err := template.New("network_template").Delims("{{{{", "}}}}").Parse(networkTemplate)
+	if err != nil {
+		return errors.Wrapf(err, "error compiling template for default network")
+	}
+	var output bytes.Buffer
+	if err := templ.Execute(&output, netInfo); err != nil {
+		return errors.Wrapf(err, "error executing template for default network")
+	}
+
+	// Next, we need to place the config on disk.
+	// Loop through possible indexes, with a limit of 100 attempts.
+	created := false
+	for i := 87; i < 187; i++ {
+		configFile, err := os.OpenFile(filepath.Join(configDir, fmt.Sprintf("%d-%s.conflist", i, name)), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+		if err != nil {
+			logrus.Infof("Attempt to create default CNI network config file failed: %v", err)
+			continue
+		}
+		defer configFile.Close()
+
+		created = true
+
+		// Success - file is open. Write our buffer to it.
+		if _, err := configFile.Write(output.Bytes()); err != nil {
+			return errors.Wrapf(err, "error writing default CNI config to file")
+		}
+		break
+	}
+	if !created {
+		return errors.Errorf("no available default network configuration file was found")
+	}
+
+	return nil
+}
+
+// Get the name of the configuration contained in a given conflist file. Accepts
+// the full path of a .conflist CNI configuration.
+func getConfigName(file string) (string, error) {
+	contents, err := ioutil.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+	config := new(network)
+	if err := json.Unmarshal(contents, config); err != nil {
+		return "", errors.Wrapf(err, "error decoding CNI configuration %s", filepath.Base(file))
+	}
+	return config.Name, nil
+}


### PR DESCRIPTION
There are two changes here: firstly, add the ability to specify a subnet for the default CNI network in containers.conf; and secondly, add a package that can be consumed by Buildah and Podman to create said default network. This will allow us to stop shipping a default Podman CNI network, and instead dynamically create it on demand.