### PR TITLE
libimage: add an events system

### DIFF
--- a/libimage/load.go
+++ b/libimage/load.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"time"
 
 	dirTransport "github.com/containers/image/v5/directory"
 	dockerArchiveTransport "github.com/containers/image/v5/docker/archive"
@@ -22,6 +23,8 @@ type LoadOptions struct {
 // oci, oci-archive, dir, docker-archive.
 func (r *Runtime) Load(ctx context.Context, path string, options *LoadOptions) ([]string, error) {
 	logrus.Debugf("Loading image from %q", path)
+
+	r.writeEvent(&Event{ID: "", Name: path, Time: time.Now(), Type: EventTypeImageLoad})
 
 	var (
 		loadedImages []string

--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -3,6 +3,7 @@ package libimage
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/containers/common/libimage/manifests"
 	imageCopy "github.com/containers/image/v5/copy"
@@ -362,6 +363,10 @@ func (m *ManifestList) Push(ctx context.Context, destination string, options *Ma
 		if err != nil {
 			return "", oldErr
 		}
+	}
+
+	if m.image.runtime.eventChannel != nil {
+		m.image.runtime.writeEvent(&Event{ID: m.ID(), Name: destination, Time: time.Now(), Type: EventTypeImagePush})
 	}
 
 	// NOTE: we're using the logic in copier to create a proper

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/containers/common/pkg/config"
 	dirTransport "github.com/containers/image/v5/directory"
@@ -78,6 +79,10 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 
 	if options.AllTags && ref.Transport().Name() != dockerTransport.Transport.Name() {
 		return nil, errors.Errorf("pulling all tags is not supported for %s transport", ref.Transport().Name())
+	}
+
+	if r.eventChannel != nil {
+		r.writeEvent(&Event{ID: "", Name: name, Time: time.Now(), Type: EventTypeImagePull})
 	}
 
 	var (

--- a/libimage/push.go
+++ b/libimage/push.go
@@ -2,6 +2,7 @@ package libimage
 
 import (
 	"context"
+	"time"
 
 	dockerArchiveTransport "github.com/containers/image/v5/docker/archive"
 	"github.com/containers/image/v5/docker/reference"
@@ -59,6 +60,10 @@ func (r *Runtime) Push(ctx context.Context, source, destination string, options 
 			return nil, err
 		}
 		destRef = dockerRef
+	}
+
+	if r.eventChannel != nil {
+		r.writeEvent(&Event{ID: image.ID(), Name: destination, Time: time.Now(), Type: EventTypeImagePush})
 	}
 
 	// Buildah compat: Make sure to tag the destination image if it's a

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -20,6 +20,9 @@ import (
 
 // RuntimeOptions allow for creating a customized Runtime.
 type RuntimeOptions struct {
+	// The base system context of the runtime which will be used throughout
+	// the entire lifespan of the Runtime.  Certain options in some
+	// functions may override specific fields.
 	SystemContext *types.SystemContext
 }
 
@@ -41,6 +44,8 @@ func setRegistriesConfPath(systemContext *types.SystemContext) {
 // Runtime is responsible for image management and storing them in a containers
 // storage.
 type Runtime struct {
+	// Use to send events out to users.
+	eventChannel chan *Event
 	// Underlying storage store.
 	store storage.Store
 	// Global system context.  No pointer to simplify copying and modifying
@@ -53,6 +58,18 @@ func (r *Runtime) systemContextCopy() *types.SystemContext {
 	var sys types.SystemContext
 	deepcopy.Copy(&sys, &r.systemContext)
 	return &sys
+}
+
+// EventChannel creates a buffered channel for events that the Runtime will use
+// to write events to.  Callers are expected to read from the channel in a
+// timely manner.
+// Can be called once for a given Runtime.
+func (r *Runtime) EventChannel() chan *Event {
+	if r.eventChannel != nil {
+		return r.eventChannel
+	}
+	r.eventChannel = make(chan *Event, 100)
+	return r.eventChannel
 }
 
 // RuntimeFromStore returns a Runtime for the specified store.
@@ -99,6 +116,7 @@ func RuntimeFromStoreOptions(runtimeOptions *RuntimeOptions, storeOptions *stora
 // is considered to be an error condition.
 func (r *Runtime) Shutdown(force bool) error {
 	_, err := r.store.Shutdown(force)
+	close(r.eventChannel)
 	return err
 }
 

--- a/libimage/save.go
+++ b/libimage/save.go
@@ -3,6 +3,7 @@ package libimage
 import (
 	"context"
 	"strings"
+	"time"
 
 	dirTransport "github.com/containers/image/v5/directory"
 	dockerArchiveTransport "github.com/containers/image/v5/docker/archive"
@@ -72,6 +73,10 @@ func (r *Runtime) saveSingleImage(ctx context.Context, name, format, path string
 	image, imageName, err := r.LookupImage(name, nil)
 	if err != nil {
 		return err
+	}
+
+	if r.eventChannel != nil {
+		r.writeEvent(&Event{ID: image.ID(), Name: path, Time: time.Now(), Type: EventTypeImageSave})
 	}
 
 	// Unless the image was referenced by ID, use the resolved name as a
@@ -160,6 +165,9 @@ func (r *Runtime) saveDockerArchive(ctx context.Context, names []string, path st
 			}
 		}
 		localImages[image.ID()] = local
+		if r.eventChannel != nil {
+			r.writeEvent(&Event{ID: image.ID(), Name: path, Time: time.Now(), Type: EventTypeImageSave})
+		}
 	}
 
 	writer, err := dockerArchiveTransport.NewWriter(r.systemContextCopy(), path)


### PR DESCRIPTION
Add an event system to libimage.  Callers can opt-in to using events by
requesting an event channel via `(*Runtime).EventChannel()`.  The
returned channel has a buffer of size 100 which should be sufficient
even under high loads.  But, to be on the safe side, writing an event
will time out after 2 seconds to prevent operations from blocking.

Currently, the only user of such an event system is Podman which will
need to convert the `Event` type to what's used internally in libpod.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
