### PR TITLE
fix image tree

### DIFF
--- a/libimage/image_tree.go
+++ b/libimage/image_tree.go
@@ -35,36 +35,45 @@ func (i *Image) Tree(traverseChildren bool) (string, error) {
 		fmt.Fprintf(sb, "No Image Layers")
 	}
 
-	tree := gotree.New(sb.String())
-
 	layerTree, err := i.runtime.layerTree()
 	if err != nil {
 		return "", err
 	}
-
 	imageNode := layerTree.node(i.TopLayer())
 
 	// Traverse the entire tree down to all children.
 	if traverseChildren {
+		tree := gotree.New(sb.String())
 		if err := imageTreeTraverseChildren(imageNode, tree); err != nil {
 			return "", err
 		}
-	} else {
-		// Walk all layers of the image and assemlbe their data.
-		for parentNode := imageNode; parentNode != nil; parentNode = parentNode.parent {
-			if parentNode.layer == nil {
-				break // we're done
-			}
-			var tags string
-			repoTags, err := parentNode.repoTags()
-			if err != nil {
-				return "", err
-			}
-			if len(repoTags) > 0 {
-				tags = fmt.Sprintf(" Top Layer of: %s", repoTags)
-			}
-			tree.Add(fmt.Sprintf("ID: %s Size: %7v%s", parentNode.layer.ID[:12], units.HumanSizeWithPrecision(float64(parentNode.layer.UncompressedSize), 4), tags))
+		return tree.Print(), nil
+	}
+
+	// Walk all layers of the image and assemlbe their data.  Note that the
+	// tree is constructed in reverse order to remain backwards compatible
+	// with Podman.
+	contents := []string{}
+	for parentNode := imageNode; parentNode != nil; parentNode = parentNode.parent {
+		if parentNode.layer == nil {
+			break // we're done
 		}
+		var tags string
+		repoTags, err := parentNode.repoTags()
+		if err != nil {
+			return "", err
+		}
+		if len(repoTags) > 0 {
+			tags = fmt.Sprintf(" Top Layer of: %s", repoTags)
+		}
+		content := fmt.Sprintf("ID: %s Size: %7v%s", parentNode.layer.ID[:12], units.HumanSizeWithPrecision(float64(parentNode.layer.UncompressedSize), 4), tags)
+		contents = append(contents, content)
+	}
+	contents = append(contents, sb.String())
+
+	tree := gotree.New(contents[len(contents)-1])
+	for i := len(contents) - 2; i >= 0; i-- {
+		tree.Add(contents[i])
 	}
 
 	return tree.Print(), nil
@@ -80,14 +89,22 @@ func imageTreeTraverseChildren(node *layerNode, parent gotree.Tree) error {
 		tags = fmt.Sprintf(" Top Layer of: %s", repoTags)
 	}
 
-	newNode := parent.Add(fmt.Sprintf("ID: %s Size: %7v%s", node.layer.ID[:12], units.HumanSizeWithPrecision(float64(node.layer.UncompressedSize), 4), tags))
+	content := fmt.Sprintf("ID: %s Size: %7v%s", node.layer.ID[:12], units.HumanSizeWithPrecision(float64(node.layer.UncompressedSize), 4), tags)
 
-	if len(node.children) <= 1 {
-		newNode = parent
+	var newTree gotree.Tree
+	if node.parent == nil || len(node.parent.children) <= 1 {
+		// No parent or no siblings, so we can go linear.
+		parent.Add(content)
+		newTree = parent
+	} else {
+		// Each siblings gets a new tree, so we can branch.
+		newTree = gotree.New(content)
+		parent.AddTree(newTree)
 	}
+
 	for i := range node.children {
 		child := node.children[i]
-		if err := imageTreeTraverseChildren(child, newNode); err != nil {
+		if err := imageTreeTraverseChildren(child, newTree); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
To remain backwards compatible with the old behavior of Podman, we need
to print the layers in the reverse order.  Also make sure that we branch
correctly when `traversChildren` is true (`--whatrequires` in Podman).

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>
