### PR TITLE
libimage: restore the ability to pull from docker-daemon and tarball

### DIFF
--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -8,13 +8,15 @@ import (
 
 	"github.com/containers/common/pkg/config"
 	dirTransport "github.com/containers/image/v5/directory"
-	dockerTransport "github.com/containers/image/v5/docker"
+	dockerRegistryTransport "github.com/containers/image/v5/docker"
 	dockerArchiveTransport "github.com/containers/image/v5/docker/archive"
+	dockerDaemonTransport "github.com/containers/image/v5/docker/daemon"
 	"github.com/containers/image/v5/docker/reference"
 	ociArchiveTransport "github.com/containers/image/v5/oci/archive"
 	ociTransport "github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/pkg/shortnames"
 	storageTransport "github.com/containers/image/v5/storage"
+	tarballTransport "github.com/containers/image/v5/tarball"
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
@@ -76,7 +78,7 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 		ref = dockerRef
 	}
 
-	if options.AllTags && ref.Transport().Name() != dockerTransport.Transport.Name() {
+	if options.AllTags && ref.Transport().Name() != dockerRegistryTransport.Transport.Name() {
 		return nil, errors.Errorf("pulling all tags is not supported for %s transport", ref.Transport().Name())
 	}
 
@@ -88,9 +90,13 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 	// Dispatch the copy operation.
 	switch ref.Transport().Name() {
 
-	// DOCKER/REGISTRY
-	case dockerTransport.Transport.Name():
+	// DOCKER REGISTRY
+	case dockerRegistryTransport.Transport.Name():
 		pulledImages, pullError = r.copyFromRegistry(ctx, ref, strings.TrimPrefix(name, "docker://"), pullPolicy, options)
+
+	// DOCKER DAEMON
+	case dockerDaemonTransport.Transport.Name():
+		pulledImages, pullError = r.copyFromDefault(ctx, ref, &options.CopyOptions)
 
 	// DOCKER ARCHIVE
 	case dockerArchiveTransport.Transport.Name():
@@ -98,6 +104,10 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 
 	// OCI
 	case ociTransport.Transport.Name():
+		pulledImages, pullError = r.copyFromDefault(ctx, ref, &options.CopyOptions)
+
+	// TARBALL
+	case tarballTransport.Transport.Name():
 		pulledImages, pullError = r.copyFromDefault(ctx, ref, &options.CopyOptions)
 
 	// OCI ARCHIVE
@@ -275,7 +285,7 @@ func (r *Runtime) copyFromRegistry(ctx context.Context, ref types.ImageReference
 	}
 
 	named := reference.TrimNamed(ref.DockerReference())
-	tags, err := dockerTransport.GetRepositoryTags(ctx, &r.systemContext, ref)
+	tags, err := dockerRegistryTransport.GetRepositoryTags(ctx, &r.systemContext, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +409,7 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 	for _, candidate := range resolved.PullCandidates {
 		candidateString := candidate.Value.String()
 		logrus.Debugf("Attempting to pull candidate %s for %s", candidateString, imageName)
-		srcRef, err := dockerTransport.NewReference(candidate.Value)
+		srcRef, err := dockerRegistryTransport.NewReference(candidate.Value)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Dropping support for these would be a regression in tools that switch to this library.  We'd have noticed earlier, but buildah's integration tests that try pulling from `docker-daemon` sources (basically, those touched by https://github.com/containers/buildah/pull/3171) get skipped when there's no dockerd available, and the CI environments that run its integration tests apparently don't currently include a dockerd.