### PR TITLE
Fix images tagged by 64 chars cannot be pulled when "docker://" prefix is ommitted

### DIFF
--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -58,7 +58,7 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 	if err != nil {
 		// If the image clearly refers to a local one, we can look it up directly.
 		// In fact, we need to since they are not parseable.
-		if strings.HasPrefix(name, "sha256:") || (len(name) == 64 && !strings.Contains(name, "/.:@")) {
+		if strings.HasPrefix(name, "sha256:") || (len(name) == 64 && !strings.ContainsAny(name, "/.:@")) {
 			if pullPolicy == config.PullPolicyAlways {
 				return nil, errors.Errorf("pull policy is always but image has been referred to by ID (%s)", name)
 			}


### PR DESCRIPTION
Recently images tagged by 64 chars cannot be pulled (e.g. length of `ghcr.io/stargz-containers/tomcat:10.0.0-jdk15-openjdk-buster-org` is 64).

```console
$ podman pull ghcr.io/stargz-containers/tomcat:10.0.0-jdk15-openjdk-buster-org
Error: pull policy is always but image has been referred to by ID (ghcr.io/stargz-containers/tomcat:10.0.0-jdk15-openjdk-buster-org)
```

This is because strings.Contains() is used where strings.ContainsAny() should be used.
This commit fixes this issue.

Please see also:

https://golang.org/pkg/strings/#Contains

> func Contains(s, substr string) bool
> Contains reports whether substr is within s.

https://golang.org/pkg/strings/#ContainsAny

> func ContainsAny(s, chars string) bool
> ContainsAny reports whether any Unicode code points in chars are within s. 
