### PR TITLE
pull: simplify transports switch

### DIFF
--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/containers/common/pkg/config"
 	dirTransport "github.com/containers/image/v5/directory"
-	dockerTransport "github.com/containers/image/v5/docker"
+	registryTransport "github.com/containers/image/v5/docker"
 	dockerArchiveTransport "github.com/containers/image/v5/docker/archive"
 	"github.com/containers/image/v5/docker/reference"
 	ociArchiveTransport "github.com/containers/image/v5/oci/archive"
@@ -76,7 +76,7 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 		ref = dockerRef
 	}
 
-	if options.AllTags && ref.Transport().Name() != dockerTransport.Transport.Name() {
+	if options.AllTags && ref.Transport().Name() != registryTransport.Transport.Name() {
 		return nil, errors.Errorf("pulling all tags is not supported for %s transport", ref.Transport().Name())
 	}
 
@@ -89,7 +89,7 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 	switch ref.Transport().Name() {
 
 	// DOCKER REGISTRY
-	case dockerTransport.Transport.Name():
+	case registryTransport.Transport.Name():
 		pulledImages, pullError = r.copyFromRegistry(ctx, ref, strings.TrimPrefix(name, "docker://"), pullPolicy, options)
 
 	// DOCKER ARCHIVE
@@ -265,7 +265,7 @@ func (r *Runtime) copyFromRegistry(ctx context.Context, ref types.ImageReference
 	}
 
 	named := reference.TrimNamed(ref.DockerReference())
-	tags, err := dockerTransport.GetRepositoryTags(ctx, &r.systemContext, ref)
+	tags, err := registryTransport.GetRepositoryTags(ctx, &r.systemContext, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +389,7 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 	for _, candidate := range resolved.PullCandidates {
 		candidateString := candidate.Value.String()
 		logrus.Debugf("Attempting to pull candidate %s for %s", candidateString, imageName)
-		srcRef, err := dockerTransport.NewReference(candidate.Value)
+		srcRef, err := registryTransport.NewReference(candidate.Value)
 		if err != nil {
 			return nil, err
 		}

--- a/libimage/search.go
+++ b/libimage/search.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	dockerTransport "github.com/containers/image/v5/docker"
+	registryTransport "github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
@@ -193,7 +193,7 @@ func (r *Runtime) searchImageInRegistry(ctx context.Context, term, registry stri
 		return results, nil
 	}
 
-	results, err := dockerTransport.SearchRegistry(ctx, sys, registry, term, limit)
+	results, err := registryTransport.SearchRegistry(ctx, sys, registry, term, limit)
 	if err != nil {
 		return []SearchResult{}, err
 	}
@@ -255,7 +255,7 @@ func (r *Runtime) searchImageInRegistry(ctx context.Context, term, registry stri
 func searchRepositoryTags(ctx context.Context, sys *types.SystemContext, registry, term string, options *SearchOptions) ([]SearchResult, error) {
 	dockerPrefix := "docker://"
 	imageRef, err := alltransports.ParseImageName(fmt.Sprintf("%s/%s", registry, term))
-	if err == nil && imageRef.Transport().Name() != dockerTransport.Transport.Name() {
+	if err == nil && imageRef.Transport().Name() != registryTransport.Transport.Name() {
 		return nil, errors.Errorf("reference %q must be a docker reference", term)
 	} else if err != nil {
 		imageRef, err = alltransports.ParseImageName(fmt.Sprintf("%s%s", dockerPrefix, fmt.Sprintf("%s/%s", registry, term)))
@@ -263,7 +263,7 @@ func searchRepositoryTags(ctx context.Context, sys *types.SystemContext, registr
 			return nil, errors.Errorf("reference %q must be a docker reference", term)
 		}
 	}
-	tags, err := dockerTransport.GetRepositoryTags(ctx, sys, imageRef)
+	tags, err := registryTransport.GetRepositoryTags(ctx, sys, imageRef)
 	if err != nil {
 		return nil, errors.Errorf("error getting repository tags: %v", err)
 	}
@@ -288,18 +288,18 @@ func searchRepositoryTags(ctx context.Context, sys *types.SystemContext, registr
 	return paramsArr, nil
 }
 
-func (f *SearchFilter) matchesStarFilter(result dockerTransport.SearchResult) bool {
+func (f *SearchFilter) matchesStarFilter(result registryTransport.SearchResult) bool {
 	return result.StarCount >= f.Stars
 }
 
-func (f *SearchFilter) matchesAutomatedFilter(result dockerTransport.SearchResult) bool {
+func (f *SearchFilter) matchesAutomatedFilter(result registryTransport.SearchResult) bool {
 	if f.IsAutomated != types.OptionalBoolUndefined {
 		return result.IsAutomated == (f.IsAutomated == types.OptionalBoolTrue)
 	}
 	return true
 }
 
-func (f *SearchFilter) matchesOfficialFilter(result dockerTransport.SearchResult) bool {
+func (f *SearchFilter) matchesOfficialFilter(result registryTransport.SearchResult) bool {
 	if f.IsOfficial != types.OptionalBoolUndefined {
 		return result.IsOfficial == (f.IsOfficial == types.OptionalBoolTrue)
 	}


### PR DESCRIPTION
Simplify the transports-sensitive dispatcher when pulling images and use
the default case for transports that do not require special casing.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
