### PR TITLE
Mount the whole crypto-policies directory

### DIFF
--- a/pkg/subscriptions/subscriptions.go
+++ b/pkg/subscriptions/subscriptions.go
@@ -335,14 +335,14 @@ func addFIPSModeSubscription(mounts *[]rspec.Mount, containerWorkingDir, mountPo
 		*mounts = append(*mounts, m)
 	}
 
-	srcBackendDir := "/usr/share/crypto-policies/back-ends/FIPS"
-	destDir := "/etc/crypto-policies/back-ends"
+	srcBackendDir := "/usr/share/crypto-policies"
+	destDir := "/etc/crypto-policies"
 	srcOnHost := filepath.Join(mountPoint, srcBackendDir)
 	if _, err := os.Stat(srcOnHost); err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return errors.Wrap(err, "FIPS Backend directory")
+		return errors.Wrap(err, "crypto-policies directory")
 	}
 
 	if !mountExists(*mounts, destDir) {


### PR DESCRIPTION
To correctly determine the crypto-policy being used
in the container with the update-crypto-policies command
it needs access to durectories such as python under
/usr/share/crypto-policies. Since we were only bind mounting
the FIPS/backends directory, it was returning that the DEFAULT
policy is being used in the container even though the container
is actually in FIPS mode.
Change the bind mount to mount /usr/share/crypto-policies to
/etc/crypto-policies in the container and the correct crypto-policy
is returned with the update-crypto-policies --show command.

Helps fix https://bugzilla.redhat.com/show_bug.cgi?id=1957310

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
