### PR TITLE
libimage: fix pull from dir

### DIFF
--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/containers/common/pkg/config"
-	dirTransport "github.com/containers/image/v5/directory"
 	registryTransport "github.com/containers/image/v5/docker"
 	dockerArchiveTransport "github.com/containers/image/v5/docker/archive"
 	"github.com/containers/image/v5/docker/reference"
@@ -100,8 +99,6 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 	// DOCKER ARCHIVE
 	case dockerArchiveTransport.Transport.Name():
 		pulledImages, pullError = r.copyFromDockerArchive(ctx, ref, &options.CopyOptions)
-
-	case dirTransport.Transport.Name():
 
 	// ALL OTHER TRANSPORTS
 	default:


### PR DESCRIPTION
The recent refactoring introduced a bug yielding a pull from the dir
transport a NOP.  I will soon add unit tests for that.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
