### PR TITLE
[NO TESTS NEEDED] Fix reading configs on mac and windows

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -532,11 +532,11 @@ func systemConfigs() ([]string, error) {
 	if _, err := os.Stat(OverrideContainersConfig); err == nil {
 		configs = append(configs, OverrideContainersConfig)
 	}
-	if unshare.IsRootless() {
-		path, err := rootlessConfigPath()
-		if err != nil {
-			return nil, err
-		}
+	path, err := ifRootlessConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	if path != "" {
 		if _, err := os.Stat(path); err == nil {
 			configs = append(configs, path)
 		}

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -4,9 +4,14 @@ import (
 	"os"
 )
 
+// podman remote clients on darwin cannot use unshare.isRootless() to determine the configuration file locations.
 func customConfigFile() (string, error) {
 	if path, found := os.LookupEnv("CONTAINERS_CONF"); found {
 		return path, nil
 	}
+	return rootlessConfigPath()
+}
+
+func ifRootlessConfigPath() (string, error) {
 	return rootlessConfigPath()
 }

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -24,3 +24,14 @@ func customConfigFile() (string, error) {
 	}
 	return OverrideContainersConfig, nil
 }
+
+func ifRootlessConfigPath() (string, error) {
+	if unshare.IsRootless() {
+		path, err := rootlessConfigPath()
+		if err != nil {
+			return "", err
+		}
+		return path, nil
+	}
+	return "", nil
+}

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -2,9 +2,14 @@ package config
 
 import "os"
 
+// podman remote clients on windows cannot use unshare.isRootless() to determine the configuration file locations.
 func customConfigFile() (string, error) {
 	if path, found := os.LookupEnv("CONTAINERS_CONF"); found {
 		return path, nil
 	}
+	return os.Getenv("APPDATA") + "\\containers\\containers.conf", nil
+}
+
+func ifRootlessConfigPath() (string, error) {
 	return os.Getenv("APPDATA") + "\\containers\\containers.conf", nil
 }


### PR DESCRIPTION
On Mac and Windows, automtically read default rootless config location, since
unshare.IsRootless doesn't work.

Should fix when vendored in: https://github.com/containers/podman/issues/9535

[NO TESTS NEEDED] because we still don't test on Mac/Windows :(

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
