### PR TITLE
libimage: add push tests

### DIFF
--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -162,6 +162,14 @@ func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference,
 			storageName = imageName
 		}
 
+	case storageTransport.Transport.Name():
+		storageName = ref.StringWithinTransport()
+		named := ref.DockerReference()
+		if named == nil {
+			return nil, errors.Errorf("could not get an image name for storage reference %q", ref)
+		}
+		imageName = named.String()
+
 	default:
 		storageName = toLocalImageName(ref.StringWithinTransport())
 		imageName = storageName
@@ -170,7 +178,7 @@ func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference,
 	// Create a storage reference.
 	destRef, err := storageTransport.Transport.ParseStoreReference(r.store, storageName)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "parsing %q", storageName)
 	}
 
 	_, err = c.copy(ctx, ref, destRef)

--- a/libimage/push_test.go
+++ b/libimage/push_test.go
@@ -1,0 +1,68 @@
+package libimage
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/containers/common/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPush(t *testing.T) {
+	runtime, cleanup := testNewRuntime(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Prefetch alpine.
+	pullOptions := &PullOptions{}
+	pullOptions.Writer = os.Stdout
+	_, err := runtime.Pull(ctx, "docker.io/library/alpine:latest", config.PullPolicyAlways, pullOptions)
+	require.NoError(t, err)
+
+	pushOptions := &PushOptions{}
+	pushOptions.Writer = os.Stdout
+
+	workdir, err := ioutil.TempDir("", "libimagepush")
+	require.NoError(t, err)
+	defer os.RemoveAll(workdir)
+
+	for _, test := range []struct {
+		source      string
+		destination string
+		expectError bool
+	}{
+		{"alpine", "dir:" + workdir + "/dir", false},
+		{"alpine", "oci:" + workdir + "/oci", false},
+		{"alpine", "oci-archive:" + workdir + "/oci-archive", false},
+		{"alpine", "docker-archive:" + workdir + "/docker-archive", false},
+		{"alpine", "containers-storage:localhost/another:alpine", false},
+	} {
+		_, err := runtime.Push(ctx, test.source, test.destination, pushOptions)
+		if test.expectError {
+			require.Error(t, err, "%v", test)
+			continue
+		}
+		require.NoError(t, err, "%v", test)
+		pulledImages, err := runtime.Pull(ctx, test.destination, config.PullPolicyAlways, pullOptions)
+		require.NoError(t, err, "%v", test)
+		require.Len(t, pulledImages, 1, "%v", test)
+	}
+
+	// Now there should only be two images: alpine in Docker format and
+	// alpine in OCI format.
+	listedImages, err := runtime.ListImages(ctx, nil, nil)
+	require.NoError(t, err, "error listing images")
+	require.Len(t, listedImages, 2, "there should only be two images (alpine in Docke/OCI)")
+
+	// And now remove all of them.
+	rmReports, rmErrors := runtime.RemoveImages(ctx, nil, nil)
+	require.Len(t, rmErrors, 0)
+	require.Len(t, rmReports, 2)
+
+	for i, image := range listedImages {
+		require.Equal(t, image.ID(), rmReports[i].ID)
+		require.True(t, rmReports[i].Removed)
+	}
+}

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -550,7 +550,7 @@ func (r *Runtime) RemoveImages(ctx context.Context, names []string, options *Rem
 			return nil, rmErrors
 		}
 
-	case len(options.Filters) > 0:
+	default:
 		filteredImages, err := r.ListImages(ctx, nil, &ListImagesOptions{Filters: options.Filters})
 		if err != nil {
 			appendError(err)


### PR DESCRIPTION
Add tests for exercising pushing images to various transports and
attempt to pull from the destinations.

Fix an error determining the storage reference and image name when
pushing to containers-storage.

Fix a bug in `RemoveImages`: leaving `names` empty and specifying no
filters should remove *all* images.

Please note that the tests are currently not exercising pushing to a
registry.  That requires a local registry but since CI is currently
running inside a container, we cannot do much just yet.  Once CI runs
in another environment, I will go back and extend the tests.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
