### PR TITLE
adjust log-driver defaults

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -175,7 +175,7 @@ the container.
 
 Indicates whether the container engine uses MAC(SELinux) container separation via labeling. This option is ignored on disabled systems.
 
-**log_driver**="journald"
+**log_driver**="k8s-file"
 
 Logging driver for the container. Available options: `k8s-file` and `journald`.
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -292,7 +292,7 @@ var _ = Describe("Config", func() {
 			gomega.Expect(config.Network.CNIPluginDirs).To(gomega.Equal(pluginDirs))
 			gomega.Expect(config.Engine.NumLocks).To(gomega.BeEquivalentTo(2048))
 			gomega.Expect(config.Engine.OCIRuntimes["runc"]).To(gomega.Equal(OCIRuntimeMap["runc"]))
-			gomega.Expect(config.LogDriver()).To(gomega.Equal("journald"))
+			gomega.Expect(config.LogDriver()).To(gomega.Equal("k8s-file"))
 		})
 
 		It("should success with valid user file path", func() {

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -157,7 +157,7 @@ default_sysctls = [
 
 # Logging driver for the container. Available options: k8s-file and journald.
 #
-# log_driver = "journald"
+log_driver = "journald"
 
 # Maximum size allowed for the container log file. Negative numbers indicate
 # that no size limit is imposed. If positive, it must be >= 8192 to match or

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -102,7 +102,7 @@ const (
 	// SystemdCgroupsManager represents systemd native cgroup manager
 	SystemdCgroupsManager = "systemd"
 	// DefaultLogDriver is the default type of log files
-	DefaultLogDriver = "journald"
+	DefaultLogDriver = "k8s-file"
 	// DefaultLogSizeMax is the default value for the maximum log size
 	// allowed for a container. Negative values mean that no limit is imposed.
 	DefaultLogSizeMax = -1


### PR DESCRIPTION
Commit 98ff7e145c2c changed the default logging driver k8s-file to
journald.  The only consumer of the log-driver is Podman which I think
still needs some more time to stabilize.  Vendoring containers/common
into Podman has revealed quite some warts (see
containers/podman/pull/10222) which reduced my confidence level.

To resolve the chicken-egg-problem of maturing the journald driver, I
want to only partially revert commit 98ff7e145c2c.  The built-in default
remains k8s-file while the containers.conf sets it to journald.  The
intention behind is to make sure that running systems are not impacted
but we can change Fedora to journald to increase coverage.

Once the confidence level is back to normal, we can change the default
to journald.  Latest before RHEL9.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

As discussed in yesterday's meeting: @rhatdan @containers/podman-maintainers PTAL
