### PR TITLE
Fix handling of all capabilities

### DIFF
--- a/pkg/capabilities/capabilities_test.go
+++ b/pkg/capabilities/capabilities_test.go
@@ -21,12 +21,12 @@ func TestBoundingCapabilities(t *testing.T) {
 }
 
 func TestMergeCapabilitiesDropVerify(t *testing.T) {
-	adds := []string{"CAP_SYS_ADMIN", "CAP_SETUID"}
+	adds := []string{"CAP_SETUID", "CAP_SYS_ADMIN"}
 	drops := []string{"CAP_NET_ADMIN", "cap_chown"}
 	base := []string{"CHOWN"}
 	caps, err := MergeCapabilities(base, adds, drops)
 	require.Nil(t, err)
-	assert.Equal(t, []string{"CAP_SYS_ADMIN", "CAP_SETUID"}, caps)
+	assert.Equal(t, []string{"CAP_SETUID", "CAP_SYS_ADMIN"}, caps)
 }
 
 func TestMergeCapabilitiesDropAddConflict(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMergeCapabilitiesDrop(t *testing.T) {
 }
 
 func TestMergeCapabilitiesDropAll(t *testing.T) {
-	adds := []string{"CAP_SYS_ADMIN", "CAP_NET_ADMIN", "CAP_CHOWN"}
+	adds := []string{"CAP_CHOWN", "CAP_NET_ADMIN", "CAP_SYS_ADMIN"}
 	drops := []string{"all"}
 	base := []string{"CAP_SETUID"}
 	caps, err := MergeCapabilities(base, adds, drops)
@@ -64,6 +64,21 @@ func TestMergeCapabilitiesAddAll(t *testing.T) {
 	allCaps, err := BoundingSet()
 	require.Nil(t, err)
 	assert.Equal(t, caps, allCaps)
+
+	drops = []string{"CAP_SETUID", "CAP_CHOWN"}
+	caps, err = MergeCapabilities(base, adds, drops)
+	require.Nil(t, err)
+	assert.NotEqual(t, caps, allCaps)
+	assert.False(t, stringInSlice("CAP_SETUID", caps))
+	assert.False(t, stringInSlice("CAP_CHOWN", caps))
+}
+
+func TestMergeCapabilitiesAddAllDropAll(t *testing.T) {
+	base := []string{"CAP_SYS_ADMIN", "CAP_NET_ADMIN", "CAP_CHOWN"}
+	adds := []string{"all"}
+	drops := []string{"all"}
+	_, err := MergeCapabilities(base, adds, drops)
+	assert.Error(t, err)
 }
 
 func TestNormalizeCapabilities(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -359,7 +359,7 @@ var _ = Describe("Config", func() {
 
 			// Drop all caps
 			dropcaps = []string{"all"}
-			caps, err = config.Capabilities("", addcaps, dropcaps)
+			caps, err = config.Capabilities("", boundingSet, dropcaps)
 			gomega.Expect(err).To(gomega.BeNil())
 			sort.Strings(caps)
 			gomega.Expect(caps).ToNot(gomega.BeEquivalentTo([]string{}))


### PR DESCRIPTION
You should be able to specify --cap-add=all --cap-drop=cap_perfmon
And end up with all capabilties except cap_perfmon.

You should not be allowed to specify --cap-add all --cap-drop all

The outcome would be undefined.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
