### PR TITLE
containers.conf: don't set default logging driver

### DIFF
--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -157,7 +157,7 @@ default_sysctls = [
 
 # Logging driver for the container. Available options: k8s-file and journald.
 #
-log_driver = "journald"
+# log_driver = "k8s-file"
 
 # Maximum size allowed for the container log file. Negative numbers indicate
 # that no size limit is imposed. If positive, it must be >= 8192 to match or


### PR DESCRIPTION
After experimenting with defaulting to journald as the default logging
driver, we have reverted to k8s-file in the built-in defaults in memory
but left journald the default in the containers.conf.

To prevent surprised in downstream packaging which may pick up the
containers.conf file, let's revert it as well.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan @containers/podman-maintainers PTAL

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
