### PR TITLE
libimage: push: ignore image platform

### DIFF
--- a/libimage/push.go
+++ b/libimage/push.go
@@ -29,8 +29,10 @@ func (r *Runtime) Push(ctx context.Context, source, destination string, options 
 		options = &PushOptions{}
 	}
 
-	// Look up the local image.
-	image, resolvedSource, err := r.LookupImage(source, nil)
+	// Look up the local image.  Note that we need to ignore the platform
+	// and push what the user specified (containers/podman/issues/10344).
+	lookupOptions := &LookupImageOptions{IgnorePlatform: true}
+	image, resolvedSource, err := r.LookupImage(source, lookupOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -244,10 +244,7 @@ func (r *Runtime) lookupImageInLocalStorage(name, candidate string, options *Loo
 	}
 
 	image := r.storageToImage(img, ref)
-	if options.IgnorePlatform {
-		logrus.Debugf("Found image %q as %q in local containers storage", name, candidate)
-		return image, nil
-	}
+	logrus.Debugf("Found image %q as %q in local containers storage", name, candidate)
 
 	// If we referenced a manifest list, we need to check whether we can
 	// find a matching instance in the local containers storage.
@@ -256,6 +253,7 @@ func (r *Runtime) lookupImageInLocalStorage(name, candidate string, options *Loo
 		return nil, err
 	}
 	if isManifestList {
+		logrus.Debugf("Candidate %q is a manifest list, looking up matching instance", candidate)
 		manifestList, err := image.ToManifestList()
 		if err != nil {
 			return nil, err
@@ -268,6 +266,10 @@ func (r *Runtime) lookupImageInLocalStorage(name, candidate string, options *Loo
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if options.IgnorePlatform {
+		return image, nil
 	}
 
 	matches, err := imageReferenceMatchesContext(context.Background(), ref, &r.systemContext)


### PR DESCRIPTION
When pushing an image, make sure to ignore the platform of the image to
push exactly what the user wishes to.  Add a test to make sure we're not
regressing in the future.

To preserve previous behaviour with respect to attempting to push a
manifest list, move the platform check below resolving to a manifest
list.

Fixes: #containers/podman/issues/10344
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
