### PR TITLE
libimage: fix manifest list lookup

### DIFF
--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -19,6 +19,10 @@ import (
 // NOTE: the abstractions and APIs here are a first step to further merge
 // `libimage/manifests` into `libimage`.
 
+// ErrNotAManifestList indicates that an image was found in the local
+// containers storage but it is not a manifest list as requested.
+var ErrNotAManifestList = errors.New("image is not a manifest list")
+
 // ManifestList represents a manifest list (Docker) or an image index (OCI) in
 // the local containers storage.
 type ManifestList struct {
@@ -73,7 +77,11 @@ func (r *Runtime) LookupManifestList(name string) (*ManifestList, error) {
 }
 
 func (r *Runtime) lookupManifestList(name string) (*Image, manifests.List, error) {
-	image, _, err := r.LookupImage(name, &LookupImageOptions{IgnorePlatform: true})
+	lookupOptions := &LookupImageOptions{
+		IgnorePlatform: true,
+		lookupManifest: true,
+	}
+	image, _, err := r.LookupImage(name, lookupOptions)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/libimage/manifest_list_test.go
+++ b/libimage/manifest_list_test.go
@@ -1,0 +1,40 @@
+package libimage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containers/common/pkg/config"
+	"github.com/containers/storage"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateManifestList(t *testing.T) {
+	runtime, cleanup := testNewRuntime(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	list, err := runtime.CreateManifestList("mylist")
+	require.NoError(t, err)
+	require.NotNil(t, list)
+	initialID := list.ID()
+
+	list, err = runtime.LookupManifestList("mylist")
+	require.NoError(t, err)
+	require.NotNil(t, list)
+	require.Equal(t, initialID, list.ID())
+
+	_, rmErrors := runtime.RemoveImages(ctx, []string{"mylist"}, nil)
+	require.Nil(t, rmErrors)
+
+	_, err = runtime.LookupManifestList("nosuchthing")
+	require.Error(t, err)
+	require.Equal(t, errors.Cause(err), storage.ErrImageUnknown)
+
+	_, err = runtime.Pull(ctx, "busybox", config.PullPolicyMissing, nil)
+	require.NoError(t, err)
+	_, err = runtime.LookupManifestList("busybox")
+	require.Error(t, err)
+	require.Equal(t, errors.Cause(err), ErrNotAManifestList)
+}


### PR DESCRIPTION
Commit b623a24c43b0 fixed an issue when pushing images from of a
platform different than the current machine.  That required to disable
the platform matching logic when looking up the image before pushing it.
It also required some restructuring of the code such that manifest lists
are resolved and their instances looked up.

The restructuring in turn introduced a regression when looking up bare
manifest lists.  To fix the regression and keep the code simple,
introduce an internal field in the LookupImageOptions that indicates
whether we're looking up a bare manifest list or not.

Now we have clearer separation of concerns between looking up images or
manfifests and whether the looked up image needs to match the current
platform or not.

Add some unit tests exercising the manifest-list code to make sure we're
not regressing again.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
