### PR TITLE
WIP - libimage: block on events

### DIFF
--- a/libimage/events.go
+++ b/libimage/events.go
@@ -52,11 +52,9 @@ func (r *Runtime) writeEvent(event *Event) {
 	select {
 	case r.eventChannel <- event:
 		// Done
-	case <-time.After(2 * time.Second):
-		// The Runtime's event channel has a buffer of size 100 which
-		// should be enough even under high load.  However, we
-		// shouldn't block too long in case the buffer runs full (could
-		// be an honest user error or bug).
+	case <-time.After(10 * time.Second):
+		// Set the timeout to a very high value to account for a
+		// worst-case I/O.  However, we shouldn't wait until infinity.
 		logrus.Warnf("Discarding libimage event which was not read within 2 seconds: %v", event)
 	}
 }

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -60,15 +60,14 @@ func (r *Runtime) systemContextCopy() *types.SystemContext {
 	return &sys
 }
 
-// EventChannel creates a buffered channel for events that the Runtime will use
-// to write events to.  Callers are expected to read from the channel in a
-// timely manner.
-// Can be called once for a given Runtime.
+// EventChannel creates a channel for events that the Runtime will use to write
+// events to.  Callers are expected to read from the channel in a timely
+// manner.
 func (r *Runtime) EventChannel() chan *Event {
 	if r.eventChannel != nil {
 		return r.eventChannel
 	}
-	r.eventChannel = make(chan *Event, 100)
+	r.eventChannel = make(chan *Event)
 	return r.eventChannel
 }
 


### PR DESCRIPTION
Debugging containers/podman/pull/10219 has revealed a number of issues
with respect to the consistency of events.  At the core, some events may
not be written to the backend when the runtime is shutdown.

While there are various changes required to tackle the consistency
issues, a first step is to make sure that writes to the events channel
block.

Set the timeout to 10 seconds.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
