### PR TITLE
libimage: lookup: tolerate corrupted image

### DIFF
--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -254,6 +254,12 @@ func (r *Runtime) lookupImageInLocalStorage(name, candidate string, options *Loo
 	// find a matching instance in the local containers storage.
 	isManifestList, err := image.IsManifestList(context.Background())
 	if err != nil {
+		if errors.Cause(err) == os.ErrNotExist {
+			// We must be tolerant toward corrupted images.
+			// See containers/podman commit fd9dd7065d44.
+			logrus.Warnf("error determining if an image is a manifest list: %v, ignoring the error", err)
+			return image, nil
+		}
 		return nil, err
 	}
 	if options.lookupManifest {


### PR DESCRIPTION
Recent changes in the image-lookup logic will, in many cases, yield a
check whether an image is a manifest list.  This had caused a regression
in Podman's test/system/330-corrupt-images.bats system tests where we're
attempting to delete a corrupted image with a missing manifest.  Since
the manifest is missing, the manifest list check fails.

To make the image lookups more tolerant towards this specific error
case, we need to ignore the error but emit a warning, similar to what
we're already doing in the parent-child checks.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
