### PR TITLE
Revert "Do not emit warnings about OCI runtime paths"

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -596,7 +596,7 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-func (c *EngineConfig) findRuntime(showWarnings bool) string {
+func (c *EngineConfig) findRuntime() string {
 	// Search for crun first followed by runc and kata
 	for _, name := range []string{"crun", "runc", "kata"} {
 		for _, v := range c.OCIRuntimes[name] {
@@ -605,9 +605,7 @@ func (c *EngineConfig) findRuntime(showWarnings bool) string {
 			}
 		}
 		if path, err := exec.LookPath(name); err == nil {
-			if showWarnings {
-				logrus.Warningf("Found default OCI runtime %s path via PATH environment variable", path)
-			}
+			logrus.Debugf("Found default OCI runtime %s path via PATH environment variable", path)
 			return name
 		}
 	}
@@ -628,10 +626,6 @@ func (c *EngineConfig) Validate() error {
 	if _, err := ValidatePullPolicy(pullPolicy); err != nil {
 		return errors.Wrapf(err, "invalid pull type from containers.conf %q", c.PullPolicy)
 	}
-
-	// Re-populate OCI runtime and emit warnings if necessary
-	c.OCIRuntime = c.findRuntime(true)
-
 	return nil
 }
 

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -293,9 +293,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 		},
 	}
 	// Needs to be called after populating c.OCIRuntimes
-	// Do not emit warnings on OCI runtime: wait for
-	// merged user configuration files
-	c.OCIRuntime = c.findRuntime(false)
+	c.OCIRuntime = c.findRuntime()
 
 	c.ConmonEnvVars = []string{
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",


### PR DESCRIPTION
This reverts commit 1752a5668095930a6e67df077f82c94e41e0d8a1 as it's
causing a regression as it overwrites any custom OCI runtime with either
rucc, crun or kata.  See the Podman CI failure below:

```
[+0383s] not ok 95 podman build - set runtime
[+0383s] # (from function `die' in file test/system/helpers.bash, line 412,
[+0383s] #  from function `run_podman' in file test/system/helpers.bash, line 220,
[+0383s] #  in test file test/system/070-build.bats, line 70)
```

I currently do not have the time for a proper fix but the next commit
attempting to address the warnings must include tests.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
