### PR TITLE
rootless networking

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -211,6 +211,11 @@ Options are:
 Maximum number of processes allowed in a container. 0 indicates that no limit
 is imposed.
 
+**rootless_networking**="slirp4netns"
+
+Set type of networking rootless containers should use.  Valid options are `slirp4netns`
+or `cni`.
+
 **seccomp_profile**="/usr/share/containers/seccomp.json"
 
 Path to the seccomp.json profile which is used as the default seccomp profile

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -150,6 +150,11 @@ type ContainersConfig struct {
 	// PidNS indicates how to create a pid namespace for the container
 	PidNS string `toml:"pidns,omitempty"`
 
+	// RootlessNetworking depicts the "kind" of networking for rootless
+	// containers.  Valid options are `slirp4netns` and `cni`. Default is
+	// `slirp4netns`
+	RootlessNetworking string `toml:"rootless_networking,omitempty"`
+
 	// SeccompProfile is the seccomp.json profile path which is used as the
 	// default for the runtime.
 	SeccompProfile string `toml:"seccomp_profile,omitempty"`

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -316,4 +316,16 @@ var _ = Describe("Config Local", func() {
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config2.Engine.MachineEnabled).To(gomega.Equal(true))
 	})
+
+	It("Rootless networking", func() {
+		// Given
+		config, err := NewConfig("")
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config.Containers.RootlessNetworking).To(gomega.Equal("slirp4netns"))
+		// When
+		config2, err := NewConfig("testdata/containers_default.conf")
+		// Then
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config2.Containers.RootlessNetworking).To(gomega.Equal("cni"))
+	})
 })

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -389,6 +389,9 @@ default_sysctls = [
 # `podman --remote=true` for access to the remote Podman service.
 # remote = false
 
+# Indicates the networking to be used for rootless containers
+# rootless_networking="slirp4netns"
+
 # Directory for persistent engine files (database, etc)
 # By default, this will be configured relative to where the containers/storage
 # stores containers

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -82,6 +82,10 @@ var (
 		"/usr/local/lib/cni",
 		"/opt/cni/bin",
 	}
+
+	// DefaultRootlessNetwork is the kind of of rootless networking
+	// for containers
+	DefaultRootlessNetwork = "slirp4netns"
 )
 
 const (
@@ -186,24 +190,25 @@ func DefaultConfig() (*Config, error) {
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 				"TERM=xterm",
 			},
-			EnvHost:        false,
-			HTTPProxy:      true,
-			Init:           false,
-			InitPath:       "",
-			IPCNS:          "private",
-			LogDriver:      DefaultLogDriver,
-			LogSizeMax:     DefaultLogSizeMax,
-			NetNS:          netns,
-			NoHosts:        false,
-			PidsLimit:      DefaultPidsLimit,
-			PidNS:          "private",
-			SeccompProfile: SeccompDefaultPath,
-			ShmSize:        DefaultShmSize,
-			TZ:             "",
-			Umask:          "0022",
-			UTSNS:          "private",
-			UserNS:         "host",
-			UserNSSize:     DefaultUserNSSize,
+			EnvHost:            false,
+			HTTPProxy:          true,
+			Init:               false,
+			InitPath:           "",
+			IPCNS:              "private",
+			LogDriver:          DefaultLogDriver,
+			LogSizeMax:         DefaultLogSizeMax,
+			NetNS:              netns,
+			NoHosts:            false,
+			PidsLimit:          DefaultPidsLimit,
+			PidNS:              "private",
+			RootlessNetworking: DefaultRootlessNetwork,
+			SeccompProfile:     SeccompDefaultPath,
+			ShmSize:            DefaultShmSize,
+			TZ:                 "",
+			Umask:              "0022",
+			UTSNS:              "private",
+			UserNS:             "host",
+			UserNSSize:         DefaultUserNSSize,
 		},
 		Network: NetworkConfig{
 			DefaultNetwork:   "podman",
@@ -543,4 +548,10 @@ func (c *Config) LogDriver() string {
 
 func (c *Config) MachineEnabled() bool {
 	return c.Engine.MachineEnabled
+}
+
+// RootlessNetworking returns the "kind" of networking
+// rootless containers should use
+func (c *Config) RootlessNetworking() string {
+	return c.Containers.RootlessNetworking
 }

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -88,6 +88,8 @@ shm_size = "65536k"
 #Umask inside the container
 umask="0002"
 
+rootless_networking = "cni"
+
 # The network table containers settings pertaining to the management of
 # CNI plugins.
 [network]


### PR DESCRIPTION
Set type of rootless networking with:

rootless_networking = "slirp4netns | cni"

slirp is the default

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
