### PR TITLE
Use Private as default for rootless when we want CNI

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -415,9 +415,6 @@ func probeConmon(conmonBinary string) error {
 
 // NetNS returns the default network namespace
 func (c *Config) NetNS() string {
-	if c.Containers.NetNS == "private" && unshare.IsRootless() {
-		return "slirp4netns"
-	}
 	return c.Containers.NetNS
 }
 


### PR DESCRIPTION
We were hardcoding Slirp4netns as the only valid option for rootless when "private" networking was selected. We shouldn't be doing that - the default networking selection in Podman itself is smart enough to figure out what to do, c/common should not decide for us.