### PR TITLE
seccomp: switch default to ENOSYS

### DIFF
--- a/pkg/seccomp/conversion.go
+++ b/pkg/seccomp/conversion.go
@@ -118,6 +118,7 @@ func specToSeccomp(spec *specs.LinuxSeccomp) (*Seccomp, error) {
 		return nil, errors.Wrap(err, "convert default action")
 	}
 	res.DefaultAction = newDefaultAction
+	res.DefaultErrnoRet = spec.DefaultErrnoRet
 
 	// Loop through all syscall blocks and convert them to the internal format
 	for _, call := range spec.Syscalls {

--- a/pkg/seccomp/default_linux.go
+++ b/pkg/seccomp/default_linux.go
@@ -44,8 +44,54 @@ func arches() []Architecture {
 // DefaultProfile defines the allowlist for the default seccomp profile.
 func DefaultProfile() *Seccomp {
 	einval := uint(unix.EINVAL)
+	enosys := uint(unix.ENOSYS)
+	eperm := uint(unix.EPERM)
 
 	syscalls := []*Syscall{
+		{
+			Names: []string{
+				"bdflush",
+				"clone3",
+				"io_pgetevents",
+				"io_uring_enter",
+				"io_uring_register",
+				"io_uring_setup",
+				"kexec_file_load",
+				"kexec_load",
+				"membarrier",
+				"migrate_pages",
+				"move_pages",
+				"nfsservctl",
+				"nice",
+				"oldfstat",
+				"oldlstat",
+				"oldolduname",
+				"oldstat",
+				"olduname",
+				"pciconfig_iobase",
+				"pciconfig_read",
+				"pciconfig_write",
+				"pkey_alloc",
+				"pkey_free",
+				"pkey_mprotect",
+				"rseq",
+				"sgetmask",
+				"ssetmask",
+				"swapcontext",
+				"swapoff",
+				"swapon",
+				"sysfs",
+				"uselib",
+				"userfaultfd",
+				"ustat",
+				"vm86",
+				"vm86old",
+				"vmsplice",
+			},
+			Action:   ActErrno,
+			ErrnoRet: &eperm,
+			Args:     []*Arg{},
+		},
 		{
 			Names: []string{
 				"_llseek",
@@ -255,6 +301,7 @@ func DefaultProfile() *Seccomp {
 				"pwritev2",
 				"read",
 				"readahead",
+				"readdir",
 				"readlink",
 				"readlinkat",
 				"readv",
@@ -524,6 +571,17 @@ func DefaultProfile() *Seccomp {
 		},
 		{
 			Names: []string{
+				"open_by_handle_at",
+			},
+			Action:   ActErrno,
+			ErrnoRet: &eperm,
+			Args:     []*Arg{},
+			Excludes: Filter{
+				Caps: []string{"CAP_DAC_READ_SEARCH"},
+			},
+		},
+		{
+			Names: []string{
 				"bpf",
 				"fanotify_init",
 				"lookup_dcookie",
@@ -541,11 +599,40 @@ func DefaultProfile() *Seccomp {
 		},
 		{
 			Names: []string{
+				"bpf",
+				"fanotify_init",
+				"lookup_dcookie",
+				"perf_event_open",
+				"quotactl",
+				"setdomainname",
+				"sethostname",
+				"setns",
+			},
+			Action:   ActErrno,
+			ErrnoRet: &eperm,
+			Args:     []*Arg{},
+			Excludes: Filter{
+				Caps: []string{"CAP_SYS_ADMIN"},
+			},
+		},
+		{
+			Names: []string{
 				"chroot",
 			},
 			Action: ActAllow,
 			Args:   []*Arg{},
 			Includes: Filter{
+				Caps: []string{"CAP_SYS_CHROOT"},
+			},
+		},
+		{
+			Names: []string{
+				"chroot",
+			},
+			Action:   ActErrno,
+			ErrnoRet: &eperm,
+			Args:     []*Arg{},
+			Excludes: Filter{
 				Caps: []string{"CAP_SYS_CHROOT"},
 			},
 		},
@@ -564,6 +651,20 @@ func DefaultProfile() *Seccomp {
 		},
 		{
 			Names: []string{
+				"delete_module",
+				"init_module",
+				"finit_module",
+				"query_module",
+			},
+			Action:   ActErrno,
+			ErrnoRet: &eperm,
+			Args:     []*Arg{},
+			Excludes: Filter{
+				Caps: []string{"CAP_SYS_MODULE"},
+			},
+		},
+		{
+			Names: []string{
 				"get_mempolicy",
 				"mbind",
 				"set_mempolicy",
@@ -576,11 +677,35 @@ func DefaultProfile() *Seccomp {
 		},
 		{
 			Names: []string{
+				"get_mempolicy",
+				"mbind",
+				"set_mempolicy",
+			},
+			Action:   ActErrno,
+			ErrnoRet: &eperm,
+			Args:     []*Arg{},
+			Excludes: Filter{
+				Caps: []string{"CAP_SYS_NICE"},
+			},
+		},
+		{
+			Names: []string{
 				"acct",
 			},
 			Action: ActAllow,
 			Args:   []*Arg{},
 			Includes: Filter{
+				Caps: []string{"CAP_SYS_PACCT"},
+			},
+		},
+		{
+			Names: []string{
+				"acct",
+			},
+			Action:   ActErrno,
+			ErrnoRet: &eperm,
+			Args:     []*Arg{},
+			Excludes: Filter{
 				Caps: []string{"CAP_SYS_PACCT"},
 			},
 		},
@@ -600,12 +725,39 @@ func DefaultProfile() *Seccomp {
 		},
 		{
 			Names: []string{
+				"kcmp",
+				"process_madvise",
+				"process_vm_readv",
+				"process_vm_writev",
+				"ptrace",
+			},
+			Action:   ActErrno,
+			ErrnoRet: &eperm,
+			Args:     []*Arg{},
+			Excludes: Filter{
+				Caps: []string{"CAP_SYS_PTRACE"},
+			},
+		},
+		{
+			Names: []string{
 				"iopl",
 				"ioperm",
 			},
 			Action: ActAllow,
 			Args:   []*Arg{},
 			Includes: Filter{
+				Caps: []string{"CAP_SYS_RAWIO"},
+			},
+		},
+		{
+			Names: []string{
+				"iopl",
+				"ioperm",
+			},
+			Action:   ActErrno,
+			ErrnoRet: &eperm,
+			Args:     []*Arg{},
+			Excludes: Filter{
 				Caps: []string{"CAP_SYS_RAWIO"},
 			},
 		},
@@ -624,11 +776,36 @@ func DefaultProfile() *Seccomp {
 		},
 		{
 			Names: []string{
+				"settimeofday",
+				"stime",
+				"clock_settime",
+				"clock_settime64",
+			},
+			Action:   ActErrno,
+			ErrnoRet: &eperm,
+			Args:     []*Arg{},
+			Excludes: Filter{
+				Caps: []string{"CAP_SYS_TIME"},
+			},
+		},
+		{
+			Names: []string{
 				"vhangup",
 			},
 			Action: ActAllow,
 			Args:   []*Arg{},
 			Includes: Filter{
+				Caps: []string{"CAP_SYS_TTY_CONFIG"},
+			},
+		},
+		{
+			Names: []string{
+				"vhangup",
+			},
+			Action:   ActErrno,
+			ErrnoRet: &eperm,
+			Args:     []*Arg{},
+			Excludes: Filter{
 				Caps: []string{"CAP_SYS_TTY_CONFIG"},
 			},
 		},
@@ -714,8 +891,9 @@ func DefaultProfile() *Seccomp {
 	}
 
 	return &Seccomp{
-		DefaultAction: ActErrno,
-		ArchMap:       arches(),
-		Syscalls:      syscalls,
+		DefaultAction:   ActErrno,
+		DefaultErrnoRet: &enosys,
+		ArchMap:         arches(),
+		Syscalls:        syscalls,
 	}
 }

--- a/pkg/seccomp/filter.go
+++ b/pkg/seccomp/filter.go
@@ -41,7 +41,7 @@ func BuildFilter(spec *specs.LinuxSeccomp) (*libseccomp.ScmpFilter, error) {
 		return nil, errors.Wrap(err, "convert spec to seccomp profile")
 	}
 
-	defaultAction, err := toAction(profile.DefaultAction, nil)
+	defaultAction, err := toAction(profile.DefaultAction, profile.DefaultErrnoRet)
 	if err != nil {
 		return nil, errors.Wrapf(err, "convert default action %s", profile.DefaultAction)
 	}

--- a/pkg/seccomp/seccomp.json
+++ b/pkg/seccomp/seccomp.json
@@ -1,5 +1,6 @@
 {
 	"defaultAction": "SCMP_ACT_ERRNO",
+	"defaultErrnoRet": 38,
 	"archMap": [
 		{
 			"architecture": "SCMP_ARCH_X86_64",
@@ -50,6 +51,53 @@
 		}
 	],
 	"syscalls": [
+		{
+			"names": [
+				"bdflush",
+				"clone3",
+				"io_pgetevents",
+				"io_uring_enter",
+				"io_uring_register",
+				"io_uring_setup",
+				"kexec_file_load",
+				"kexec_load",
+				"membarrier",
+				"migrate_pages",
+				"move_pages",
+				"nfsservctl",
+				"nice",
+				"oldfstat",
+				"oldlstat",
+				"oldolduname",
+				"oldstat",
+				"olduname",
+				"pciconfig_iobase",
+				"pciconfig_read",
+				"pciconfig_write",
+				"pkey_alloc",
+				"pkey_free",
+				"pkey_mprotect",
+				"rseq",
+				"sgetmask",
+				"ssetmask",
+				"swapcontext",
+				"swapoff",
+				"swapon",
+				"sysfs",
+				"uselib",
+				"userfaultfd",
+				"ustat",
+				"vm86",
+				"vm86old",
+				"vmsplice"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {},
+			"errnoRet": 1
+		},
 		{
 			"names": [
 				"_llseek",
@@ -259,6 +307,7 @@
 				"pwritev2",
 				"read",
 				"readahead",
+				"readdir",
 				"readlink",
 				"readlinkat",
 				"readv",
@@ -590,6 +639,21 @@
 		},
 		{
 			"names": [
+				"open_by_handle_at"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_DAC_READ_SEARCH"
+				]
+			},
+			"errnoRet": 1
+		},
+		{
+			"names": [
 				"bpf",
 				"fanotify_init",
 				"lookup_dcookie",
@@ -611,6 +675,28 @@
 		},
 		{
 			"names": [
+				"bpf",
+				"fanotify_init",
+				"lookup_dcookie",
+				"perf_event_open",
+				"quotactl",
+				"setdomainname",
+				"sethostname",
+				"setns"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			},
+			"errnoRet": 1
+		},
+		{
+			"names": [
 				"chroot"
 			],
 			"action": "SCMP_ACT_ALLOW",
@@ -622,6 +708,21 @@
 				]
 			},
 			"excludes": {}
+		},
+		{
+			"names": [
+				"chroot"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_CHROOT"
+				]
+			},
+			"errnoRet": 1
 		},
 		{
 			"names": [
@@ -642,6 +743,24 @@
 		},
 		{
 			"names": [
+				"delete_module",
+				"init_module",
+				"finit_module",
+				"query_module"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_MODULE"
+				]
+			},
+			"errnoRet": 1
+		},
+		{
+			"names": [
 				"get_mempolicy",
 				"mbind",
 				"set_mempolicy"
@@ -658,6 +777,23 @@
 		},
 		{
 			"names": [
+				"get_mempolicy",
+				"mbind",
+				"set_mempolicy"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_NICE"
+				]
+			},
+			"errnoRet": 1
+		},
+		{
+			"names": [
 				"acct"
 			],
 			"action": "SCMP_ACT_ALLOW",
@@ -669,6 +805,21 @@
 				]
 			},
 			"excludes": {}
+		},
+		{
+			"names": [
+				"acct"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_PACCT"
+				]
+			},
+			"errnoRet": 1
 		},
 		{
 			"names": [
@@ -690,6 +841,25 @@
 		},
 		{
 			"names": [
+				"kcmp",
+				"process_madvise",
+				"process_vm_readv",
+				"process_vm_writev",
+				"ptrace"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_PTRACE"
+				]
+			},
+			"errnoRet": 1
+		},
+		{
+			"names": [
 				"iopl",
 				"ioperm"
 			],
@@ -702,6 +872,22 @@
 				]
 			},
 			"excludes": {}
+		},
+		{
+			"names": [
+				"iopl",
+				"ioperm"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_RAWIO"
+				]
+			},
+			"errnoRet": 1
 		},
 		{
 			"names": [
@@ -722,6 +908,24 @@
 		},
 		{
 			"names": [
+				"settimeofday",
+				"stime",
+				"clock_settime",
+				"clock_settime64"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_TIME"
+				]
+			},
+			"errnoRet": 1
+		},
+		{
+			"names": [
 				"vhangup"
 			],
 			"action": "SCMP_ACT_ALLOW",
@@ -733,6 +937,21 @@
 				]
 			},
 			"excludes": {}
+		},
+		{
+			"names": [
+				"vhangup"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_TTY_CONFIG"
+				]
+			},
+			"errnoRet": 1
 		},
 		{
 			"names": [

--- a/pkg/seccomp/seccomp_linux.go
+++ b/pkg/seccomp/seccomp_linux.go
@@ -111,6 +111,7 @@ func setupSeccomp(config *Seccomp, rs *specs.Spec) (*specs.LinuxSeccomp, error) 
 	}
 
 	newConfig.DefaultAction = specs.LinuxSeccompAction(config.DefaultAction)
+	newConfig.DefaultErrnoRet = config.DefaultErrnoRet
 
 Loop:
 	// Loop through all syscall blocks and convert them to libcontainer format after filtering them

--- a/pkg/seccomp/types.go
+++ b/pkg/seccomp/types.go
@@ -6,7 +6,8 @@ package seccomp
 
 // Seccomp represents the config for a seccomp profile for syscall restriction.
 type Seccomp struct {
-	DefaultAction Action `json:"defaultAction"`
+	DefaultAction   Action `json:"defaultAction"`
+	DefaultErrnoRet *uint  `json:"defaultErrnoRet"`
 	// Architectures is kept to maintain backward compatibility with the old
 	// seccomp profile.
 	Architectures []Arch         `json:"architectures,omitempty"`


### PR DESCRIPTION
add the currently blocked syscalls to a deny-list and switch the default to ENOSYS.
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
