### PR TITLE
Do not include gateway in generated default networks

### DIFF
--- a/pkg/defaultnet/default_network.go
+++ b/pkg/defaultnet/default_network.go
@@ -33,8 +33,7 @@ const networkTemplate = `{
         "ranges": [
           [
             {
-              "subnet": "{{{{.Subnet}}}}",
-              "gateway": "{{{{.Gateway}}}}"
+              "subnet": "{{{{.Subnet}}}}"
             }
           ]
         ]


### PR DESCRIPTION
It's not required (CNI is perfectly happy to accept conflists that do not include it) and it seems to be breaking default network creation as non-root.
