### PR TITLE
Ensure configuration directory is created for networks

### DIFF
--- a/pkg/defaultnet/default_network.go
+++ b/pkg/defaultnet/default_network.go
@@ -120,6 +120,11 @@ func Create(name, subnet, configDir, existsDir string, isMachine bool) error {
 	}
 	file.Close()
 
+	// We may need to make the config dir.
+	if err := os.MkdirAll(configDir, 0755); err != nil && !os.IsExist(err) {
+		return errors.Wrapf(err, "error creating CNI configuration directory")
+	}
+
 	// Check all networks in the CNI conflist.
 	files, err := ioutil.ReadDir(configDir)
 	if err != nil {


### PR DESCRIPTION
We need to make sure the default network directory gets created if it does not exist. We previously did this after CNI was initialized but this could race on CNI recognizing the new network, so we moved it before CNI init. Unfortunately, CNI init made the configuration directory, so we now have to do that ourselves.
