### PR TITLE
Don't use systemd defaults if /proc/1/comm != systemd

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -195,7 +195,7 @@ func DefaultConfig() (*Config, error) {
 			Init:               false,
 			InitPath:           "",
 			IPCNS:              "private",
-			LogDriver:          DefaultLogDriver,
+			LogDriver:          defaultLogDriver(),
 			LogSizeMax:         DefaultLogSizeMax,
 			NetNS:              netns,
 			NoHosts:            false,

--- a/pkg/config/nosystemd.go
+++ b/pkg/config/nosystemd.go
@@ -3,9 +3,17 @@
 package config
 
 func defaultCgroupManager() string {
-	return "cgroupfs"
+	return CgroupfsCgroupsManager
 }
 
 func defaultEventsLogger() string {
 	return "file"
+}
+
+func defaultLogDriver() string {
+	return DefaultLogDriver
+}
+
+func useSystemd() bool {
+	return false
 }

--- a/pkg/config/systemd.go
+++ b/pkg/config/systemd.go
@@ -3,11 +3,21 @@
 package config
 
 import (
+	"sync"
+
 	"github.com/containers/common/pkg/cgroupv2"
 	"github.com/containers/storage/pkg/unshare"
 )
 
+var (
+	systemdOnce sync.Once
+	usesSystemd bool
+)
+
 func defaultCgroupManager() string {
+	if !useSystemd() {
+		return CgroupfsCgroupsManager
+	}
 	enabled, err := cgroupv2.Enabled()
 	if err == nil && !enabled && unshare.IsRootless() {
 		return CgroupfsCgroupsManager
@@ -16,5 +26,30 @@ func defaultCgroupManager() string {
 	return SystemdCgroupsManager
 }
 func defaultEventsLogger() string {
-	return "journald"
+	if useSystemd() {
+		return "journald"
+	}
+	return "file"
+}
+
+func defaultLogDriver() string {
+	// If we decide to change the default for logdriver, it should be done here.
+	if useSystemd() {
+		return DefaultLogDriver
+	}
+
+	return DefaultLogDriver
+
+}
+
+func useSystemd() bool {
+	systemdOnce.Do(func() {
+		dat, err := ioutil.ReadFile("/proc/1/comm")
+		if err == nil {
+			val := strings.TrimSuffix(string(dat), "\n")
+			usesSystemd = (val == "systemd")
+		}
+		return
+	})
+	return usesSystemd
 }


### PR DESCRIPTION
Currently we have users failing to run containers within containers
or on systems without systemd support.  This change will give us
better defaults on these systems.

Fixes: https://github.com/containers/common/issues/580

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
