### PR TITLE
pkg/config: fix systemd compile errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GO_BUILD=$(GO) build
 ifeq ($(shell go help mod >/dev/null 2>&1 && echo true), true)
 	GO_BUILD=GO111MODULE=on $(GO) build -mod=vendor
 endif
-BUILDTAGS := containers_image_openpgp
+BUILDTAGS := containers_image_openpgp,systemd
 DESTDIR ?=
 PREFIX := /usr/local
 CONFIGDIR := ${PREFIX}/share/containers

--- a/pkg/config/systemd.go
+++ b/pkg/config/systemd.go
@@ -3,6 +3,8 @@
 package config
 
 import (
+	"io/ioutil"
+	"strings"
 	"sync"
 
 	"github.com/containers/common/pkg/cgroupv2"
@@ -25,6 +27,7 @@ func defaultCgroupManager() string {
 
 	return SystemdCgroupsManager
 }
+
 func defaultEventsLogger() string {
 	if useSystemd() {
 		return "journald"


### PR DESCRIPTION
The errors sneaked through CI as we didn't use the systemd build tag for
testing.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan @giuseppe PTAL
