### PR TITLE
Tests are writing customer config to host machine

### DIFF
--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -260,12 +260,6 @@ var _ = Describe("Config Local", func() {
 		oldContainersConf, envSet := os.LookupEnv("CONTAINERS_CONF")
 		os.Setenv("CONTAINERS_CONF", tmpfile)
 		config, err := ReadCustomConfig()
-		// Undo that
-		if envSet {
-			os.Setenv("CONTAINERS_CONF", oldContainersConf)
-		} else {
-			os.Unsetenv("CONTAINERS_CONF")
-		}
 		gomega.Expect(err).To(gomega.BeNil())
 		config.Containers.Devices = []string{"/dev/null:/dev/null:rw",
 			"/dev/sdc/",
@@ -274,6 +268,12 @@ var _ = Describe("Config Local", func() {
 		}
 
 		err = config.Write()
+		// Undo that
+		if envSet {
+			os.Setenv("CONTAINERS_CONF", oldContainersConf)
+		} else {
+			os.Unsetenv("CONTAINERS_CONF")
+		}
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
 		defer os.Remove(tmpfile)


### PR DESCRIPTION
[NO TESTS NEEDED]

the config.Write() command looks for the CONTAINERS_CONF setting,
since we were resetting it back to default, it was mistakenly
overwriting the user executing the tests local containers.conf file.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
