### PR TITLE
Do not set the default netns

### DIFF
--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -328,4 +328,16 @@ var _ = Describe("Config Local", func() {
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config2.Containers.RootlessNetworking).To(gomega.Equal("cni"))
 	})
+
+	It("default netns", func() {
+		// Given
+		config, err := NewConfig("")
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config.Containers.NetNS).To(gomega.Equal(""))
+		// When
+		config2, err := NewConfig("testdata/containers_default.conf")
+		// Then
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config2.Containers.NetNS).To(gomega.Equal("bridge"))
+	})
 })

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -190,6 +190,9 @@ default_sysctls = [
 #
 # pidns = "private"
 
+# Indicates the networking to be used for rootless containers
+# rootless_networking="slirp4netns"
+
 # Path to the seccomp.json profile which is used as the default seccomp profile
 # for the runtime.
 #
@@ -388,9 +391,6 @@ default_sysctls = [
 # --remote option on container engines. Setting the flag to true will default
 # `podman --remote=true` for access to the remote Podman service.
 # remote = false
-
-# Indicates the networking to be used for rootless containers
-# rootless_networking="slirp4netns"
 
 # Directory for persistent engine files (database, etc)
 # By default, this will be configured relative to where the containers/storage

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -144,8 +144,6 @@ func DefaultConfig() (*Config, error) {
 		return nil, err
 	}
 
-	netns := "bridge"
-
 	cniConfig := _cniConfigDir
 
 	defaultEngineConfig.SignaturePolicyPath = DefaultSignaturePolicyPath
@@ -161,7 +159,6 @@ func DefaultConfig() (*Config, error) {
 				defaultEngineConfig.SignaturePolicyPath = DefaultSignaturePolicyPath
 			}
 		}
-		netns = "slirp4netns"
 		cniConfig = filepath.Join(configHome, _cniConfigDirRootless)
 	}
 
@@ -197,7 +194,6 @@ func DefaultConfig() (*Config, error) {
 			IPCNS:              "private",
 			LogDriver:          defaultLogDriver(),
 			LogSizeMax:         DefaultLogSizeMax,
-			NetNS:              netns,
 			NoHosts:            false,
 			PidsLimit:          DefaultPidsLimit,
 			PidNS:              "private",

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -88,6 +88,9 @@ shm_size = "65536k"
 #Umask inside the container
 umask="0002"
 
+# default network mode
+netns="bridge"
+
 rootless_networking = "cni"
 
 # The network table containers settings pertaining to the management of


### PR DESCRIPTION
The default netns must be empty. Podman should decide what the default
option is. While podman also defaults to slirp4netns as rootless and
bridge as root, there are also other defaults for `podman run --pod ...`
and `podman pod create --infra=false` where it defaults to the pods
netns. This config field was always ignored by podman and trying to
make it work requires this patch since the default values are incorrect
for podman.

Buildah does not seem to use it either.

Also move the rootless_networking field in the default config file to
the correct containers stanza.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
