### PR TITLE
secrets: fix build with go 1.15

### DIFF
--- a/pkg/secrets/passdriver/passdriver.go
+++ b/pkg/secrets/passdriver/passdriver.go
@@ -157,7 +157,7 @@ func (d *Driver) gpg(ctx context.Context, in io.Reader, out io.Writer, args ...s
 	cmd := exec.CommandContext(ctx, "gpg", args...)
 	cmd.Stdin = in
 	cmd.Stdout = out
-	cmd.Stderr = io.Discard
+	cmd.Stderr = ioutil.Discard
 	return cmd.Run()
 }
 


### PR DESCRIPTION
io.Discard was added to go 1.16, prefer ioutil.Discard that is also
present in older Go versions.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
