### PR TITLE
add 'secret' section to the containers.conf struct.

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -519,6 +519,21 @@ used as the backend for Podman named volumes. Individual plugins are specified
 below, as a map of the plugin name (what the plugin will be called) to its path
 (filepath of the plugin's unix socket).
 
+
+## SECRET TABLE
+The `secret` table contains settings for the configuration of the secret subsystem.
+
+**driver**=file
+
+Name of the secret driver to be used.
+Currently valid values are:
+  * file
+  * pass
+
+**opts**={}
+
+The driver specific options object.
+
 # FILES
 
 **containers.conf**

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,6 +55,8 @@ type Config struct {
 	Engine EngineConfig `toml:"engine"`
 	// Network section defines the configuration of CNI Plugins
 	Network NetworkConfig `toml:"network"`
+	// Secret section defines configurations for the secret management
+	Secrets SecretConfig `toml:"secrets"`
 }
 
 // ContainersConfig represents the "containers" TOML config table
@@ -443,6 +445,17 @@ type NetworkConfig struct {
 
 	// NetworkConfigDir is where CNI network configuration files are stored.
 	NetworkConfigDir string `toml:"network_config_dir,omitempty"`
+}
+
+// SecretConfig represents the "secret" TOML config table
+type SecretConfig struct {
+	// Driver specifies the secret driver to use.
+	// Current valid value:
+	//  * file
+	//  * pass
+	Driver string `toml:"driver,omitempty"`
+	// Opts contains driver specific options
+	Opts map[string]string `toml:"opts,omitempty"`
 }
 
 // Destination represents destination for remote service

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -340,4 +340,28 @@ var _ = Describe("Config Local", func() {
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config2.Containers.NetNS).To(gomega.Equal("bridge"))
 	})
+
+	It("should have a default secret driver", func() {
+		// Given
+		path := ""
+		// When
+		config, err := NewConfig(path)
+		gomega.Expect(err).To(gomega.BeNil())
+		// Then
+		gomega.Expect(config.Secrets.Driver).To(gomega.Equal("file"))
+	})
+
+	It("should be possible to override the secret driver and options", func() {
+		// Given
+		path := "testdata/containers_override.conf"
+		// When
+		config, err := NewConfig(path)
+		gomega.Expect(err).To(gomega.BeNil())
+		// Then
+		gomega.Expect(config.Secrets.Driver).To(gomega.Equal("pass"))
+		gomega.Expect(config.Secrets.Opts).To(gomega.Equal(map[string]string{
+			"key":  "foo@bar",
+			"root": "/srv/password-store",
+		}))
+	})
 })

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -503,3 +503,9 @@ default_sysctls = [
 # TOML does not provide a way to end a table other than a further table being
 # defined, so every key hereafter will be part of [volume_plugins] and not the
 # main config.
+
+[secret]
+# driver="file"
+
+[secret.opts]
+# root = "/example/directory"

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -211,8 +211,17 @@ func DefaultConfig() (*Config, error) {
 			NetworkConfigDir: cniConfig,
 			CNIPluginDirs:    cniBinDir,
 		},
-		Engine: *defaultEngineConfig,
+		Engine:  *defaultEngineConfig,
+		Secrets: defaultSecretConfig(),
 	}, nil
+}
+
+// defaultSecretConfig returns the default secret configuration.
+// Please note that the default is choosing the "file" driver.
+func defaultSecretConfig() SecretConfig {
+	return SecretConfig{
+		Driver: "file",
+	}
 }
 
 // defaultConfigFromMemory returns a default engine configuration. Note that the

--- a/pkg/config/testdata/containers_override.conf
+++ b/pkg/config/testdata/containers_override.conf
@@ -8,3 +8,10 @@ log_size_max = 100000
 [engine]
 image_parallel_copies=10
 image_default_format="v2s2"
+
+[secrets]
+driver = "pass"
+
+[secrets.opts]
+key = "foo@bar"
+root = "/srv/password-store"


### PR DESCRIPTION
This adds a 'secret' section to the `config.Config` struct. I do this as a follow up to #514 so we can specify which driver to use by default + its options in the config file. As a next step I'd like to evaluate that config in podman in the `infra.ContainerEngine.SecretCreate` function. At this point we would be able to use the new passdriver for secrets.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
