### PR TITLE
Leave default seccomp path empty

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -198,7 +198,6 @@ func DefaultConfig() (*Config, error) {
 			PidsLimit:          DefaultPidsLimit,
 			PidNS:              "private",
 			RootlessNetworking: DefaultRootlessNetwork,
-			SeccompProfile:     SeccompDefaultPath,
 			ShmSize:            DefaultShmSize,
 			TZ:                 "",
 			Umask:              "0022",


### PR DESCRIPTION
The default path should be empty in order for podman to distinguish
between a path the was explicitly or to use the default (in memory)
profile.

Fixes: containers/podman#10556


<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
