### PR TITLE
made necessary changes to handle OS/Arch while importing an image

### DIFF
--- a/libimage/import.go
+++ b/libimage/import.go
@@ -23,6 +23,10 @@ type ImportOptions struct {
 	CommitMessage string
 	// Tag the imported image with this value.
 	Tag string
+	// Overwrite OS of imported image.
+	OS string
+	// Overwrite Arch of imported image.
+	Arch string
 }
 
 // Import imports a custom tarball at the specified path.  Returns the name of
@@ -48,8 +52,10 @@ func (r *Runtime) Import(ctx context.Context, path string, options *ImportOption
 	}
 
 	config := v1.Image{
-		Config:  ic,
-		History: hist,
+		Config:       ic,
+		History:      hist,
+		OS:           options.OS,
+		Architecture: options.Arch,
 	}
 
 	u, err := url.ParseRequestURI(path)


### PR DESCRIPTION
Signed-off-by: cdoern <cbdoer23@g.holycross.edu>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

Making necessary changes in order to reference a platform as described in [this issue on podman](https://github.com/containers/podman/issues/10566). This PR modifies the ImportOptions struct to handle OS/Arch and added two lines so that the config reads in these new parameters. Will open up a new PR on podman to handle parsing of OS/Arch [here](https://github.com/containers/podman/blob/master/pkg/api/handlers/compat/images.go#L168).

This is stemming from implementation of the platform parameter in the docker-compatabile API of podman. As seen [in image_routes.go](https://github.com/docker/engine/blob/7c6a9484ee37b28fa314f716581bdb268cd78ce2/api/server/router/image/image_routes.go#L85) the docker engine handles platform with both fromSrc and fromImage. In order to mirror this, certain structs on this end must be modified.