### PR TITLE
libimage: pull: turn image-lookup errors non-fatal

### DIFF
--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -351,7 +351,7 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 	// attempt pulling that instead of doing the full short-name dance.
 	localImage, resolvedImageName, err = r.LookupImage(imageName, nil)
 	if err != nil && errors.Cause(err) != storage.ErrImageUnknown {
-		return nil, errors.Wrap(err, "error looking up local image")
+		logrus.Errorf("Looking up %s in local storage: %v", imageName, err)
 	}
 
 	if pullPolicy == config.PullPolicyNever {


### PR DESCRIPTION
An image can be corrupted if, for instance, a pull or build
operation is killed (e.g., during commit).  In such cases, an image may
be listed even if a layer is missing.

Over time, Podman and Buildah have made various execution paths more
robust to handle such cases gracefully and/or give the users some help
in trying to resolve the issue.  So far, the recommended way was to
remove the corrupted image from storage and then pull it.

The linked Bugzilla issue raised the desire to simplify the recovery by
allowing to pull an image even if the local counterpart is corrupted.
This is especially important for installer scenarios, where users may
restart the installer which would attempt to pull the image again.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1966872
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
