### PR TITLE
libimage: fix Exists

### DIFF
--- a/libimage/corrupted_test.go
+++ b/libimage/corrupted_test.go
@@ -24,6 +24,10 @@ func TestCorruptedImage(t *testing.T) {
 
 	imageName := "quay.io/libpod/alpine_nginx:latest"
 
+	exists, err := runtime.Exists(imageName)
+	require.NoError(t, err, "image does not exist yet")
+	require.False(t, exists, "image does not exist yet")
+
 	pulledImages, err := runtime.Pull(ctx, imageName, config.PullPolicyAlways, pullOptions)
 	require.NoError(t, err)
 	require.Len(t, pulledImages, 1)
@@ -33,7 +37,7 @@ func TestCorruptedImage(t *testing.T) {
 	_, err = image.Inspect(ctx, false)
 	require.NoError(t, err, "inspecting healthy image should work")
 
-	exists, err := runtime.Exists(imageName)
+	exists, err = runtime.Exists(imageName)
 	require.NoError(t, err, "healthy image exists")
 	require.True(t, exists, "healthy image exists")
 

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -135,8 +135,11 @@ func (r *Runtime) storageToImage(storageImage *storage.Image, ref types.ImageRef
 // storage.  Note that it may return false if an image corrupted.
 func (r *Runtime) Exists(name string) (bool, error) {
 	image, _, err := r.LookupImage(name, &LookupImageOptions{IgnorePlatform: true})
-	if image == nil || err != nil && errors.Cause(err) != storage.ErrImageUnknown {
+	if err != nil && errors.Cause(err) != storage.ErrImageUnknown {
 		return false, err
+	}
+	if image == nil {
+		return false, nil
 	}
 	// Inspect the image to make sure if it's corrupted or not.
 	if _, err := image.Inspect(context.Background(), false); err != nil {


### PR DESCRIPTION
Commit 964b00275fe2 introduced a regression to Exists() which would
return an error if the image does not exist.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
