### PR TITLE
libimage: lookup images by custom platform

### DIFF
--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -349,7 +349,12 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 	// resolved name for pulling.  Assume we're doing a `pull foo`.
 	// If there's already a local image "localhost/foo", then we should
 	// attempt pulling that instead of doing the full short-name dance.
-	localImage, resolvedImageName, err = r.LookupImage(imageName, nil)
+	lookupOptions := &LookupImageOptions{
+		Architecture: options.Architecture,
+		OS:           options.OS,
+		Variant:      options.Variant,
+	}
+	localImage, resolvedImageName, err = r.LookupImage(imageName, lookupOptions)
 	if err != nil && errors.Cause(err) != storage.ErrImageUnknown {
 		logrus.Errorf("Looking up %s in local storage: %v", imageName, err)
 	}

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -153,6 +153,13 @@ type LookupImageOptions struct {
 	// the platform does not matter, for instance, for image removal.
 	IgnorePlatform bool
 
+	// Lookup an image matching the specified architecture.
+	Architecture string
+	// Lookup an image matching the specified OS.
+	OS string
+	// Lookup an image matching the specified variant.
+	Variant string
+
 	// If set, do not look for items/instances in the manifest list that
 	// match the current platform but return the manifest list as is.
 	lookupManifest bool
@@ -202,6 +209,25 @@ func (r *Runtime) LookupImage(name string, options *LookupImageOptions) (*Image,
 		// Strip off the sha256 prefix so it can be parsed later on.
 		idByDigest = true
 		name = strings.TrimPrefix(name, "sha256:")
+	}
+
+	// Set the platform for matching local images.
+	if !options.IgnorePlatform {
+		if options.Architecture == "" {
+			options.Architecture = r.systemContext.ArchitectureChoice
+		}
+		if options.Architecture == "" {
+			options.Architecture = runtime.GOARCH
+		}
+		if options.OS == "" {
+			options.OS = r.systemContext.OSChoice
+		}
+		if options.OS == "" {
+			options.OS = runtime.GOOS
+		}
+		if options.Variant == "" {
+			options.Variant = r.systemContext.VariantChoice
+		}
 	}
 
 	// First, check if we have an exact match in the storage. Maybe an ID
@@ -289,7 +315,7 @@ func (r *Runtime) lookupImageInLocalStorage(name, candidate string, options *Loo
 		if err != nil {
 			return nil, err
 		}
-		instance, err := manifestList.LookupInstance(context.Background(), "", "", "")
+		instance, err := manifestList.LookupInstance(context.Background(), options.Architecture, options.OS, options.Variant)
 		if err != nil {
 			// NOTE: If we are not looking for a specific platform
 			// and already found the manifest list, then return it
@@ -310,7 +336,7 @@ func (r *Runtime) lookupImageInLocalStorage(name, candidate string, options *Loo
 		return image, nil
 	}
 
-	matches, err := imageReferenceMatchesContext(context.Background(), ref, &r.systemContext)
+	matches, err := r.imageReferenceMatchesContext(ref, options)
 	if err != nil {
 		return nil, err
 	}
@@ -422,12 +448,13 @@ func (r *Runtime) ResolveName(name string) (string, error) {
 }
 
 // imageReferenceMatchesContext return true if the specified reference matches
-// the platform (os, arch, variant) as specified by the system context.
-func imageReferenceMatchesContext(ctx context.Context, ref types.ImageReference, sys *types.SystemContext) (bool, error) {
-	if sys == nil {
+// the platform (os, arch, variant) as specified by the lookup options.
+func (r *Runtime) imageReferenceMatchesContext(ref types.ImageReference, options *LookupImageOptions) (bool, error) {
+	if options.IgnorePlatform {
 		return true, nil
 	}
-	img, err := ref.NewImage(ctx, sys)
+	ctx := context.Background()
+	img, err := ref.NewImage(ctx, &r.systemContext)
 	if err != nil {
 		return false, err
 	}
@@ -436,16 +463,8 @@ func imageReferenceMatchesContext(ctx context.Context, ref types.ImageReference,
 	if err != nil {
 		return false, err
 	}
-	osChoice := sys.OSChoice
-	if osChoice == "" {
-		osChoice = runtime.GOOS
-	}
-	arch := sys.ArchitectureChoice
-	if arch == "" {
-		arch = runtime.GOARCH
-	}
-	if osChoice == data.Os && arch == data.Architecture {
-		if sys.VariantChoice == "" || sys.VariantChoice == data.Variant {
+	if options.OS == data.Os && options.Architecture == data.Architecture {
+		if options.Variant == "" || options.Variant == data.Variant {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
Allow for looking up images via customizable arch, os and variant.
This prevents `podman run --arch=xxx` from redundantly pulling down the
image if needed.

Context: containers/podman/issues/10648
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
