### PR TITLE
seccomp: allow timer_settime64

### DIFF
--- a/pkg/seccomp/default_linux.go
+++ b/pkg/seccomp/default_linux.go
@@ -368,6 +368,7 @@ func DefaultProfile() *Seccomp {
 				"timer_gettime",
 				"timer_gettime64",
 				"timer_settime",
+				"timer_settime64",
 				"timerfd_create",
 				"timerfd_gettime",
 				"timerfd_gettime64",

--- a/pkg/seccomp/seccomp.json
+++ b/pkg/seccomp/seccomp.json
@@ -372,6 +372,7 @@
 				"timer_gettime",
 				"timer_gettime64",
 				"timer_settime",
+				"timer_settime64",
 				"timerfd_create",
 				"timerfd_gettime",
 				"timerfd_gettime64",


### PR DESCRIPTION
allow time64 variant of timer_settime which was missed in 4e31f66

Signed-off-by: Jan Palus <jpalus@fastmail.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
