### PR TITLE
Set BigFilesTemporaryDir to GetEnv(TMPDIR) if set or /var/tmp 

### DIFF
--- a/libimage/download.go
+++ b/libimage/download.go
@@ -11,7 +11,7 @@ import (
 )
 
 // tmpdir returns a path to a temporary directory.
-func (r *Runtime) tmpdir() string {
+func tmpdir() string {
 	tmpdir := os.Getenv("TMPDIR")
 	if tmpdir == "" {
 		tmpdir = "/var/tmp"
@@ -25,7 +25,7 @@ func (r *Runtime) tmpdir() string {
 func (r *Runtime) downloadFromURL(source string) (string, error) {
 	fmt.Printf("Downloading from %q\n", source)
 
-	outFile, err := ioutil.TempFile(r.tmpdir(), "import")
+	outFile, err := ioutil.TempFile(r.systemContext.BigFilesTemporaryDir, "import")
 	if err != nil {
 		return "", errors.Wrap(err, "error creating file")
 	}

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -84,6 +84,9 @@ func RuntimeFromStore(store storage.Store, options *RuntimeOptions) (*Runtime, e
 	} else {
 		systemContext = types.SystemContext{}
 	}
+	if systemContext.BigFilesTemporaryDir == "" {
+		systemContext.BigFilesTemporaryDir = tmpdir()
+	}
 
 	setRegistriesConfPath(&systemContext)
 

--- a/libimage/runtime_test.go
+++ b/libimage/runtime_test.go
@@ -38,6 +38,7 @@ func testNewRuntime(t *testing.T) (runtime *Runtime, cleanup func()) {
 
 	runtime, err = RuntimeFromStoreOptions(&RuntimeOptions{SystemContext: systemContext}, storeOptions)
 	require.NoError(t, err)
+	require.Equal(t, runtime.systemContext.BigFilesTemporaryDir, tmpdir())
 
 	cleanup = func() {
 		runtime.Shutdown(true)


### PR DESCRIPTION
Currently if the caller does not specify the BigFilesTemporaryDir,
Podman and Buildah users expect this to default TMPDIR environment
variable or /var/tmp if not set.

Moving to libimage caused a regression in this functionality.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1972282

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
