### PR TITLE
libimage: force remove: only untag on multi tag image

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/containers/image/v5 v5.13.1
+	github.com/containers/image/v5 v5.13.2-0.20210617132750-db0df5e0cf5e
 	github.com/containers/ocicrypt v1.1.1
 	github.com/containers/storage v1.32.2
 	github.com/disiqueira/gotree/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,8 @@ github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHVlzhJpcY6TQxn/fUyDDM=
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
-github.com/containers/image/v5 v5.13.1 h1:eUb9YHEEo+akiQQEfCqZbAa9edg9Y6Mm30BG3NU4MbY=
-github.com/containers/image/v5 v5.13.1/go.mod h1:GkWursKDlDcUIT7L7vZf70tADvZCk/Ga0wgS0MuF0ag=
+github.com/containers/image/v5 v5.13.2-0.20210617132750-db0df5e0cf5e h1:5Q9jlvOsaPAavVxGbb2gBHcYi/SKKXERzPUCpeTP5E4=
+github.com/containers/image/v5 v5.13.2-0.20210617132750-db0df5e0cf5e/go.mod h1:GkWursKDlDcUIT7L7vZf70tADvZCk/Ga0wgS0MuF0ag=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=

--- a/libimage/load_test.go
+++ b/libimage/load_test.go
@@ -55,7 +55,7 @@ func TestLoad(t *testing.T) {
 		}
 
 		// Now remove the image.
-		rmReports, rmErrors := runtime.RemoveImages(ctx, loadedImages, &RemoveImagesOptions{Force: true})
+		rmReports, rmErrors := runtime.RemoveImages(ctx, ids, &RemoveImagesOptions{Force: true})
 		require.Len(t, rmErrors, 0)
 		require.Len(t, rmReports, test.numImages)
 

--- a/libimage/remove_test.go
+++ b/libimage/remove_test.go
@@ -1,0 +1,44 @@
+package libimage
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/containers/common/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveImages(t *testing.T) {
+	// Note: this will resolve pull from the GCR registry (see
+	// testdata/registries.conf).
+	busyboxLatest := "docker.io/library/busybox:latest"
+
+	runtime, cleanup := testNewRuntime(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	pullOptions := &PullOptions{}
+	pullOptions.Writer = os.Stdout
+	pulledImages, err := runtime.Pull(ctx, busyboxLatest, config.PullPolicyAlways, pullOptions)
+	require.NoError(t, err)
+	require.Len(t, pulledImages, 1)
+
+	err = pulledImages[0].Tag("foobar")
+	require.NoError(t, err)
+
+	// containers/podman/issues/10685 - force removal on image with
+	// multiple tags will only untag but not remove all tags including the
+	// image.
+	rmReports, rmErrors := runtime.RemoveImages(ctx, []string{"foobar"}, &RemoveImagesOptions{Force: true})
+	require.Nil(t, rmErrors)
+	require.Len(t, rmReports, 1)
+	require.Equal(t, pulledImages[0].ID(), rmReports[0].ID)
+	require.False(t, rmReports[0].Removed)
+	require.Equal(t, []string{"localhost/foobar:latest"}, rmReports[0].Untagged)
+
+	// The busybox image is still present even if foobar was force removed.
+	exists, err := runtime.Exists(busyboxLatest)
+	require.NoError(t, err)
+	require.True(t, exists)
+}

--- a/vendor/github.com/containers/image/v5/version/version.go
+++ b/vendor/github.com/containers/image/v5/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 13
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -48,7 +48,7 @@ github.com/containerd/cgroups/stats/v1
 github.com/containerd/containerd/errdefs
 github.com/containerd/containerd/log
 github.com/containerd/containerd/platforms
-# github.com/containers/image/v5 v5.13.1
+# github.com/containers/image/v5 v5.13.2-0.20210617132750-db0df5e0cf5e
 ## explicit
 github.com/containers/image/v5/copy
 github.com/containers/image/v5/directory


### PR DESCRIPTION
When removing an image by name, do not remove the image and all its
tags, even if force is set.  Instead, just untag the specified name.

Context: containers/podman/issues/10685
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
