### PR TITLE
[0.38] libimage: force remove: only untag on multi tag image

### DIFF
--- a/libimage/load_test.go
+++ b/libimage/load_test.go
@@ -55,7 +55,7 @@ func TestLoad(t *testing.T) {
 		}
 
 		// Now remove the image.
-		rmReports, rmErrors := runtime.RemoveImages(ctx, loadedImages, &RemoveImagesOptions{Force: true})
+		rmReports, rmErrors := runtime.RemoveImages(ctx, ids, &RemoveImagesOptions{Force: true})
 		require.Len(t, rmErrors, 0)
 		require.Len(t, rmReports, test.numImages)
 

--- a/libimage/remove_test.go
+++ b/libimage/remove_test.go
@@ -1,0 +1,44 @@
+package libimage
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/containers/common/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveImages(t *testing.T) {
+	// Note: this will resolve pull from the GCR registry (see
+	// testdata/registries.conf).
+	busyboxLatest := "docker.io/library/busybox:latest"
+
+	runtime, cleanup := testNewRuntime(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	pullOptions := &PullOptions{}
+	pullOptions.Writer = os.Stdout
+	pulledImages, err := runtime.Pull(ctx, busyboxLatest, config.PullPolicyAlways, pullOptions)
+	require.NoError(t, err)
+	require.Len(t, pulledImages, 1)
+
+	err = pulledImages[0].Tag("foobar")
+	require.NoError(t, err)
+
+	// containers/podman/issues/10685 - force removal on image with
+	// multiple tags will only untag but not remove all tags including the
+	// image.
+	rmReports, rmErrors := runtime.RemoveImages(ctx, []string{"foobar"}, &RemoveImagesOptions{Force: true})
+	require.Nil(t, rmErrors)
+	require.Len(t, rmReports, 1)
+	require.Equal(t, pulledImages[0].ID(), rmReports[0].ID)
+	require.False(t, rmReports[0].Removed)
+	require.Equal(t, []string{"localhost/foobar:latest"}, rmReports[0].Untagged)
+
+	// The busybox image is still present even if foobar was force removed.
+	exists, err := runtime.Exists(busyboxLatest)
+	require.NoError(t, err)
+	require.True(t, exists)
+}


### PR DESCRIPTION
When removing an image by name, do not remove the image and all its
tags, even if force is set.  Instead, just untag the specified name.

Note: adjust the load test to preserve the order in the untagged field.

Also vendor in the latest HEAD in containers/image to fix a bug revealed
in Podman CI.

Backport of commit c6578d76fb0da6f6a87d62ac33306945dc616205.

Context: containers/podman/issues/10685
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@containers/podman-maintainers PTAL
