### PR TITLE
libimage: pull: ignore platform for local image lookup

### DIFF
--- a/libimage/corrupted_test.go
+++ b/libimage/corrupted_test.go
@@ -64,6 +64,9 @@ func TestCorruptedImage(t *testing.T) {
 	_, err = image.Inspect(ctx, false)
 	require.Error(t, err, "inspecting corrupted image should fail")
 
+	err = image.isCorrupted(imageName)
+	require.Error(t, err, "image is corrupted")
+
 	exists, err = runtime.Exists(imageName)
 	require.NoError(t, err, "corrupted image exists should not fail")
 	require.False(t, exists, "corrupted image should not be marked to exist")
@@ -75,7 +78,7 @@ func TestCorruptedImage(t *testing.T) {
 	require.Len(t, pulledImages, 1)
 	image = pulledImages[0]
 
-	// Inpsecting a repaired image should work.
+	// Inspecting a repaired image should work.
 	_, err = image.Inspect(ctx, false)
 	require.NoError(t, err, "inspecting repaired image should work")
 }

--- a/libimage/image.go
+++ b/libimage/image.go
@@ -61,6 +61,24 @@ func (i *Image) reload() error {
 	return nil
 }
 
+// isCorrupted returns an error if the image may be corrupted.
+func (i *Image) isCorrupted(name string) error {
+	// If it's a manifest list, we're good for now.
+	if _, err := i.getManifestList(); err == nil {
+		return nil
+	}
+
+	ref, err := i.StorageReference()
+	if err != nil {
+		return err
+	}
+
+	if _, err := ref.NewImage(context.Background(), nil); err != nil {
+		return errors.Errorf("Image %s exists in local storage but may be corrupted: %v", name, err)
+	}
+	return nil
+}
+
 // Names returns associated names with the image which may be a mix of tags and
 // digests.
 func (i *Image) Names() []string {

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -105,6 +105,20 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 		r.writeEvent(&Event{ID: "", Name: name, Time: time.Now(), Type: EventTypeImagePull})
 	}
 
+	// Some callers may set the platform via the system context at creation
+	// time of the runtime.  We need this information to decide whether we
+	// need to enforce pulling from a registry (see
+	// containers/podman/issues/10682).
+	if options.Architecture == "" {
+		options.Architecture = r.systemContext.ArchitectureChoice
+	}
+	if options.OS == "" {
+		options.OS = r.systemContext.OSChoice
+	}
+	if options.Variant == "" {
+		options.Variant = r.systemContext.VariantChoice
+	}
+
 	var (
 		pulledImages []string
 		pullError    error
@@ -370,6 +384,20 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 		}
 	}
 
+	// Unless the pull policy is "always", we must pessimistically assume
+	// that the local image has an invalid architecture (see
+	// containers/podman/issues/10682).  Hence, whenever the user requests
+	// a custom platform, set the pull policy to "always" to make sure
+	// we're pulling down the image.
+	//
+	// NOTE that this is will even override --pull={false,never}.  This is
+	// very likely a bug but a consistent one in Podman/Buildah and should
+	// be addressed at a later point.
+	if pullPolicy != config.PullPolicyAlways && len(options.Architecture)+len(options.OS)+len(options.Variant) > 0 {
+		logrus.Debugf("Enforcing pull policy to %q to support custom platform (arch: %q, os: %q, variant: %q)", "always", options.Architecture, options.OS, options.Variant)
+		pullPolicy = config.PullPolicyAlways
+	}
+
 	if pullPolicy == config.PullPolicyNever {
 		if localImage != nil {
 			logrus.Debugf("Pull policy %q but no local image has been found for %s", pullPolicy, imageName)
@@ -377,16 +405,6 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 		}
 		logrus.Debugf("Pull policy %q and %s resolved to local image %s", pullPolicy, imageName, resolvedImageName)
 		return nil, errors.Wrap(storage.ErrImageUnknown, imageName)
-	}
-
-	// Unless the pull policy is "always", we must pessimistically assume
-	// that the local image has an invalid architecture (see
-	// containers/podman/issues/10682).  Hence, whenever the user requests
-	// a custom platform, set the pull policy to "always" to make sure
-	// we're pulling down the image.
-	if pullPolicy != config.PullPolicyAlways && len(options.Architecture)+len(options.OS)+len(options.Variant) > 0 {
-		logrus.Debugf("Enforcing pull policy to %q to support custom platform (arch: %q, os: %q, variant: %q)", "always", options.Architecture, options.OS, options.Variant)
-		pullPolicy = config.PullPolicyAlways
 	}
 
 	if pullPolicy == config.PullPolicyMissing && localImage != nil {

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -144,9 +144,8 @@ func (r *Runtime) Exists(name string) (bool, error) {
 	if image == nil {
 		return false, nil
 	}
-	// Inspect the image to make sure if it's corrupted or not.
-	if _, err := image.Inspect(context.Background(), false); err != nil {
-		logrus.Errorf("Image %s exists in local storage but may be corrupted: %v", name, err)
+	if err := image.isCorrupted(name); err != nil {
+		logrus.Error(err)
 		return false, nil
 	}
 	return true, nil


### PR DESCRIPTION
We must ignore the platform of a local image when doing lookups.  Some
images set an incorrect or even invalid platform (see
containers/podman/issues/10682).  Doing the lookup while ignoring the
platform checks prevents redundantly downloading the same image.

Note that this has the consequence that a `--pull-never --arch=hurz` may
chose a local image of another architecture.  However, I estimate the
benefit of continuing to allow potentially invalid images higher than
not running them (and breaking workloads).

The changes required to touch the corrupted checks.  I used the occasion
to make the corrupted checks a bit cheaper.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
