### PR TITLE
Allow /etc/containers/containers.conf to be read by non-root

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1053,7 +1053,7 @@ func (c *Config) Write() error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	configFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0600)
+	configFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -276,6 +276,11 @@ var _ = Describe("Config Local", func() {
 		}
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
+		fi, err := os.Stat(tmpfile)
+		gomega.Expect(err).To(gomega.BeNil())
+		perm := int(fi.Mode().Perm())
+		// 436 decimal = 644 octal
+		gomega.Expect(perm).To(gomega.Equal(420))
 		defer os.Remove(tmpfile)
 	})
 	It("Default Umask", func() {


### PR DESCRIPTION
If a root user writes to a config using Write(), and there is not already an /etc/containers/containers.conf, Write() will create it. This config file also needs to be read by non-root podman.

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
