### PR TITLE
0.38 backports plus bump to v0.38.10

### DIFF
--- a/libimage/corrupted_test.go
+++ b/libimage/corrupted_test.go
@@ -64,6 +64,9 @@ func TestCorruptedImage(t *testing.T) {
 	_, err = image.Inspect(ctx, false)
 	require.Error(t, err, "inspecting corrupted image should fail")
 
+	err = image.isCorrupted(imageName)
+	require.Error(t, err, "image is corrupted")
+
 	exists, err = runtime.Exists(imageName)
 	require.NoError(t, err, "corrupted image exists should not fail")
 	require.False(t, exists, "corrupted image should not be marked to exist")
@@ -75,7 +78,7 @@ func TestCorruptedImage(t *testing.T) {
 	require.Len(t, pulledImages, 1)
 	image = pulledImages[0]
 
-	// Inpsecting a repaired image should work.
+	// Inspecting a repaired image should work.
 	_, err = image.Inspect(ctx, false)
 	require.NoError(t, err, "inspecting repaired image should work")
 }

--- a/libimage/image.go
+++ b/libimage/image.go
@@ -61,6 +61,24 @@ func (i *Image) reload() error {
 	return nil
 }
 
+// isCorrupted returns an error if the image may be corrupted.
+func (i *Image) isCorrupted(name string) error {
+	// If it's a manifest list, we're good for now.
+	if _, err := i.getManifestList(); err == nil {
+		return nil
+	}
+
+	ref, err := i.StorageReference()
+	if err != nil {
+		return err
+	}
+
+	if _, err := ref.NewImage(context.Background(), nil); err != nil {
+		return errors.Errorf("Image %s exists in local storage but may be corrupted: %v", name, err)
+	}
+	return nil
+}
+
 // Names returns associated names with the image which may be a mix of tags and
 // digests.
 func (i *Image) Names() []string {

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -323,7 +323,7 @@ func (r *Runtime) copyFromRegistry(ctx context.Context, ref types.ImageReference
 // from a registry.  On successful pull it returns the used fully-qualified
 // name that can later be used to look up the image in the local containers
 // storage.
-func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName string, pullPolicy config.PullPolicy, options *PullOptions) ([]string, error) {
+func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName string, pullPolicy config.PullPolicy, options *PullOptions) ([]string, error) { //nolint:gocyclo
 	// Sanity check.
 	if err := pullPolicy.Validate(); err != nil {
 		return nil, err
@@ -339,9 +339,25 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 	// resolved name for pulling.  Assume we're doing a `pull foo`.
 	// If there's already a local image "localhost/foo", then we should
 	// attempt pulling that instead of doing the full short-name dance.
-	localImage, resolvedImageName, err = r.LookupImage(imageName, nil)
+	lookupOptions := &LookupImageOptions{
+		// NOTE: we must ignore the platform of a local image when
+		// doing lookups.  Some images set an incorrect or even invalid
+		// platform (see containers/podman/issues/10682).  Doing the
+		// lookup while ignoring the platform checks prevents
+		// redundantly downloading the same image.
+		IgnorePlatform: true,
+	}
+	localImage, resolvedImageName, err = r.LookupImage(imageName, lookupOptions)
 	if err != nil && errors.Cause(err) != storage.ErrImageUnknown {
 		logrus.Errorf("Looking up %s in local storage: %v", imageName, err)
+	}
+
+	// If the local image is corrupted, we need to repull it.
+	if localImage != nil {
+		if err := localImage.isCorrupted(imageName); err != nil {
+			logrus.Error(err)
+			localImage = nil
+		}
 	}
 
 	if pullPolicy == config.PullPolicyNever {

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -369,6 +369,16 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 		return nil, errors.Wrap(storage.ErrImageUnknown, imageName)
 	}
 
+	// Unless the pull policy is "always", we must pessimistically assume
+	// that the local image has an invalid architecture (see
+	// containers/podman/issues/10682).  Hence, whenever the user requests
+	// a custom platform, set the pull policy to "always" to make sure
+	// we're pulling down the image.
+	if pullPolicy != config.PullPolicyAlways && len(options.Architecture)+len(options.OS)+len(options.Variant) > 0 {
+		logrus.Debugf("Enforcing pull policy to %q to support custom platform (arch: %q, os: %q, variant: %q)", "always", options.Architecture, options.OS, options.Variant)
+		pullPolicy = config.PullPolicyAlways
+	}
+
 	if pullPolicy == config.PullPolicyMissing && localImage != nil {
 		return []string{resolvedImageName}, nil
 	}

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -141,9 +141,8 @@ func (r *Runtime) Exists(name string) (bool, error) {
 	if image == nil {
 		return false, nil
 	}
-	// Inspect the image to make sure if it's corrupted or not.
-	if _, err := image.Inspect(context.Background(), false); err != nil {
-		logrus.Errorf("Image %s exists in local storage but may be corrupted: %v", name, err)
+	if err := image.isCorrupted(name); err != nil {
+		logrus.Error(err)
 		return false, nil
 	}
 	return true, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -981,7 +981,7 @@ func (c *Config) Write() error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	configFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0600)
+	configFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -260,12 +260,6 @@ var _ = Describe("Config Local", func() {
 		oldContainersConf, envSet := os.LookupEnv("CONTAINERS_CONF")
 		os.Setenv("CONTAINERS_CONF", tmpfile)
 		config, err := ReadCustomConfig()
-		// Undo that
-		if envSet {
-			os.Setenv("CONTAINERS_CONF", oldContainersConf)
-		} else {
-			os.Unsetenv("CONTAINERS_CONF")
-		}
 		gomega.Expect(err).To(gomega.BeNil())
 		config.Containers.Devices = []string{"/dev/null:/dev/null:rw",
 			"/dev/sdc/",
@@ -274,6 +268,12 @@ var _ = Describe("Config Local", func() {
 		}
 
 		err = config.Write()
+		// Undo that
+		if envSet {
+			os.Setenv("CONTAINERS_CONF", oldContainersConf)
+		} else {
+			os.Unsetenv("CONTAINERS_CONF")
+		}
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
 		fi, err := os.Stat(tmpfile)

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -276,6 +276,11 @@ var _ = Describe("Config Local", func() {
 		err = config.Write()
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
+		fi, err := os.Stat(tmpfile)
+		gomega.Expect(err).To(gomega.BeNil())
+		perm := int(fi.Mode().Perm())
+		// 436 decimal = 644 octal
+		gomega.Expect(perm).To(gomega.Equal(420))
 		defer os.Remove(tmpfile)
 	})
 	It("Default Umask", func() {

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.38.10-dev"
+const Version = "0.38.10"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.38.10"
+const Version = "0.38.11-dev"


### PR DESCRIPTION
* libimage: pull: override even --pull=never with custom platfo
* libimage: pull: enforce pull policy for custom platforms
* libimage: pull: ignore platform for local image lookup
* Allow /etc/containers/containers.conf to be read by non-root
* [0.38] libimage: force remove: only untag on multi tag image

@rhatdan @Luap99 @mheon PTAL

Those are the backports for Podman v3.2.2