### PR TITLE
libimage: `(*Runtime).SystemContext()`

### DIFF
--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -54,6 +54,11 @@ type Runtime struct {
 }
 
 // Returns a copy of the runtime's system context.
+func (r *Runtime) SystemContext() *types.SystemContext {
+	return r.systemContextCopy()
+}
+
+// Returns a copy of the runtime's system context.
 func (r *Runtime) systemContextCopy() *types.SystemContext {
 	var sys types.SystemContext
 	deepcopy.Copy(&sys, &r.systemContext)

--- a/libimage/runtime_test.go
+++ b/libimage/runtime_test.go
@@ -44,5 +44,8 @@ func testNewRuntime(t *testing.T) (runtime *Runtime, cleanup func()) {
 		runtime.Shutdown(true)
 		_ = os.RemoveAll(workdir)
 	}
+
+	sys := runtime.SystemContext()
+	require.NotNil(t, sys)
 	return runtime, cleanup
 }


### PR DESCRIPTION
Add a method to the libimage runtime to access (a copy of) its
types.SystemContext.  That can be helpful for callers which may need to
access the system context.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
