### PR TITLE
libimage: events: deferred write

### DIFF
--- a/libimage/image.go
+++ b/libimage/image.go
@@ -298,7 +298,7 @@ func (i *Image) remove(ctx context.Context, rmMap map[string]*RemoveImageReport,
 	}
 
 	if i.runtime.eventChannel != nil {
-		i.runtime.writeEvent(&Event{ID: i.ID(), Name: referencedBy, Time: time.Now(), Type: EventTypeImageRemove})
+		defer i.runtime.writeEvent(&Event{ID: i.ID(), Name: referencedBy, Time: time.Now(), Type: EventTypeImageRemove})
 	}
 
 	// Check if already visisted this image.
@@ -450,7 +450,7 @@ func (i *Image) Tag(name string) error {
 
 	logrus.Debugf("Tagging image %s with %q", i.ID(), ref.String())
 	if i.runtime.eventChannel != nil {
-		i.runtime.writeEvent(&Event{ID: i.ID(), Name: name, Time: time.Now(), Type: EventTypeImageTag})
+		defer i.runtime.writeEvent(&Event{ID: i.ID(), Name: name, Time: time.Now(), Type: EventTypeImageTag})
 	}
 
 	newNames := append(i.Names(), ref.String())
@@ -484,7 +484,7 @@ func (i *Image) Untag(name string) error {
 
 	logrus.Debugf("Untagging %q from image %s", ref.String(), i.ID())
 	if i.runtime.eventChannel != nil {
-		i.runtime.writeEvent(&Event{ID: i.ID(), Name: name, Time: time.Now(), Type: EventTypeImageUntag})
+		defer i.runtime.writeEvent(&Event{ID: i.ID(), Name: name, Time: time.Now(), Type: EventTypeImageUntag})
 	}
 
 	removedName := false
@@ -626,7 +626,7 @@ func (i *Image) RepoDigests() ([]string, error) {
 // evaluated path to the mount point.
 func (i *Image) Mount(ctx context.Context, mountOptions []string, mountLabel string) (string, error) {
 	if i.runtime.eventChannel != nil {
-		i.runtime.writeEvent(&Event{ID: i.ID(), Name: "", Time: time.Now(), Type: EventTypeImageMount})
+		defer i.runtime.writeEvent(&Event{ID: i.ID(), Name: "", Time: time.Now(), Type: EventTypeImageMount})
 	}
 
 	mountPoint, err := i.runtime.store.MountImage(i.ID(), mountOptions, mountLabel)
@@ -671,7 +671,7 @@ func (i *Image) Mountpoint() (string, error) {
 // unmount.
 func (i *Image) Unmount(force bool) error {
 	if i.runtime.eventChannel != nil {
-		i.runtime.writeEvent(&Event{ID: i.ID(), Name: "", Time: time.Now(), Type: EventTypeImageUnmount})
+		defer i.runtime.writeEvent(&Event{ID: i.ID(), Name: "", Time: time.Now(), Type: EventTypeImageUnmount})
 	}
 	logrus.Debugf("Unmounted image %s", i.ID())
 	_, err := i.runtime.store.UnmountImage(i.ID(), force)

--- a/libimage/load.go
+++ b/libimage/load.go
@@ -25,7 +25,7 @@ func (r *Runtime) Load(ctx context.Context, path string, options *LoadOptions) (
 	logrus.Debugf("Loading image from %q", path)
 
 	if r.eventChannel != nil {
-		r.writeEvent(&Event{ID: "", Name: path, Time: time.Now(), Type: EventTypeImageLoad})
+		defer r.writeEvent(&Event{ID: "", Name: path, Time: time.Now(), Type: EventTypeImageLoad})
 	}
 
 	var (

--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -374,7 +374,7 @@ func (m *ManifestList) Push(ctx context.Context, destination string, options *Ma
 	}
 
 	if m.image.runtime.eventChannel != nil {
-		m.image.runtime.writeEvent(&Event{ID: m.ID(), Name: destination, Time: time.Now(), Type: EventTypeImagePush})
+		defer m.image.runtime.writeEvent(&Event{ID: m.ID(), Name: destination, Time: time.Now(), Type: EventTypeImagePush})
 	}
 
 	// NOTE: we're using the logic in copier to create a proper

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -102,7 +102,7 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 	}
 
 	if r.eventChannel != nil {
-		r.writeEvent(&Event{ID: "", Name: name, Time: time.Now(), Type: EventTypeImagePull})
+		defer r.writeEvent(&Event{ID: "", Name: name, Time: time.Now(), Type: EventTypeImagePull})
 	}
 
 	// Some callers may set the platform via the system context at creation

--- a/libimage/push.go
+++ b/libimage/push.go
@@ -65,7 +65,7 @@ func (r *Runtime) Push(ctx context.Context, source, destination string, options 
 	}
 
 	if r.eventChannel != nil {
-		r.writeEvent(&Event{ID: image.ID(), Name: destination, Time: time.Now(), Type: EventTypeImagePush})
+		defer r.writeEvent(&Event{ID: image.ID(), Name: destination, Time: time.Now(), Type: EventTypeImagePush})
 	}
 
 	// Buildah compat: Make sure to tag the destination image if it's a

--- a/libimage/save.go
+++ b/libimage/save.go
@@ -80,7 +80,7 @@ func (r *Runtime) saveSingleImage(ctx context.Context, name, format, path string
 	}
 
 	if r.eventChannel != nil {
-		r.writeEvent(&Event{ID: image.ID(), Name: path, Time: time.Now(), Type: EventTypeImageSave})
+		defer r.writeEvent(&Event{ID: image.ID(), Name: path, Time: time.Now(), Type: EventTypeImageSave})
 	}
 
 	// Unless the image was referenced by ID, use the resolved name as a
@@ -183,7 +183,7 @@ func (r *Runtime) saveDockerArchive(ctx context.Context, names []string, path st
 		}
 		localImages[image.ID()] = local
 		if r.eventChannel != nil {
-			r.writeEvent(&Event{ID: image.ID(), Name: path, Time: time.Now(), Type: EventTypeImageSave})
+			defer r.writeEvent(&Event{ID: image.ID(), Name: path, Time: time.Now(), Type: EventTypeImageSave})
 		}
 	}
 


### PR DESCRIPTION
Some users rely on events being written *after* the operation ran.
Hence, defer all event writes.

Context: containers/podman/issues/10812
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
