### PR TITLE
Report bad entries in containers.conf to the user

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jinzhu/copier v0.3.2
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -523,6 +523,7 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -526,9 +526,15 @@ func NewConfig(userConfigPath string) (*Config, error) {
 // the defaults from the config parameter will be used for all other fields.
 func readConfigFromFile(path string, config *Config) error {
 	logrus.Tracef("Reading configuration file %q", path)
-	if _, err := toml.DecodeFile(path, config); err != nil {
+	meta, err := toml.DecodeFile(path, config)
+	if err != nil {
 		return errors.Wrapf(err, "decode configuration %v", path)
 	}
+	keys := meta.Undecoded()
+	if len(keys) > 0 {
+		logrus.Warningf("Failed to decode the keys %q from %q.", keys, path)
+	}
+
 	return nil
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"sort"
@@ -11,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	selinux "github.com/opencontainers/selinux/go-selinux"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("Config", func() {
@@ -640,6 +642,18 @@ var _ = Describe("Config", func() {
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			testConfigs := append(configs, []string{file4, file3, file2, file1}...)
 			gomega.Expect(newConfigs).To(gomega.Equal(testConfigs))
+		})
+
+		It("test config errors", func() {
+			conf := Config{}
+			content := bytes.NewBufferString("")
+			logrus.SetOutput(content)
+			err := readConfigFromFile("testdata/containers_broken.conf", &conf)
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(conf.Containers.NetNS).To(gomega.Equal("bridge"))
+			gomega.Expect(conf.Containers.Umask).To(gomega.Equal("0002"))
+			gomega.Expect(content).To(gomega.ContainSubstring("Failed to decode the keys [\\\"foo\\\" \\\"containers.image_default_transport\\\"] from \\\"testdata/containers_broken.conf\\\""))
+			logrus.SetOutput(os.Stderr)
 		})
 	})
 

--- a/pkg/config/testdata/containers_broken.conf
+++ b/pkg/config/testdata/containers_broken.conf
@@ -1,0 +1,16 @@
+foo="bar"
+[containers]
+
+#Umask inside the container
+umask="0002"
+
+# default network mode
+netns="bridge"
+
+# Default transport method for pulling and pushing for images
+image_default_transport = "docker://"
+
+[engine]
+
+# Cgroup management implementation used for the runtime.
+cgroup_manager = "systemd"


### PR DESCRIPTION
Currently if a user puts a typo into a contianers.conf
or puts the keys in the wrong section, then tools using
container-common ignore them. This patch will print them
as warnings, so that the user has some ide.

[NO TESTS NEEDED] Since I have no idea how to test this.

I have tested this locally with Podman.
./bin/podman run alpine echo hi
WARN[0000] Failed to decode the keys ["containers.events_logger" "engine.foo"] from "/home/dwalsh/.config/containers/containers.conf".
WARN[0000] Failed to decode the keys ["containers.events_logger" "engine.foo"] from "/home/dwalsh/.config/containers/containers.conf".
WARN[0000] Failed to decode the keys ["containers.events_logger" "engine.foo"] from "/home/dwalsh/.config/containers/containers.conf".
WARN[0000] Failed to decode the keys ["containers.events_logger" "engine.foo"] from "/home/dwalsh/.config/containers/containers.conf".
hi

With ~/.config/containers/containers.conf

[containers]
events_logger = "file"
[engine]
foo="bar"

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
