### PR TITLE
0.38 backports

### DIFF
--- a/libimage/filters.go
+++ b/libimage/filters.go
@@ -63,14 +63,14 @@ func (r *Runtime) compileImageFilters(ctx context.Context, filters []string) ([]
 		switch key {
 
 		case "after", "since":
-			img, _, err := r.LookupImage(value, nil)
+			img, _, err := r.LookupImage(value, &LookupImageOptions{IgnorePlatform: true})
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not find local image for filter %q", filter)
 			}
 			filterFuncs = append(filterFuncs, filterAfter(img.Created()))
 
 		case "before":
-			img, _, err := r.LookupImage(value, nil)
+			img, _, err := r.LookupImage(value, &LookupImageOptions{IgnorePlatform: true})
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not find local image for filter %q", filter)
 			}

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -61,7 +61,7 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 			if pullPolicy == config.PullPolicyAlways {
 				return nil, errors.Errorf("pull policy is always but image has been referred to by ID (%s)", name)
 			}
-			local, _, err := r.LookupImage(name, nil)
+			local, _, err := r.LookupImage(name, &LookupImageOptions{IgnorePlatform: true})
 			if err != nil {
 				return nil, err
 			}
@@ -136,9 +136,8 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 	}
 
 	localImages := []*Image{}
-	lookupOptions := &LookupImageOptions{IgnorePlatform: true}
 	for _, name := range pulledImages {
-		local, _, err := r.LookupImage(name, lookupOptions)
+		local, _, err := r.LookupImage(name, &LookupImageOptions{IgnorePlatform: true})
 		if err != nil {
 			return nil, errors.Wrapf(err, "error locating pulled image %q name in containers storage", name)
 		}

--- a/libimage/save.go
+++ b/libimage/save.go
@@ -74,7 +74,7 @@ func (r *Runtime) Save(ctx context.Context, names []string, format, path string,
 // saveSingleImage saves the specified image name to the specified path.
 // Supported formats are "oci-archive", "oci-dir" and "docker-dir".
 func (r *Runtime) saveSingleImage(ctx context.Context, name, format, path string, options *SaveOptions) error {
-	image, imageName, err := r.LookupImage(name, nil)
+	image, imageName, err := r.LookupImage(name, &LookupImageOptions{IgnorePlatform: true})
 	if err != nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func (r *Runtime) saveDockerArchive(ctx context.Context, names []string, path st
 	visitedNames := make(map[string]bool)       // filters duplicate names
 	for _, name := range names {
 		// Look up local images.
-		image, imageName, err := r.LookupImage(name, nil)
+		image, imageName, err := r.LookupImage(name, &LookupImageOptions{IgnorePlatform: true})
 		if err != nil {
 			return err
 		}

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.38.14-dev"
+const Version = "0.38.14"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.38.14"
+const Version = "0.38.15-dev"


### PR DESCRIPTION
Backport of commit ec93641802d0 plus version dance.  I expect this to be the last fix for all the multi-arch farts.

I'll tackle the general issue in the main branch and get rid off the IgnorePlatform option altogether.