### PR TITLE
libimage: LookupImage: remove IgnorePlatform option

### DIFF
--- a/libimage/filters.go
+++ b/libimage/filters.go
@@ -63,14 +63,14 @@ func (r *Runtime) compileImageFilters(ctx context.Context, filters []string) ([]
 		switch key {
 
 		case "after", "since":
-			img, _, err := r.LookupImage(value, &LookupImageOptions{IgnorePlatform: true})
+			img, _, err := r.LookupImage(value, nil)
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not find local image for filter %q", filter)
 			}
 			filterFuncs = append(filterFuncs, filterAfter(img.Created()))
 
 		case "before":
-			img, _, err := r.LookupImage(value, &LookupImageOptions{IgnorePlatform: true})
+			img, _, err := r.LookupImage(value, nil)
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not find local image for filter %q", filter)
 			}

--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -78,7 +78,6 @@ func (r *Runtime) LookupManifestList(name string) (*ManifestList, error) {
 
 func (r *Runtime) lookupManifestList(name string) (*Image, manifests.List, error) {
 	lookupOptions := &LookupImageOptions{
-		IgnorePlatform: true,
 		lookupManifest: true,
 	}
 	image, _, err := r.LookupImage(name, lookupOptions)

--- a/libimage/pull_test.go
+++ b/libimage/pull_test.go
@@ -87,10 +87,6 @@ func TestPullPlatforms(t *testing.T) {
 	require.NoError(t, err, "lookup busybox")
 	require.NotNil(t, image, "lookup busybox")
 
-	image, _, err = runtime.LookupImage("busybox", &LookupImageOptions{IgnorePlatform: true})
-	require.NoError(t, err, "lookup busybox - ign. platform")
-	require.NotNil(t, image, "lookup busybox - ing. platform")
-
 	image, _, err = runtime.LookupImage("busybox", &LookupImageOptions{Architecture: localArch})
 	require.NoError(t, err, "lookup busybox - by local arch")
 	require.NotNil(t, image, "lookup busybox - by local arch")
@@ -109,17 +105,9 @@ func TestPullPlatforms(t *testing.T) {
 	pulledImages, err = runtime.Pull(ctx, "busybox", config.PullPolicyAlways, pullOptions)
 	require.NoError(t, err, "pull busybox - arm")
 	require.Len(t, pulledImages, 1)
-
-	if localArch != "arm" {
-		_, _, err = runtime.LookupImage("busybox", nil)
-		require.Error(t, err, "lookup busybox - local arch != arm")
-	}
+	pullOptions.Architecture = ""
 
 	image, _, err = runtime.LookupImage("busybox", &LookupImageOptions{Architecture: "arm"})
 	require.NoError(t, err, "lookup busybox - by arm")
 	require.NotNil(t, image, "lookup busybox - by local arch")
-
-	image, _, err = runtime.LookupImage("busybox", &LookupImageOptions{IgnorePlatform: true})
-	require.NoError(t, err, "lookup busybox - ign. platform")
-	require.NotNil(t, image, "lookup busybox - ing. platform")
 }

--- a/libimage/push.go
+++ b/libimage/push.go
@@ -31,8 +31,7 @@ func (r *Runtime) Push(ctx context.Context, source, destination string, options 
 
 	// Look up the local image.  Note that we need to ignore the platform
 	// and push what the user specified (containers/podman/issues/10344).
-	lookupOptions := &LookupImageOptions{IgnorePlatform: true}
-	image, resolvedSource, err := r.LookupImage(source, lookupOptions)
+	image, resolvedSource, err := r.LookupImage(source, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/libimage/save.go
+++ b/libimage/save.go
@@ -74,7 +74,7 @@ func (r *Runtime) Save(ctx context.Context, names []string, format, path string,
 // saveSingleImage saves the specified image name to the specified path.
 // Supported formats are "oci-archive", "oci-dir" and "docker-dir".
 func (r *Runtime) saveSingleImage(ctx context.Context, name, format, path string, options *SaveOptions) error {
-	image, imageName, err := r.LookupImage(name, &LookupImageOptions{IgnorePlatform: true})
+	image, imageName, err := r.LookupImage(name, nil)
 	if err != nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func (r *Runtime) saveDockerArchive(ctx context.Context, names []string, path st
 	visitedNames := make(map[string]bool)       // filters duplicate names
 	for _, name := range names {
 		// Look up local images.
-		image, imageName, err := r.LookupImage(name, &LookupImageOptions{IgnorePlatform: true})
+		image, imageName, err := r.LookupImage(name, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When writing LookupImage, I thought that it's a good idea to always
attempt to match an image against the local (or requested) platform.
The use case I had in mind is multi-arch support:

`$ podman run image` should only match `image` if it matches the local
platform.  We may have previously pulled `image` for another
architecture.

The core criteria for these checks is that images set their platform
(arch/os/variant) correctly.  As it turned out that is not the case.
We recently performed a number of fixes to better support multi-arch
images and this change should put the last nail in the coffin.

Hence, entirely remove the `IgnorePlatform` option and only perform
platform matches if the arch, os or variant is specified explicitly via
the LookupImageOptions or the runtime's system context (as Buildah likes
to do it).

Note that this is a breaking change, so I need to update Buildah and
Podman.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
