### PR TITLE
Fix default definition of secrets in containers.conf

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -530,7 +530,7 @@ Currently valid values are:
   * file
   * pass
 
-**opts**={}
+**[secrets.opts]**
 
 The driver specific options object.
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -655,6 +655,16 @@ var _ = Describe("Config", func() {
 			gomega.Expect(content).To(gomega.ContainSubstring("Failed to decode the keys [\\\"foo\\\" \\\"containers.image_default_transport\\\"] from \\\"testdata/containers_broken.conf\\\""))
 			logrus.SetOutput(os.Stderr)
 		})
+
+		It("test default config errors", func() {
+			conf := Config{}
+			content := bytes.NewBufferString("")
+			logrus.SetOutput(content)
+			err := readConfigFromFile("containers.conf", &conf)
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(content.String()).To(gomega.Equal(""))
+			logrus.SetOutput(os.Stderr)
+		})
 	})
 
 	Describe("Reload", func() {

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -243,6 +243,12 @@ default_sysctls = [
 # The network table contains settings pertaining to the management of
 # CNI plugins.
 
+[secrets]
+# driver = "file"
+
+[secrets.opts]
+# root = "/example/directory"
+
 [network]
 
 # Path to directory where CNI plugin binaries are located.
@@ -503,9 +509,3 @@ default_sysctls = [
 # TOML does not provide a way to end a table other than a further table being
 # defined, so every key hereafter will be part of [volume_plugins] and not the
 # main config.
-
-[secret]
-# driver = "file"
-
-[secret.opts]
-# root = "/example/directory"


### PR DESCRIPTION
We had a bogus setting for secrets in our default containers.conf
[secret] should have been [secrets].

Also added a test to make sure this never happens again.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
