### PR TITLE
[0.38] Don't use systemd defaults if /proc/1/comm != systemd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GO_BUILD=$(GO) build
 ifeq ($(shell go help mod >/dev/null 2>&1 && echo true), true)
 	GO_BUILD=GO111MODULE=on $(GO) build -mod=vendor
 endif
-BUILDTAGS := containers_image_openpgp
+BUILDTAGS := containers_image_openpgp,systemd
 DESTDIR ?=
 PREFIX := /usr/local
 CONFIGDIR := ${PREFIX}/share/containers

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -191,7 +191,7 @@ func DefaultConfig() (*Config, error) {
 			Init:       false,
 			InitPath:   "",
 			IPCNS:      "private",
-			LogDriver:  DefaultLogDriver,
+			LogDriver:  defaultLogDriver(),
 			LogSizeMax: DefaultLogSizeMax,
 			NetNS:      netns,
 			NoHosts:    false,

--- a/pkg/config/nosystemd.go
+++ b/pkg/config/nosystemd.go
@@ -3,9 +3,17 @@
 package config
 
 func defaultCgroupManager() string {
-	return "cgroupfs"
+	return CgroupfsCgroupsManager
 }
 
 func defaultEventsLogger() string {
 	return "file"
+}
+
+func defaultLogDriver() string {
+	return DefaultLogDriver
+}
+
+func useSystemd() bool {
+	return false
 }

--- a/pkg/config/systemd.go
+++ b/pkg/config/systemd.go
@@ -3,11 +3,23 @@
 package config
 
 import (
+	"io/ioutil"
+	"strings"
+	"sync"
+
 	"github.com/containers/common/pkg/cgroupv2"
 	"github.com/containers/storage/pkg/unshare"
 )
 
+var (
+	systemdOnce sync.Once
+	usesSystemd bool
+)
+
 func defaultCgroupManager() string {
+	if !useSystemd() {
+		return CgroupfsCgroupsManager
+	}
 	enabled, err := cgroupv2.Enabled()
 	if err == nil && !enabled && unshare.IsRootless() {
 		return CgroupfsCgroupsManager
@@ -15,6 +27,32 @@ func defaultCgroupManager() string {
 
 	return SystemdCgroupsManager
 }
+
 func defaultEventsLogger() string {
-	return "journald"
+	if useSystemd() {
+		return "journald"
+	}
+	return "file"
+}
+
+func defaultLogDriver() string {
+	// If we decide to change the default for logdriver, it should be done here.
+	if useSystemd() {
+		return DefaultLogDriver
+	}
+
+	return DefaultLogDriver
+
+}
+
+func useSystemd() bool {
+	systemdOnce.Do(func() {
+		dat, err := ioutil.ReadFile("/proc/1/comm")
+		if err == nil {
+			val := strings.TrimSuffix(string(dat), "\n")
+			usesSystemd = (val == "systemd")
+		}
+		return
+	})
+	return usesSystemd
 }


### PR DESCRIPTION
Currently we have users failing to run containers within containers
or on systems without systemd support.  This change will give us
better defaults on these systems.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1979497
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@containers/podman-maintainers PTAL

I did not bump the version yet as I want to wait a bit for more things to pile up.