### PR TITLE
libimage: import: fix tags

### DIFF
--- a/libimage/import.go
+++ b/libimage/import.go
@@ -86,16 +86,12 @@ func (r *Runtime) Import(ctx context.Context, path string, options *ImportOption
 		return "", err
 	}
 
-	name := options.Tag
-	if name == "" {
-		name, err = getImageDigest(ctx, srcRef, r.systemContextCopy())
-		if err != nil {
-			return "", err
-		}
-		name = "sha256:" + name[1:] // strip leading "@"
+	id, err := getImageDigest(ctx, srcRef, r.systemContextCopy())
+	if err != nil {
+		return "", err
 	}
 
-	destRef, err := storageTransport.Transport.ParseStoreReference(r.store, name)
+	destRef, err := storageTransport.Transport.ParseStoreReference(r.store, id)
 	if err != nil {
 		return "", err
 	}
@@ -110,5 +106,19 @@ func (r *Runtime) Import(ctx context.Context, path string, options *ImportOption
 		return "", err
 	}
 
-	return name, nil
+	// Strip the leading @ off the id.
+	name := id[1:]
+
+	// If requested, tag the imported image.
+	if options.Tag != "" {
+		image, _, err := r.LookupImage(name, nil)
+		if err != nil {
+			return "", errors.Wrap(err, "looking up imported image")
+		}
+		if err := image.Tag(options.Tag); err != nil {
+			return "", err
+		}
+	}
+
+	return "sha256:" + name, nil
 }

--- a/libimage/import_test.go
+++ b/libimage/import_test.go
@@ -16,11 +16,19 @@ func TestImport(t *testing.T) {
 	importOptions := &ImportOptions{}
 	importOptions.Writer = os.Stdout
 
-	imported, err := runtime.Import(ctx, "testdata/exported-container.tar", importOptions)
-	require.NoError(t, err)
+	for _, tag := range []string{"", "foobar"} {
+		importOptions.Tag = tag
+		imported, err := runtime.Import(ctx, "testdata/exported-container.tar", importOptions)
+		require.NoError(t, err)
 
-	image, resolvedName, err := runtime.LookupImage(imported, nil)
-	require.NoError(t, err)
-	require.Equal(t, imported, resolvedName)
-	require.Equal(t, imported, "sha256:"+image.ID())
+		image, resolvedName, err := runtime.LookupImage(imported, nil)
+		require.NoError(t, err)
+		require.Equal(t, imported, resolvedName)
+		require.Equal(t, "sha256:"+image.ID(), imported)
+
+		if tag != "" {
+			_, _, err := runtime.LookupImage(tag, nil)
+			require.NoError(t, err)
+		}
+	}
 }


### PR DESCRIPTION
When importing, first create the image and tag it afterwards.  This also
makes sure that an imported image *without* a tag is correctly listed as
"<none>".  Previously, such images were tagged as
"docker.io/library/sha256:$ID" (inherited from older Podman code).

Context: containers/podman/issues/10854
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
