### PR TITLE
[0.38] libimage: import: fix tags

### DIFF
--- a/libimage/import_test.go
+++ b/libimage/import_test.go
@@ -16,11 +16,19 @@ func TestImport(t *testing.T) {
 	importOptions := &ImportOptions{}
 	importOptions.Writer = os.Stdout
 
-	imported, err := runtime.Import(ctx, "testdata/exported-container.tar", importOptions)
-	require.NoError(t, err)
+	for _, tag := range []string{"", "foobar"} {
+		importOptions.Tag = tag
+		imported, err := runtime.Import(ctx, "testdata/exported-container.tar", importOptions)
+		require.NoError(t, err)
 
-	image, resolvedName, err := runtime.LookupImage(imported, nil)
-	require.NoError(t, err)
-	require.Equal(t, imported, resolvedName)
-	require.Equal(t, imported, "sha256:"+image.ID())
+		image, resolvedName, err := runtime.LookupImage(imported, nil)
+		require.NoError(t, err)
+		require.Equal(t, imported, resolvedName)
+		require.Equal(t, "sha256:"+image.ID(), imported)
+
+		if tag != "" {
+			_, _, err := runtime.LookupImage(tag, nil)
+			require.NoError(t, err)
+		}
+	}
 }


### PR DESCRIPTION
When importing, first create the image and tag it afterwards.  This also
makes sure that an imported image *without* a tag is correctly listed as
"<none>".  Previously, such images were tagged as
"docker.io/library/sha256:$ID" (inherited from older Podman code).

Context: containers/podman/issues/10854
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
