### PR TITLE
libimage: image tree: fix nil deref

### DIFF
--- a/libimage/image_tree.go
+++ b/libimage/image_tree.go
@@ -80,6 +80,10 @@ func (i *Image) Tree(traverseChildren bool) (string, error) {
 }
 
 func imageTreeTraverseChildren(node *layerNode, parent gotree.Tree) error {
+	if node.layer == nil {
+		return nil
+	}
+
 	var tags string
 	repoTags, err := node.repoTags()
 	if err != nil {


### PR DESCRIPTION
(*Image)Tree() hit a nil deref when traversing the children of an image
without a physical layer.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

There are no tests _here_ for image tree yet, so I hope you trust me :) @rhatdan @Luap99 PTAL