### PR TITLE
add config option for ChownCopiedFiles

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -494,6 +494,11 @@ By default this will be configured relative to where containers/storage store
 containers. This convention is followed by the default volume driver, but may
 not be by other drivers.
 
+**chown_copied_files**=true
+
+Determines whether file copied into a container will have changed ownership to
+the primary uid/gid of the container.
+
 ## SERVICE DESTINATION TABLE
 The `service_destinations` table contains configuration options used to set up remote connections to the podman service for the podman API.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -384,6 +384,10 @@ type EngineConfig struct {
 	// will refer to the plugin as) mapped to a path, which must point to a
 	// Unix socket that conforms to the Volume Plugin specification.
 	VolumePlugins map[string]string `toml:"volume_plugins,omitempty"`
+
+	// ChownCopiedFiles tells the container engine whether to chown files copied
+	// into a container to the container's primary uid/gid.
+	ChownCopiedFiles bool `toml:"chown_copied_files"`
 }
 
 // SetOptions contains a subset of options in a Config. It's used to indicate if

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -340,6 +340,8 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	c.LockType = "shm"
 	c.MachineEnabled = false
 
+	c.ChownCopiedFiles = true
+
 	return c, nil
 }
 


### PR DESCRIPTION
A new container engine config boolean determining whether files copied into a container should have changed ownership to the primary uid/gid of the container.
