### PR TITLE
User option to prepare container after creation for volume copy-up.

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -219,6 +219,10 @@ Options are:
 Maximum number of processes allowed in a container. 0 indicates that no limit
 is imposed.
 
+**prepare_volume_on_create**=false
+
+Copy the content from the underlying image into the newly created volume when the container is created instead of when it is started. If `false`, the container engine will not copy the content until the container is started. Setting it to `true` may have negative performance implications.
+
 **rootless_networking**="slirp4netns"
 
 Set type of networking rootless containers should use.  Valid options are `slirp4netns`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -158,6 +158,13 @@ type ContainersConfig struct {
 	// PidNS indicates how to create a pid namespace for the container
 	PidNS string `toml:"pidns,omitempty"`
 
+	// Copy the content from the underlying image into the newly created
+	// volume when the container is created instead of when it is started.
+	// If false, the container engine will not copy the content until
+	// the container is started. Setting it to true may have negative
+	// performance implications.
+	PrepareVolumeOnCreate bool `toml:"prepare_volume_on_create,omitempty"`
+
 	// RootlessNetworking depicts the "kind" of networking for rootless
 	// containers.  Valid options are `slirp4netns` and `cni`. Default is
 	// `slirp4netns`

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -189,6 +189,13 @@ default_sysctls = [
 #
 # pids_limit = 2048
 
+# Copy the content from the underlying image into the newly created volume
+# when the container is created instead of when it is started. If false,
+# the container engine will not copy the content until the container is started.
+# Setting it to true may have negative performance implications.
+#
+# prepare_volume_on_create = false
+
 # Indicates the networking to be used for rootless containers
 # rootless_networking = "slirp4netns"
 


### PR DESCRIPTION
Docker does this by default.

Relates to podman#10262

[NO TESTS NEEDED]

Signed-off-by: Vikas Goel <vikas.goel@gmail.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
