### PR TITLE
pull with custom platform: handle "localhost/"

### DIFF
--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -394,8 +394,23 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 		// very likely a bug but a consistent one in Podman/Buildah and should
 		// be addressed at a later point.
 		if pullPolicy != config.PullPolicyAlways {
-			logrus.Debugf("Enforcing pull policy to %q to support custom platform (arch: %q, os: %q, variant: %q)", "always", options.Architecture, options.OS, options.Variant)
-			pullPolicy = config.PullPolicyAlways
+			switch {
+			// User input clearly refer to a local image.
+			case strings.HasPrefix(imageName, "localhost/"):
+				logrus.Debugf("Enforcing pull policy to %q to support custom platform (arch: %q, os: %q, variant: %q)", "never", options.Architecture, options.OS, options.Variant)
+				pullPolicy = config.PullPolicyNever
+
+			// Image resolved to a local one, so let's still have a
+			// look at the registries or aliases but use it
+			// otherwise.
+			case strings.HasPrefix(resolvedImageName, "localhost/"):
+				logrus.Debugf("Enforcing pull policy to %q to support custom platform (arch: %q, os: %q, variant: %q)", "newer", options.Architecture, options.OS, options.Variant)
+				pullPolicy = config.PullPolicyNewer
+
+			default:
+				logrus.Debugf("Enforcing pull policy to %q to support custom platform (arch: %q, os: %q, variant: %q)", "always", options.Architecture, options.OS, options.Variant)
+				pullPolicy = config.PullPolicyAlways
+			}
 		}
 	}
 


### PR DESCRIPTION
Commit bee8cae83037 enforced the pull policy to "always" when a custom
platform was specified.  The reason for always pulling is that many
multi-arch images are broken; wrong configs, wrong platforms, etc.

We cannot perform reliable platform checks.  While we may to have to
revisit this strategy in the future, it is more important to keep
existing workloads running; a bit between a rock and hard place.

This change complements commit bee8cae83037: if attempt to pull an image
that resolves to "localhost/", set the pull policy "newer" instead of
"always" such that the image may be used instead of erroring out.
Ultimately to preserve previous behavior.

Context: containers/podman/issues/10914
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
