### PR TITLE
libimage.RuntimeFromStore(): stop overriding the BlobInfoCache location

### DIFF
--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -3,7 +3,6 @@ package libimage
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/containers/image/v5/docker/reference"
@@ -93,10 +92,6 @@ func RuntimeFromStore(store storage.Store, options *RuntimeOptions) (*Runtime, e
 	}
 
 	setRegistriesConfPath(&systemContext)
-
-	if systemContext.BlobInfoCacheDir == "" {
-		systemContext.BlobInfoCacheDir = filepath.Join(store.GraphRoot(), "cache")
-	}
 
 	return &Runtime{
 		store:         store,


### PR DESCRIPTION
When it was first introduced, the blob info cache's location didn't
change from the system-wide default location when we were running in
rootless mode, so we started setting its location ourselves to avoid
triggering permissions errors when updating it.

The image library has since started taking into account that it was
running in rootless mode, but its hardwired default isn't the same as
the one we were setting, so we ended up creating a second cache file.

Stop doing that.

Fixes #682.