### PR TITLE
libimage: pull: normalize docker-daemon

### DIFF
--- a/libimage/pull_test.go
+++ b/libimage/pull_test.go
@@ -19,6 +19,12 @@ func TestPull(t *testing.T) {
 	pullOptions := &PullOptions{}
 	pullOptions.Writer = os.Stdout
 
+	// Make sure that parsing errors of the daemon transport are returned
+	// and that we do not fallthrough attempting to pull the specified
+	// string as an image from a registry.
+	_, err := runtime.Pull(ctx, "docker-daemon:alpine", config.PullPolicyAlways, pullOptions)
+	require.Error(t, err, "return parsing error from daemon transport")
+
 	for _, test := range []struct {
 		input       string
 		expectError bool


### PR DESCRIPTION
Normalize images pulled from the docker-daemon transport to docker.io
and not to localhost.  That preserves previous behavior of Podman.

Also fix a parsing bug in the pull code that was revealed while testing
the changes; parsing errors should be returned if there is a matching
transport without falling through to pulling the input string as an
image from a registry.

Context: containers/podman/issues/10998
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan @Luap99 PTAL
