### PR TITLE
Add libimage/manifests.LockerForImage()

### DIFF
--- a/libimage/manifests/manifests_test.go
+++ b/libimage/manifests/manifests_test.go
@@ -72,6 +72,10 @@ func TestSaveLoad(t *testing.T) {
 
 	image, err := list.SaveToImage(store, "", []string{listImageName}, manifest.DockerV2ListMediaType)
 	assert.Nilf(t, err, "SaveToImage(1)")
+	locker, err := LockerForImage(store, image)
+	assert.Nilf(t, err, "LockerForImage()")
+	locker.Lock()
+	defer locker.Unlock()
 	imageReused, err := list.SaveToImage(store, image, nil, manifest.DockerV2ListMediaType)
 	assert.Nilf(t, err, "SaveToImage(2)")
 


### PR DESCRIPTION
Add a `LockerForImage()` function that allocates and returns a file-based lock for an image record that we're using to hold a manifest list.  Without some locking mechanism, two processes that wish to update a list at roughly the same time can't do so without risk of accidentally discarding one or the other set of changes.

Multiple processes that merely want to read the list can already safely do so; only cases with multiple writers that need to bother with using this function.