### PR TITLE
Add and use libimage.Runtime.imageIDsForManifest()

### DIFF
--- a/libimage/image.go
+++ b/libimage/image.go
@@ -836,9 +836,9 @@ func (i *Image) Manifest(ctx context.Context) (rawManifest []byte, mimeType stri
 	return src.GetManifest(ctx, nil)
 }
 
-// getImageDigest creates an image object and uses the hex value of the digest as the image ID
-// for parsing the store reference
-func getImageDigest(ctx context.Context, src types.ImageReference, sys *types.SystemContext) (string, error) {
+// getImageID creates an image object and uses the hex value of the config
+// blob's digest (if it has one) as the image ID for parsing the store reference
+func getImageID(ctx context.Context, src types.ImageReference, sys *types.SystemContext) (string, error) {
 	newImg, err := src.NewImage(ctx, sys)
 	if err != nil {
 		return "", err
@@ -852,5 +852,5 @@ func getImageDigest(ctx context.Context, src types.ImageReference, sys *types.Sy
 	if err = imageDigest.Validate(); err != nil {
 		return "", errors.Wrapf(err, "error getting config info")
 	}
-	return "@" + imageDigest.Hex(), nil
+	return "@" + imageDigest.Encoded(), nil
 }

--- a/libimage/import.go
+++ b/libimage/import.go
@@ -86,7 +86,7 @@ func (r *Runtime) Import(ctx context.Context, path string, options *ImportOption
 		return "", err
 	}
 
-	id, err := getImageDigest(ctx, srcRef, r.systemContextCopy())
+	id, err := getImageID(ctx, srcRef, r.systemContextCopy())
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
When copying images into local storage, parse the manifest of the copied image and then look up the IDs of the matching image.

There's a short period of time, between when we copy the image into local storage and when we subsequently go to look for it using the name that we specified for it when we copied it, when the name we wanted to assign to the image could have been assigned to another image by another process.

The manifest that we copied as part of the image that we copied will still be in the right image regardless, and we can use that to find the image's ID, and from there fill out our own Image structure that we return to our caller.