### PR TITLE
[0.38] seccomp: add support for defaultErrnoRet

### DIFF
--- a/pkg/seccomp/conversion.go
+++ b/pkg/seccomp/conversion.go
@@ -118,6 +118,7 @@ func specToSeccomp(spec *specs.LinuxSeccomp) (*Seccomp, error) {
 		return nil, errors.Wrap(err, "convert default action")
 	}
 	res.DefaultAction = newDefaultAction
+	res.DefaultErrnoRet = spec.DefaultErrnoRet
 
 	// Loop through all syscall blocks and convert them to the internal format
 	for _, call := range spec.Syscalls {

--- a/pkg/seccomp/filter.go
+++ b/pkg/seccomp/filter.go
@@ -41,7 +41,7 @@ func BuildFilter(spec *specs.LinuxSeccomp) (*libseccomp.ScmpFilter, error) {
 		return nil, errors.Wrap(err, "convert spec to seccomp profile")
 	}
 
-	defaultAction, err := toAction(profile.DefaultAction, nil)
+	defaultAction, err := toAction(profile.DefaultAction, profile.DefaultErrnoRet)
 	if err != nil {
 		return nil, errors.Wrapf(err, "convert default action %s", profile.DefaultAction)
 	}

--- a/pkg/seccomp/seccomp_linux.go
+++ b/pkg/seccomp/seccomp_linux.go
@@ -111,6 +111,7 @@ func setupSeccomp(config *Seccomp, rs *specs.Spec) (*specs.LinuxSeccomp, error) 
 	}
 
 	newConfig.DefaultAction = specs.LinuxSeccompAction(config.DefaultAction)
+	newConfig.DefaultErrnoRet = config.DefaultErrnoRet
 
 Loop:
 	// Loop through all syscall blocks and convert them to libcontainer format after filtering them

--- a/pkg/seccomp/types.go
+++ b/pkg/seccomp/types.go
@@ -6,7 +6,8 @@ package seccomp
 
 // Seccomp represents the config for a seccomp profile for syscall restriction.
 type Seccomp struct {
-	DefaultAction Action `json:"defaultAction"`
+	DefaultAction   Action `json:"defaultAction"`
+	DefaultErrnoRet *uint  `json:"defaultErrnoRet"`
 	// Architectures is kept to maintain backward compatibility with the old
 	// seccomp profile.
 	Architectures []Arch         `json:"architectures,omitempty"`

--- a/pkg/seccomp/types.go
+++ b/pkg/seccomp/types.go
@@ -7,7 +7,7 @@ package seccomp
 // Seccomp represents the config for a seccomp profile for syscall restriction.
 type Seccomp struct {
 	DefaultAction   Action `json:"defaultAction"`
-	DefaultErrnoRet *uint  `json:"defaultErrnoRet"`
+	DefaultErrnoRet *uint  `json:"defaultErrnoRet,omitempty"`
 	// Architectures is kept to maintain backward compatibility with the old
 	// seccomp profile.
 	Architectures []Arch         `json:"architectures,omitempty"`

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.38.17-dev"
+const Version = "0.38.17"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.38.17"
+const Version = "0.38.18-dev"


### PR DESCRIPTION
This is a partial backport of https://github.com/containers/common/pull/573 to v0.38 branch.
Needed to fix https://github.com/containers/podman/issues/11029 and the likes.
Original description follows.

----

Add support to specify the default errno return value.

The OCI runtime specs already have support for it, and both crun (>=
0.19) and runc (>= 1.0-rc95) have support for it.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit adee333df76c02d99c740cf82cdf6074cade49b9)
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>