### PR TITLE
pkg/seccomp: avoid DefaultErrnoRet: null

### DIFF
--- a/pkg/seccomp/types.go
+++ b/pkg/seccomp/types.go
@@ -7,7 +7,7 @@ package seccomp
 // Seccomp represents the config for a seccomp profile for syscall restriction.
 type Seccomp struct {
 	DefaultAction   Action `json:"defaultAction"`
-	DefaultErrnoRet *uint  `json:"defaultErrnoRet"`
+	DefaultErrnoRet *uint  `json:"defaultErrnoRet,omitempty"`
 	// Architectures is kept to maintain backward compatibility with the old
 	// seccomp profile.
 	Architectures []Arch         `json:"architectures,omitempty"`


### PR DESCRIPTION
This prevents

	"defaultErrnoRet": null,

from appearing in seccomp.json, in case `DefaultErrnoRet` is not set
(if set, this is purely cosmetical).

This member is similar to ErrnoRet in type Syscall,
and should also be marked with omitempty.

Fixes: adee333df76c02d99c740c
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>

Forward ported from https://github.com/containers/common/pull/689
Cc; @giuseppe 