### PR TITLE
config: split arguments in DBUS_SESSION_BUS_ADDRESS

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -637,9 +637,14 @@ func (c *Config) CheckCgroupsAndAdjustConfig() {
 
 	session := os.Getenv("DBUS_SESSION_BUS_ADDRESS")
 	hasSession := session != ""
-	if hasSession && strings.HasPrefix(session, "unix:path=") {
-		_, err := os.Stat(strings.TrimPrefix(session, "unix:path="))
-		hasSession = err == nil
+	if hasSession {
+		for _, part := range strings.Split(session, ",") {
+			if strings.HasPrefix(part, "unix:path=") {
+				_, err := os.Stat(strings.TrimPrefix(part, "unix:path="))
+				hasSession = err == nil
+				break
+			}
+		}
 	}
 
 	if !hasSession && unshare.GetRootlessUID() != 0 {


### PR DESCRIPTION
split the DBUS_SESSION_BUS_ADDRESS value so that something like:

unix:path=/run/user/1000/bus,guid=817e9ffcfb383869ad17ea8360e7428a

will ignore ",guid=817e9ffcfb383869ad17ea8360e7428a" when checking
that the path exists.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1984531

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
