### PR TITLE
pull policy: support camel cases

### DIFF
--- a/pkg/config/pull_policy.go
+++ b/pkg/config/pull_policy.go
@@ -76,13 +76,13 @@ func (p PullPolicy) Validate() error {
 // * "never"   <-> PullPolicyNever
 func ParsePullPolicy(s string) (PullPolicy, error) {
 	switch s {
-	case "always":
+	case "always", "Always":
 		return PullPolicyAlways, nil
-	case "missing", "ifnotpresent", "":
+	case "missing", "Missing", "ifnotpresent", "IfNotPresent", "":
 		return PullPolicyMissing, nil
-	case "newer", "ifnewer":
+	case "newer", "Newer", "ifnewer", "IfNewer":
 		return PullPolicyNewer, nil
-	case "never":
+	case "never", "Never":
 		return PullPolicyNever, nil
 	default:
 		return PullPolicyUnsupported, errors.Errorf("unsupported pull policy %q", s)


### PR DESCRIPTION
The K8s pull policies are in camel case:
 * Always
 * IfNotPresent
 * Never

Support them in conjunction to Missing, Newer and IfNewer.  Doing it
here prevents Podman (and possibly CRI-O in the future) from adding
custom parsers.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@cdoern @containers/podman-maintainers PTAL
