### PR TITLE
Use authfile in options to search image

### DIFF
--- a/libimage/search.go
+++ b/libimage/search.go
@@ -185,6 +185,10 @@ func (r *Runtime) searchImageInRegistry(ctx context.Context, term, registry stri
 		sys.DockerInsecureSkipTLSVerify = options.InsecureSkipTLSVerify
 	}
 
+	if options.Authfile != "" {
+		sys.AuthFilePath = options.Authfile
+	}
+
 	if options.ListTags {
 		results, err := searchRepositoryTags(ctx, sys, registry, term, options)
 		if err != nil {


### PR DESCRIPTION
An authfile path set by `podman search --authfile` is passed in
`SearchOptions`. This fix uses this authfile for accessing
registries.

Signed-off-by: Hironori Shiina <shiina.hironori@jp.fujitsu.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
