### PR TITLE
Pull fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ PREFIX := /usr/local
 CONFIGDIR := ${PREFIX}/share/containers
 PROJECT := github.com/containers/common
 
+# Enforce the GOPROXY to make sure dependencies are resovled consistently
+# across different environments.
+export GOPROXY := https://proxy.golang.org
+
 # If GOPATH not specified, use one in the local directory
 ifeq ($(GOPATH),)
 export GOPATH := $(CURDIR)/_output

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -61,7 +61,10 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 		// Check whether `name` points to a transport.  If so, we
 		// return the error.  Otherwise we assume that `name` refers to
 		// an image on a registry (e.g., "fedora").
-		if alltransports.TransportFromImageName(name) != nil {
+		//
+		// NOTE: the `docker` transport is an exception to support a
+		// `pull docker:latest` which would otherwise return an error.
+		if t := alltransports.TransportFromImageName(name); t != nil && t.Name() != registryTransport.Transport.Name() {
 			return nil, err
 		}
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.42.1"
+const Version = "0.42.2-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.42.2-dev"
+const Version = "0.43.0-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.42.1-dev"
+const Version = "0.42.1"


### PR DESCRIPTION
* Fixes for the CI failure in https://github.com/containers/buildah/pull/3410
* bump to v0.42.1
* bump to v0.42.2-dev
* bump to v0.43.0-dev (since we need to cut a v0.42 branch)

@rhatdan PTAL

