### PR TITLE
Add machine_image to containers.conf

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -412,6 +412,11 @@ Indicates if Podman is running inside a VM via Podman Machine.
 Podman uses this value to do extra setup around networking from the
 container inside the VM to to host.
 
+**machine_image**="testing"
+
+Default image used when creating a new VM using `podman machine init`.
+Options: `testing`, `stable`, or a custom path or download URL to an image
+
 **multi_image_archive**=false
 
 Allows for creating archives (e.g., tarballs) with more than one image.  Some container engines, such as Podman, interpret additional arguments as tags for one image and hence do not store more than one image.  The default behavior can be altered with this option.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -274,6 +274,9 @@ type EngineConfig struct {
 	// MachineEnabled indicates if Podman is running in a podman-machine VM
 	MachineEnabled bool `toml:"machine_enabled,omitempty"`
 
+	// MachineImage is the image used when creating a podman-machine VM
+	MachineImage string `toml:"machine_image,omitempty"`
+
 	// MultiImageArchive - if true, the container engine allows for storing
 	// archives (e.g., of the docker-archive transport) with multiple
 	// images.  By default, Podman creates single-image archives.

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -369,4 +369,17 @@ var _ = Describe("Config Local", func() {
 			"root": "/srv/password-store",
 		}))
 	})
+
+	It("Set machine image path", func() {
+		// Given
+		config, err := NewConfig("")
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config.Engine.MachineImage).To(gomega.Equal("testing"))
+		// When
+		config2, err := NewConfig("testdata/containers_default.conf")
+		// Then
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config2.Engine.MachineImage).To(gomega.Equal("stable"))
+	})
+
 })

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -381,6 +381,9 @@ default_sysctls = [
 #
 #machine_enabled = false
 
+# The image used when creating a podman-machine VM.
+# machine_image = "testing"
+
 # MultiImageArchive - if true, the container engine allows for storing archives
 # (e.g., of the docker-archive transport) with multiple images.  By default,
 # Podman creates single-image archives.

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -339,6 +339,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	// constants.
 	c.LockType = "shm"
 	c.MachineEnabled = false
+	c.MachineImage = "testing"
 
 	c.ChownCopiedFiles = true
 
@@ -549,6 +550,7 @@ func (c *Config) LogDriver() string {
 	return c.Containers.LogDriver
 }
 
+// MachineEnabled returns if podman is running inside a VM or not
 func (c *Config) MachineEnabled() bool {
 	return c.Engine.MachineEnabled
 }
@@ -557,4 +559,10 @@ func (c *Config) MachineEnabled() bool {
 // rootless containers should use
 func (c *Config) RootlessNetworking() string {
 	return c.Containers.RootlessNetworking
+}
+
+// MachineImage returns the image to be
+// used when creating a podman-machine VM
+func (c *Config) MachineImage() string {
+	return c.Engine.MachineImage
 }

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -152,6 +152,9 @@ tmp_dir = "/run/libpod"
 
 machine_enabled = true
 
+# The image used when creating a podman-machine VM.
+machine_image = "stable"
+
 # Whether to use chroot instead of pivot_root in the runtime
 no_pivot_root = false
 


### PR DESCRIPTION
Current default for image_stream is "testing"

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
