### PR TITLE
Remove no_libsubid flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GO_BUILD=$(GO) build
 ifeq ($(shell go help mod >/dev/null 2>&1 && echo true), true)
 	GO_BUILD=GO111MODULE=on $(GO) build -mod=vendor
 endif
-BUILDTAGS := containers_image_openpgp,systemd,no_libsubid,exclude_graphdriver_devicemapper
+BUILDTAGS := containers_image_openpgp,systemd,exclude_graphdriver_devicemapper
 DESTDIR ?=
 PREFIX := /usr/local
 CONFIGDIR := ${PREFIX}/share/containers
@@ -81,7 +81,7 @@ docs:
 
 .PHONY: validate
 validate: build/golangci-lint
-	./build/golangci-lint run --build-tags no_libsubid
+	./build/golangci-lint run
 	./tools/validate_seccomp.sh ./pkg/seccomp
 
 vendor-in-container:


### PR DESCRIPTION
Container/storage now only links in libsubid if libsubid tag is set.

no_libsubid tag no longer exists.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
