### PR TITLE
path: dest paths inside container should always be treated as *nix type

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -5,6 +5,7 @@ package parse
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -155,7 +156,7 @@ func ValidateVolumeCtrDir(ctrDir string) error {
 	if ctrDir == "" {
 		return errors.New("container directory cannot be empty")
 	}
-	if !filepath.IsAbs(ctrDir) {
+	if !path.IsAbs(ctrDir) {
 		return errors.Errorf("invalid container path %q, must be an absolute path", ctrDir)
 	}
 	return nil


### PR DESCRIPTION
Closes: https://github.com/containers/podman/issues/10900

Destination path inside containers should be always validated  as
***nix**type absolute path. 

So its recommended to use `path.IsAbs()` instead of `filtepath.IsAbs()` for destination checks. Since `filepath.IsAbs()` will use path_windows on windows host but destination path inside the containers should always be of ***nix** type.

Reference:
https://cs.opensource.google/go/go/+/refs/tags/go1.16.7:src/path/path.go;l=219
https://cs.opensource.google/go/go/+/refs/tags/go1.16.7:src/path/filepath/path_windows.go
https://cs.opensource.google/go/go/+/refs/tags/go1.16.7:src/path/filepath/path_unix.go


