### PR TITLE
log driver: do not use journald as default

### DIFF
--- a/pkg/config/systemd.go
+++ b/pkg/config/systemd.go
@@ -44,9 +44,14 @@ func defaultEventsLogger() string {
 }
 
 func defaultLogDriver() string {
-	if useJournald() {
-		return "journald"
-	}
+	// FIXME: Podman's journald driver still has some issues which prevents
+	// defaulting to journald.  containers/podman/pull/11241 flaked with
+	// the following error: "Error: initial journal cursor: failed to get
+	// cursor: cannot assign requested address".
+	//
+	//	if useJournald() {
+	//		return "journald"
+	//	}
 	return "k8s-file"
 }
 


### PR DESCRIPTION
FIXME: Podman's journald driver still has some issues which prevents
defaulting to journald.  containers/podman/pull/11241 flaked with
the following error: "Error: initial journal cursor: failed to get
cursor: cannot assign requested address".

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
