### PR TITLE
Enable IPv6 by default for slirp4netns

### DIFF
--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -199,7 +199,7 @@ default_sysctls = [
 
 # Indicates the networking to be used for rootless containers
 #
-#rootless_networking = "slirp4netns"
+#rootless_networking = "slirp4netns:enable_ipv6=true"
 
 # Path to the seccomp.json profile which is used as the default seccomp profile
 # for the runtime.


### PR DESCRIPTION
Fixes https://github.com/containers/podman/issues/10889 in case that is the correct thing to change.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
