### PR TITLE
seccomp: allow memfd_secret

### DIFF
--- a/pkg/seccomp/default_linux.go
+++ b/pkg/seccomp/default_linux.go
@@ -236,6 +236,7 @@ func DefaultProfile() *Seccomp {
 				"madvise",
 				"mbind",
 				"memfd_create",
+				"memfd_secret",
 				"mincore",
 				"mkdir",
 				"mkdirat",

--- a/pkg/seccomp/seccomp.json
+++ b/pkg/seccomp/seccomp.json
@@ -242,6 +242,7 @@
 				"madvise",
 				"mbind",
 				"memfd_create",
+				"memfd_secret",
 				"mincore",
 				"mkdir",
 				"mkdirat",


### PR DESCRIPTION
memfd_secret is a new syscall that will be added to Linux 5.14

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
