### PR TITLE
runtime: Add `ManifestList` to `LookupImageOptions`

### DIFF
--- a/libimage/manifest_list_test.go
+++ b/libimage/manifest_list_test.go
@@ -38,3 +38,40 @@ func TestCreateManifestList(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, errors.Cause(err), ErrNotAManifestList)
 }
+
+// Following test ensure that `Tag` tags the manifest list instead of resolved image.
+// Both the tags should point to same image id
+func TestCreateAndTagManifestList(t *testing.T) {
+
+	tagName := "testlisttagged"
+	listName := "testlist"
+	runtime, cleanup := testNewRuntime(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	list, err := runtime.CreateManifestList(listName)
+	require.NoError(t, err)
+	require.NotNil(t, list)
+
+	manifestListOpts := &ManifestListAddOptions{All: true}
+	_, err = list.Add(ctx, "docker://busybox", manifestListOpts)
+	require.NoError(t, err)
+
+	list, err = runtime.LookupManifestList(listName)
+	require.NoError(t, err)
+	require.NotNil(t, list)
+
+	lookupOptions := &LookupImageOptions{ManifestList: true}
+	image, _, err := runtime.LookupImage(listName, lookupOptions)
+	require.NoError(t, err)
+	require.NotNil(t, image)
+	err = image.Tag(tagName)
+	require.NoError(t, err, "tag should have succeeded: %s", tagName)
+
+	taggedImage, _, err := runtime.LookupImage(tagName, lookupOptions)
+	require.NoError(t, err)
+	require.NotNil(t, taggedImage)
+
+	// Both origin list and newly tagged list should point to same image id
+	require.Equal(t, image.ID(), taggedImage.ID())
+}

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -161,7 +161,13 @@ type LookupImageOptions struct {
 
 	// If set, do not look for items/instances in the manifest list that
 	// match the current platform but return the manifest list as is.
+	// only check for manifest list, return ErrNotAManifestList if not found.
 	lookupManifest bool
+
+	// If matching images resolves to a manifest list, return manifest list
+	// instead of resolving to image instance, if manifest list is not found
+	// try resolving image.
+	ManifestList bool
 
 	// If the image resolves to a manifest list, we usually lookup a
 	// matching instance and error if none could be found.  In this case,
@@ -305,11 +311,14 @@ func (r *Runtime) lookupImageInLocalStorage(name, candidate string, options *Loo
 		}
 		return nil, err
 	}
-	if options.lookupManifest {
+	if options.lookupManifest || options.ManifestList {
 		if isManifestList {
 			return image, nil
 		}
-		return nil, errors.Wrapf(ErrNotAManifestList, candidate)
+		// return ErrNotAManifestList if lookupManifest is set otherwise try resolving image.
+		if options.lookupManifest {
+			return nil, errors.Wrapf(ErrNotAManifestList, candidate)
+		}
 	}
 
 	if isManifestList {


### PR DESCRIPTION
If matching images resolves to a manifest list, return manifest list
instead of resolving to image instance, if manifest list is not found
try resolving image.
