### PR TITLE
libimage: disk usage: catch corrupted images

### DIFF
--- a/libimage/disk_usage.go
+++ b/libimage/disk_usage.go
@@ -52,6 +52,10 @@ func (r *Runtime) DiskUsage(ctx context.Context) ([]ImageDiskUsage, error) {
 
 // diskUsageForImage returns the disk-usage baseistics for the specified image.
 func diskUsageForImage(ctx context.Context, image *Image, tree *layerTree) ([]ImageDiskUsage, error) {
+	if err := image.isCorrupted(""); err != nil {
+		return nil, err
+	}
+
 	base := ImageDiskUsage{
 		ID:         image.ID(),
 		Created:    image.Created(),

--- a/libimage/image.go
+++ b/libimage/image.go
@@ -74,7 +74,10 @@ func (i *Image) isCorrupted(name string) error {
 	}
 
 	if _, err := ref.NewImage(context.Background(), nil); err != nil {
-		return errors.Errorf("Image %s exists in local storage but may be corrupted: %v", name, err)
+		if name == "" {
+			name = i.ID()[:12]
+		}
+		return errors.Errorf("Image %s exists in local storage but may be corrupted (remove the image to resolve the issue): %v", name, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Make sure to check an image for corruption before running disk usage on
it.  Such checks are already applied on various execution paths but not
yet on disk usage.

Further update the corrupted-image error to include that the image
should be removed to resolve the error.  This should ultimately guide
users to resolve the issue.

Fixes: #751
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@Luap99 @giuseppe @containers/podman-maintainers PTAL