### PR TITLE
Switch default Rootless Networking to "CNI" for OSX

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -167,7 +167,7 @@ type ContainersConfig struct {
 
 	// RootlessNetworking depicts the "kind" of networking for rootless
 	// containers.  Valid options are `slirp4netns` and `cni`. Default is
-	// `slirp4netns`
+	// `slirp4netns` on Linux, and `cni` on non-Linux OSes.
 	RootlessNetworking string `toml:"rootless_networking,omitempty"`
 
 	// SeccompProfile is the seccomp.json profile path which is used as the

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -84,10 +84,6 @@ var (
 		"/usr/lib/cni",
 		"/opt/cni/bin",
 	}
-
-	// DefaultRootlessNetwork is the kind of of rootless networking
-	// for containers
-	DefaultRootlessNetwork = "slirp4netns"
 )
 
 const (
@@ -197,7 +193,7 @@ func DefaultConfig() (*Config, error) {
 			NoHosts:            false,
 			PidsLimit:          DefaultPidsLimit,
 			PidNS:              "private",
-			RootlessNetworking: DefaultRootlessNetwork,
+			RootlessNetworking: getDefaultRootlessNetwork(),
 			ShmSize:            DefaultShmSize,
 			TZ:                 "",
 			Umask:              "0022",

--- a/pkg/config/default_linux.go
+++ b/pkg/config/default_linux.go
@@ -13,6 +13,12 @@ const (
 	oldMaxSize = uint64(1048576)
 )
 
+// getDefaultRootlessNetwork returns the default rootless network configuration.
+// It is "slirp4netns" for Linux.
+func getDefaultRootlessNetwork() string {
+	return "slirp4netns"
+}
+
 // getDefaultProcessLimits returns the nproc for the current process in ulimits format
 // Note that nfile sometimes cannot be set to unlimited, and the limit is hardcoded
 // to (oldMaxSize) 1048576 (2^20), see: http://stackoverflow.com/a/1213069/1811501

--- a/pkg/config/default_unsupported.go
+++ b/pkg/config/default_unsupported.go
@@ -2,6 +2,12 @@
 
 package config
 
+// getDefaultRootlessNetwork returns the default rootless network configuration.
+// It is "cni" for non-Linux OSes (to better support `podman-machine` usecases).
+func getDefaultRootlessNetwork() string {
+	return "cni"
+}
+
 // isCgroup2UnifiedMode returns whether we are running in cgroup2 mode.
 func isCgroup2UnifiedMode() (isUnified bool, isUnifiedErr error) {
 	return false, nil


### PR DESCRIPTION
This should better support rootless CNI usescases.

Fixes https://github.com/containers/podman/issues/11396
