### PR TITLE
docs/containers.conf.5.md: Fix manpage section

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -1,4 +1,4 @@
-% containers.conf(5) Container engine configuration file
+% containers.conf 5 Container engine configuration file
 
 # NAME
 containers.conf - The container engine configuration file specifies default


### PR DESCRIPTION
Avoids a nroff warning in the generated manpage

[CI:DOCS]

Signed-off-by: Reinhard Tartler <siretart@tauware.de>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
