### PR TITLE
Fix login/logout for docker.io/user

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -193,6 +193,12 @@ func parseRegistryArgument(arg string, acceptRepositories bool) (key, registry s
 		return key, registry, nil, nil
 	}
 
+	// Special case when user inputs `docker.io/username`. reference.ParseNamed
+	// will fail if we do not include the `docker.io/library/username` in the key.
+	if strings.HasPrefix(key, "docker.io/") && !strings.HasPrefix(key, "docker.io/library/") {
+		key = "docker.io/library/" + strings.TrimPrefix(key, "docker.io/")
+	}
+
 	ref, parseErr := reference.ParseNamed(key)
 	if parseErr != nil {
 		return key, registry, nil, errors.Wrapf(parseErr, "parse reference from %q", key)

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -98,6 +98,28 @@ func TestParseRegistryArgument(t *testing.T) {
 			},
 		},
 		{
+			name:               "with docker.io user input",
+			arg:                "docker.io/user",
+			acceptRepositories: true,
+			shouldErr:          false,
+			expect: func(key, registry string, ref reference.Named) {
+				assert.Equal(t, "docker.io/library/user", key)
+				assert.Equal(t, "docker.io", registry)
+				assert.NotNil(t, ref)
+			},
+		},
+		{
+			name:               "with docker.io user input and library prefix",
+			arg:                "docker.io/library/user",
+			acceptRepositories: true,
+			shouldErr:          false,
+			expect: func(key, registry string, ref reference.Named) {
+				assert.Equal(t, "docker.io/library/user", key)
+				assert.Equal(t, "docker.io", registry)
+				assert.NotNil(t, ref)
+			},
+		},
+		{
 			name:               "with http[s] prefix",
 			arg:                "https://quay.io",
 			acceptRepositories: true,


### PR DESCRIPTION
`reference.ParseNamed()` fails on `docker.io/user` because it expects
`docker.io/library/user`. We handle this special case now by changing
the domain prefix to always include `/library/`.

Refers to https://github.com/containers/buildah/issues/3500