### PR TITLE
Add HelperBinariesDir field to engine config

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -378,6 +378,29 @@ if you want to set environment variables for the container.
 Default method to use when logging events.
 Valid values: `file`, `journald`, and `none`.
 
+**helper_binaries_dir**=["/usr/libexec/podman", ...]
+
+A is a list of directories which are used to search for helper binaries.
+
+The default paths on Linux are:
+- `/usr/local/libexec/podman`
+- `/usr/local/lib/podman`
+- `/usr/libexec/podman`
+- `/usr/lib/podman`
+
+The default paths on macOS are:
+- `/usr/local/opt/podman/libexec`
+-	`/opt/homebrew/bin`
+-	`/opt/homebrew/opt/podman/libexec`
+- `/usr/local/bin`
+-	`/usr/local/libexec/podman`
+-	`/usr/local/lib/podman`
+-	`/usr/libexec/podman`
+-	`/usr/lib/podman`
+
+The default path on Windows is:
+- `C:\Program Files\RedHat\Podman`
+
 **hooks_dir**=["/etc/containers/oci/hooks.d", ...]
 
 Path to the OCI hooks directories for automatically executed hooks.

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -15,3 +15,16 @@ func customConfigFile() (string, error) {
 func ifRootlessConfigPath() (string, error) {
 	return rootlessConfigPath()
 }
+
+var defaultHelperBinariesDir = []string{
+	// Homebrew install paths
+	"/usr/local/opt/podman/libexec",
+	"/opt/homebrew/bin",
+	"/opt/homebrew/opt/podman/libexec",
+	"/usr/local/bin",
+	// default paths
+	"/usr/local/libexec/podman",
+	"/usr/local/lib/podman",
+	"/usr/libexec/podman",
+	"/usr/lib/podman",
+}

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -35,3 +35,10 @@ func ifRootlessConfigPath() (string, error) {
 	}
 	return "", nil
 }
+
+var defaultHelperBinariesDir = []string{
+	"/usr/local/libexec/podman",
+	"/usr/local/lib/podman",
+	"/usr/libexec/podman",
+	"/usr/lib/podman",
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -163,6 +163,10 @@ var _ = Describe("Config", func() {
 				"TERM=xterm",
 			}
 
+			helperDirs := []string{
+				"/somepath",
+			}
+
 			// Then
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(defaultConfig.Engine.CgroupManager).To(gomega.Equal("systemd"))
@@ -172,6 +176,7 @@ var _ = Describe("Config", func() {
 			gomega.Expect(defaultConfig.Engine.NumLocks).To(gomega.BeEquivalentTo(2048))
 			gomega.Expect(defaultConfig.Engine.OCIRuntimes).To(gomega.Equal(OCIRuntimeMap))
 			gomega.Expect(defaultConfig.Containers.HTTPProxy).To(gomega.Equal(false))
+			gomega.Expect(defaultConfig.Engine.HelperBinariesDir).To(gomega.Equal(helperDirs))
 		})
 
 		It("test GetDefaultEnvEx", func() {

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -13,3 +13,7 @@ func customConfigFile() (string, error) {
 func ifRootlessConfigPath() (string, error) {
 	return os.Getenv("APPDATA") + "\\containers\\containers.conf", nil
 }
+
+var defaultHelperBinariesDir = []string{
+	"C:\\Program Files\\RedHat\\Podman",
+}

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -341,6 +341,15 @@ default_sysctls = [
 #
 #events_logger = "journald"
 
+# A is a list of directories which are used to search for helper binaries.
+#
+#helper_binaries_dir = [
+#  "/usr/local/libexec/podman",
+#  "/usr/local/lib/podman",
+#  "/usr/libexec/podman",
+#  "/usr/lib/podman",
+#]
+
 # Path to OCI hooks directories for automatically executed hooks.
 #
 #hooks_dir = [

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -247,6 +247,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	c.StaticDir = filepath.Join(storeOpts.GraphRoot, "libpod")
 	c.VolumePath = filepath.Join(storeOpts.GraphRoot, "volumes")
 
+	c.HelperBinariesDir = defaultHelperBinariesDir
 	c.HooksDir = DefaultHooksDirs
 	c.ImageDefaultTransport = _defaultTransport
 	c.StateType = BoltDBStateStore

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -164,6 +164,13 @@ no_pivot_root = false
 # namespace is set, all containers and pods are visible.
 #namespace = ""
 
+# A is a list of directories which are used to search for helper binaries.
+#
+helper_binaries_dir = [
+ "/somepath",
+]
+
+
 # Path to OCI hooks directories for automatically executed hooks.
 hooks_dir = [
 ]


### PR DESCRIPTION
This field contains a list of directories which should be used to store
some helper binaries, e.g. gvproxy.

Also add a FindHelperBinary method to the config struct to get the full
path to a helper binary.

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
