### PR TITLE
Fix the fallback runtime path

### DIFF
--- a/pkg/config/util_supported.go
+++ b/pkg/config/util_supported.go
@@ -48,7 +48,7 @@ func getRuntimeDir() (string, error) {
 			}
 		}
 		if runtimeDir == "" {
-			tmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("run-%s", uid))
+			tmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("podman-run-%s", uid))
 			if err := os.MkdirAll(tmpDir, 0700); err != nil {
 				logrus.Debugf("unable to make temp dir %v", err)
 			}


### PR DESCRIPTION
Podman should not use `/tmp/run-...`. The Podman PR#8241 changed the
path to `/tmp/podman-run-...` and added systemd tmpfile config to make
sure the path is not removed. However the tmpDir is set in c/common and
was never changed.

Fixes containers/podman#11478

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
