### PR TITLE
Add support for image_copy_tmp_dir

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -514,6 +514,14 @@ The list of OCI runtimes that support running containers with KVM separation.
 
 The list of OCI runtimes that support running containers without CGroups.
 
+**image_copy_tmp_dir**="/var/tmp"
+
+Default location for storing temporary container image content.  Can be
+overridden with the TMPDIR environment variable.  If you specify "storage", then
+the location of the container/storage tmp directory will be used. If set then it
+is the users responsibility to cleanup storage. Configure tmpfiles.d(5) to
+cleanup storage.
+
 **static_dir**="/var/lib/containers/storage/libpod"
 
 Directory for persistent libpod files (database, etc).
@@ -609,6 +617,6 @@ is used for the storage.conf file rather than the default.
 This is primarily used for testing.
 
 # SEE ALSO
-containers-storage.conf(5), containers-policy.json(5), containers-registries.conf(5)
+containers-storage.conf(5), containers-policy.json(5), containers-registries.conf(5), tmpfiles.d(5)
 
 [toml]: https://github.com/toml-lang/toml

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -461,6 +461,11 @@ default_sysctls = [
 #
 #runtime_supports_nocgroups = ["crun"]
 
+# Default location for storing temporary container image content.  Can be overridden with the TMPDIR environment
+# variable.  If you specify "storage", then the location of the
+# container/storage tmp directory will be used.
+# image_copy_tmp_dir="/var/tmp"
+
 # Directory for persistent engine files (database, etc)
 # By default, this will be configured relative to where the containers/storage
 # stores containers

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -244,6 +244,8 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 		logrus.Warnf("Storage configuration is unset - using hardcoded default graph root %q", _defaultGraphRoot)
 		storeOpts.GraphRoot = _defaultGraphRoot
 	}
+	c.graphRoot = storeOpts.GraphRoot
+	c.ImageCopyTmpDir = "/var/tmp"
 	c.StaticDir = filepath.Join(storeOpts.GraphRoot, "libpod")
 	c.VolumePath = filepath.Join(storeOpts.GraphRoot, "volumes")
 

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -119,6 +119,9 @@ conmon_env_vars = [
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 ]
 
+image_copy_tmp_dir="storage"
+
+
 # Paths to look for the Conmon container manager binary
 conmon_path = [
 	    "/usr/libexec/podman/conmon",

--- a/pkg/config/testdata/containers_override.conf
+++ b/pkg/config/testdata/containers_override.conf
@@ -8,6 +8,7 @@ log_size_max = 100000
 [engine]
 image_parallel_copies=10
 image_default_format="v2s2"
+image_copy_tmp_dir="/tmp/foobar"
 
 [secrets]
 driver = "pass"


### PR DESCRIPTION
Allow users to set the default location for the temporary files used
during image pulls and pushes.

Defaults to /var/tmp;

Overridden via "TMPDIR" environment variable.

Allow special flag "storage" to indicate the the storage should use
the tmp directory in containers/storage/tmp.

Needed to fix: https://github.com/containers/podman/issues/11107

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
