### PR TITLE
Fix login/logout for docker.io/vendor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/BurntSushi/toml v0.4.1
-	github.com/containers/image/v5 v5.17.0
+	github.com/containers/image/v5 v5.17.1-0.20211201214147-603ec1341d58
 	github.com/containers/ocicrypt v1.1.2
 	github.com/containers/storage v1.37.1-0.20211119174841-bf170b3ddac0
 	github.com/disiqueira/gotree/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHVlzhJpcY6TQxn/fUyDDM=
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
-github.com/containers/image/v5 v5.17.0 h1:KS5pro80CCsSp5qDBTMmSAWQo+xcBX19zUPExmYX2OQ=
-github.com/containers/image/v5 v5.17.0/go.mod h1:GnYVusVRFPMMTAAUkrcS8NNSpBp8oyrjOUe04AAmRr4=
+github.com/containers/image/v5 v5.17.1-0.20211201214147-603ec1341d58 h1:DI6d+6aRBC14mbfnh0eYlHeFBSZQ4adDykrS8F/Awrg=
+github.com/containers/image/v5 v5.17.1-0.20211201214147-603ec1341d58/go.mod h1:iUA6fv9NnqIhEaP3+dqo22nKMNkSWCj8d5o8Dju0j1Q=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=
@@ -653,7 +653,6 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.0/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/image-spec v1.0.2-0.20210819154149-5ad6f50d6283/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.2-0.20211123152302-43a7dee1ec31 h1:Wh4aR2I6JFwySre9m3iHJYuMnvUFE/HT6qAXozRWi/E=
 github.com/opencontainers/image-spec v1.0.2-0.20211123152302-43a7dee1ec31/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -285,10 +285,8 @@ func Logout(systemContext *types.SystemContext, opts *LogoutOptions, args []stri
 		ref           reference.Named
 		err           error
 	)
-	if len(args) > 1 {
-		return errors.New("logout accepts only one registry to logout from")
-	}
-	if len(args) == 0 {
+	switch len(args) {
+	case 0:
 		if !opts.AcceptUnspecifiedRegistry {
 			return errors.New("please provide a registry to logout from")
 		}
@@ -297,12 +295,15 @@ func Logout(systemContext *types.SystemContext, opts *LogoutOptions, args []stri
 		}
 		registry = key
 		logrus.Debugf("registry not specified, default to the first registry %q from registries.conf", key)
-	}
-	if len(args) != 0 {
+
+	case 1:
 		key, registry, ref, err = parseRegistryArgument(args[0], opts.AcceptRepositories)
 		if err != nil {
 			return err
 		}
+
+	default:
+		return errors.New("logout accepts only one registry to logout from")
 	}
 
 	err = config.RemoveAuthentication(systemContext, key)

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -184,7 +184,7 @@ func parseRegistryArgument(arg string, acceptRepositories bool) (key, registry s
 
 	key = trimScheme(arg)
 	if key != arg {
-		return key, registry, nil, errors.New("credentials key has https[s]:// prefix")
+		return "", "", nil, errors.New("credentials key has https[s]:// prefix")
 	}
 
 	registry = getRegistryName(key)
@@ -195,11 +195,11 @@ func parseRegistryArgument(arg string, acceptRepositories bool) (key, registry s
 
 	ref, parseErr := reference.ParseNamed(key)
 	if parseErr != nil {
-		return key, registry, nil, errors.Wrapf(parseErr, "parse reference from %q", key)
+		return "", "", nil, errors.Wrapf(parseErr, "parse reference from %q", key)
 	}
 
 	if !reference.IsNameOnly(ref) {
-		return key, registry, nil, errors.Errorf("reference %q contains tag or digest", ref.String())
+		return "", "", nil, errors.Errorf("reference %q contains tag or digest", ref.String())
 	}
 
 	maybeRef = ref

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -75,8 +75,7 @@ func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginO
 		ref           reference.Named
 		err           error
 	)
-	l := len(args)
-	switch l {
+	switch len(args) {
 	case 0:
 		if !opts.AcceptUnspecifiedRegistry {
 			return errors.New("please provide a registry to login to")
@@ -95,7 +94,6 @@ func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginO
 
 	default:
 		return errors.New("login accepts only one registry to login to")
-
 	}
 
 	if ref != nil {

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -74,15 +74,16 @@ func TestParseRegistryArgument(t *testing.T) {
 		arg                string
 		acceptRepositories bool
 		expectedKey        string // or "" if we expect failure
-		expect             func(key, registry string, ref reference.Named)
+		expectedRegistry   string
+		expect             func(key string, ref reference.Named)
 	}{
 		{
 			name:               "success repository",
 			arg:                "quay.io/user",
 			acceptRepositories: true,
 			expectedKey:        "quay.io/user",
-			expect: func(key, registry string, ref reference.Named) {
-				assert.Equal(t, "quay.io", registry)
+			expectedRegistry:   "quay.io",
+			expect: func(key string, ref reference.Named) {
 				assert.Equal(t, key, ref.String())
 			},
 		},
@@ -91,8 +92,8 @@ func TestParseRegistryArgument(t *testing.T) {
 			arg:                "quay.io",
 			acceptRepositories: true,
 			expectedKey:        "quay.io",
-			expect: func(key, registry string, ref reference.Named) {
-				assert.Equal(t, "quay.io", registry)
+			expectedRegistry:   "quay.io",
+			expect: func(key string, ref reference.Named) {
 				assert.Nil(t, ref)
 			},
 		},
@@ -101,8 +102,8 @@ func TestParseRegistryArgument(t *testing.T) {
 			arg:                "docker.io/library/user",
 			acceptRepositories: true,
 			expectedKey:        "docker.io/library/user",
-			expect: func(key, registry string, ref reference.Named) {
-				assert.Equal(t, "docker.io", registry)
+			expectedRegistry:   "docker.io",
+			expect: func(key string, ref reference.Named) {
 				assert.Equal(t, key, ref.String())
 			},
 		},
@@ -129,8 +130,8 @@ func TestParseRegistryArgument(t *testing.T) {
 			arg:                "https://quay.io/user",
 			acceptRepositories: false,
 			expectedKey:        "quay.io",
-			expect: func(key, registry string, ref reference.Named) {
-				assert.Equal(t, "quay.io", registry)
+			expectedRegistry:   "quay.io",
+			expect: func(key string, ref reference.Named) {
 				assert.Nil(t, ref)
 			},
 		},
@@ -141,7 +142,8 @@ func TestParseRegistryArgument(t *testing.T) {
 		} else {
 			require.NoError(t, err, tc.name)
 			assert.Equal(t, tc.expectedKey, key, tc.name)
-			tc.expect(key, registry, ref)
+			assert.Equal(t, tc.expectedRegistry, registry)
+			tc.expect(key, ref)
 		}
 	}
 }

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -83,7 +83,7 @@ func TestParseRegistryArgument(t *testing.T) {
 			expect: func(key, registry string, ref reference.Named) {
 				assert.Equal(t, "quay.io/user", key)
 				assert.Equal(t, "quay.io", registry)
-				assert.NotNil(t, ref)
+				assert.Equal(t, key, ref.String())
 			},
 		},
 		{
@@ -105,7 +105,7 @@ func TestParseRegistryArgument(t *testing.T) {
 			expect: func(key, registry string, ref reference.Named) {
 				assert.Equal(t, "docker.io/library/user", key)
 				assert.Equal(t, "docker.io", registry)
-				assert.NotNil(t, ref)
+				assert.Equal(t, key, ref.String())
 			},
 		},
 		{

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Config", func() {
 	})
 })
 
-func TestParseRegistryArgument(t *testing.T) {
+func TestParseCredentialsKey(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		name               string
@@ -88,6 +88,13 @@ func TestParseRegistryArgument(t *testing.T) {
 			acceptRepositories: true,
 			expectedKey:        "quay.io",
 			expectedRegistry:   "quay.io",
+		},
+		{
+			name:               "a docker.io top-level namespace",
+			arg:                "docker.io/user",
+			acceptRepositories: true,
+			expectedKey:        "docker.io/user",
+			expectedRegistry:   "docker.io",
 		},
 		{
 			name:               "a single docker.io/library repo",
@@ -122,19 +129,13 @@ func TestParseRegistryArgument(t *testing.T) {
 			expectedRegistry:   "quay.io",
 		},
 	} {
-		key, registry, ref, err := parseRegistryArgument(tc.arg, tc.acceptRepositories)
+		key, registry, err := parseCredentialsKey(tc.arg, tc.acceptRepositories)
 		if tc.expectedKey == "" {
 			assert.Error(t, err, tc.name)
 		} else {
 			require.NoError(t, err, tc.name)
 			assert.Equal(t, tc.expectedKey, key, tc.name)
 			assert.Equal(t, tc.expectedRegistry, registry)
-			if tc.expectedKey != tc.expectedRegistry {
-				require.NotNil(t, ref, tc.name)
-				assert.Equal(t, tc.expectedKey, ref.String(), tc.name)
-			} else {
-				assert.Nil(t, ref, tc.name)
-			}
 		}
 	}
 }

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/containers/image/v5/docker/reference"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
@@ -75,7 +74,6 @@ func TestParseRegistryArgument(t *testing.T) {
 		acceptRepositories bool
 		expectedKey        string // or "" if we expect failure
 		expectedRegistry   string
-		expect             func(key string, ref reference.Named)
 	}{
 		{
 			name:               "success repository",
@@ -83,9 +81,6 @@ func TestParseRegistryArgument(t *testing.T) {
 			acceptRepositories: true,
 			expectedKey:        "quay.io/user",
 			expectedRegistry:   "quay.io",
-			expect: func(key string, ref reference.Named) {
-				assert.Equal(t, key, ref.String())
-			},
 		},
 		{
 			name:               "success no repository",
@@ -93,9 +88,6 @@ func TestParseRegistryArgument(t *testing.T) {
 			acceptRepositories: true,
 			expectedKey:        "quay.io",
 			expectedRegistry:   "quay.io",
-			expect: func(key string, ref reference.Named) {
-				assert.Nil(t, ref)
-			},
 		},
 		{
 			name:               "a single docker.io/library repo",
@@ -103,9 +95,6 @@ func TestParseRegistryArgument(t *testing.T) {
 			acceptRepositories: true,
 			expectedKey:        "docker.io/library/user",
 			expectedRegistry:   "docker.io",
-			expect: func(key string, ref reference.Named) {
-				assert.Equal(t, key, ref.String())
-			},
 		},
 		{
 			name:               "with http[s] prefix",
@@ -131,9 +120,6 @@ func TestParseRegistryArgument(t *testing.T) {
 			acceptRepositories: false,
 			expectedKey:        "quay.io",
 			expectedRegistry:   "quay.io",
-			expect: func(key string, ref reference.Named) {
-				assert.Nil(t, ref)
-			},
 		},
 	} {
 		key, registry, ref, err := parseRegistryArgument(tc.arg, tc.acceptRepositories)
@@ -143,7 +129,12 @@ func TestParseRegistryArgument(t *testing.T) {
 			require.NoError(t, err, tc.name)
 			assert.Equal(t, tc.expectedKey, key, tc.name)
 			assert.Equal(t, tc.expectedRegistry, registry)
-			tc.expect(key, ref)
+			if tc.expectedKey != tc.expectedRegistry {
+				require.NotNil(t, ref, tc.name)
+				assert.Equal(t, tc.expectedKey, ref.String(), tc.name)
+			} else {
+				assert.Nil(t, ref, tc.name)
+			}
 		}
 	}
 }

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -98,6 +98,17 @@ func TestParseRegistryArgument(t *testing.T) {
 			},
 		},
 		{
+			name:               "a single docker.io/library repo",
+			arg:                "docker.io/library/user",
+			acceptRepositories: true,
+			shouldErr:          false,
+			expect: func(key, registry string, ref reference.Named) {
+				assert.Equal(t, "docker.io/library/user", key)
+				assert.Equal(t, "docker.io", registry)
+				assert.NotNil(t, ref)
+			},
+		},
+		{
 			name:               "with http[s] prefix",
 			arg:                "https://quay.io",
 			acceptRepositories: true,

--- a/vendor/github.com/containers/image/v5/copy/copy.go
+++ b/vendor/github.com/containers/image/v5/copy/copy.go
@@ -80,13 +80,13 @@ type copier struct {
 
 // imageCopier tracks state specific to a single image (possibly an item of a manifest list)
 type imageCopier struct {
-	c                  *copier
-	manifestUpdates    *types.ManifestUpdateOptions
-	src                types.Image
-	diffIDsAreNeeded   bool
-	canModifyManifest  bool
-	canSubstituteBlobs bool
-	ociEncryptLayers   *[]int
+	c                          *copier
+	manifestUpdates            *types.ManifestUpdateOptions
+	src                        types.Image
+	diffIDsAreNeeded           bool
+	cannotModifyManifestReason string // The reason the manifest cannot be modified, or an empty string if it can
+	canSubstituteBlobs         bool
+	ociEncryptLayers           *[]int
 }
 
 const (
@@ -129,10 +129,14 @@ type Options struct {
 	DestinationCtx   *types.SystemContext
 	ProgressInterval time.Duration                 // time to wait between reports to signal the progress channel
 	Progress         chan types.ProgressProperties // Reported to when ProgressInterval has arrived for a single artifact+offset.
+
+	// Preserve digests, and fail if we cannot.
+	PreserveDigests bool
 	// manifest MIME type of image set by user. "" is default and means use the autodetection to the the manifest MIME type
 	ForceManifestMIMEType string
 	ImageListSelection    ImageListSelection // set to either CopySystemImage (the default), CopyAllImages, or CopySpecificImages to control which instances we copy when the source reference is a list; ignored if the source reference is not a list
 	Instances             []digest.Digest    // if ImageListSelection is CopySpecificImages, copy only these instances and the list itself
+
 	// If OciEncryptConfig is non-nil, it indicates that an image should be encrypted.
 	// The encryption options is derived from the construction of EncryptConfig object.
 	// Note: During initial encryption process of a layer, the resultant digest is not known
@@ -410,7 +414,36 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 			return nil, errors.Wrapf(err, "Can not copy signatures to %s", transports.ImageName(c.dest.Reference()))
 		}
 	}
-	canModifyManifestList := (len(sigs) == 0)
+
+	// If the destination is a digested reference, make a note of that, determine what digest value we're
+	// expecting, and check that the source manifest matches it.
+	destIsDigestedReference := false
+	if named := c.dest.Reference().DockerReference(); named != nil {
+		if digested, ok := named.(reference.Digested); ok {
+			destIsDigestedReference = true
+			matches, err := manifest.MatchesDigest(manifestList, digested.Digest())
+			if err != nil {
+				return nil, errors.Wrapf(err, "computing digest of source image's manifest")
+			}
+			if !matches {
+				return nil, errors.New("Digest of source image's manifest would not match destination reference")
+			}
+		}
+	}
+
+	// Determine if we're allowed to modify the manifest list.
+	// If we can, set to the empty string. If we can't, set to the reason why.
+	// Compare, and perhaps keep in sync with, the version in copyOneImage.
+	cannotModifyManifestListReason := ""
+	if len(sigs) > 0 {
+		cannotModifyManifestListReason = "Would invalidate signatures"
+	}
+	if destIsDigestedReference {
+		cannotModifyManifestListReason = "Destination specifies a digest"
+	}
+	if options.PreserveDigests {
+		cannotModifyManifestListReason = "Instructed to preserve digests"
+	}
 
 	// Determine if we'll need to convert the manifest list to a different format.
 	forceListMIMEType := options.ForceManifestMIMEType
@@ -425,8 +458,8 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 		return nil, errors.Wrapf(err, "determining manifest list type to write to destination")
 	}
 	if selectedListType != originalList.MIMEType() {
-		if !canModifyManifestList {
-			return nil, errors.Errorf("manifest list must be converted to type %q to be written to destination, but that would invalidate signatures", selectedListType)
+		if cannotModifyManifestListReason != "" {
+			return nil, errors.Errorf("Manifest list must be converted to type %q to be written to destination, but we cannot modify it: %q", selectedListType, cannotModifyManifestListReason)
 		}
 	}
 
@@ -510,8 +543,8 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 
 		// If we can't just use the original value, but we have to change it, flag an error.
 		if !bytes.Equal(attemptedManifestList, originalManifestList) {
-			if !canModifyManifestList {
-				return nil, errors.Errorf(" manifest list must be converted to type %q to be written to destination, but that would invalidate signatures", thisListType)
+			if cannotModifyManifestListReason != "" {
+				return nil, errors.Errorf("Manifest list must be converted to type %q to be written to destination, but we cannot modify it: %q", thisListType, cannotModifyManifestListReason)
 			}
 			logrus.Debugf("Manifest list has been updated")
 		} else {
@@ -629,13 +662,27 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 		}
 	}
 
+	// Determine if we're allowed to modify the manifest.
+	// If we can, set to the empty string. If we can't, set to the reason why.
+	// Compare, and perhaps keep in sync with, the version in copyMultipleImages.
+	cannotModifyManifestReason := ""
+	if len(sigs) > 0 {
+		cannotModifyManifestReason = "Would invalidate signatures"
+	}
+	if destIsDigestedReference {
+		cannotModifyManifestReason = "Destination specifies a digest"
+	}
+	if options.PreserveDigests {
+		cannotModifyManifestReason = "Instructed to preserve digests"
+	}
+
 	ic := imageCopier{
 		c:               c,
 		manifestUpdates: &types.ManifestUpdateOptions{InformationOnly: types.ManifestUpdateInformation{Destination: c.dest}},
 		src:             src,
 		// diffIDsAreNeeded is computed later
-		canModifyManifest: len(sigs) == 0 && !destIsDigestedReference,
-		ociEncryptLayers:  options.OciEncryptLayers,
+		cannotModifyManifestReason: cannotModifyManifestReason,
+		ociEncryptLayers:           options.OciEncryptLayers,
 	}
 	// Ensure _this_ copy sees exactly the intended data when either processing a signed image or signing it.
 	// This may be too conservative, but for now, better safe than sorry, _especially_ on the SignBy path:
@@ -643,7 +690,7 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 	// We do intend the RecordDigestUncompressedPair calls to only work with reliable data, but at least there’s a risk
 	// that the compressed version coming from a third party may be designed to attack some other decompressor implementation,
 	// and we would reuse and sign it.
-	ic.canSubstituteBlobs = ic.canModifyManifest && options.SignBy == ""
+	ic.canSubstituteBlobs = ic.cannotModifyManifestReason == "" && options.SignBy == ""
 
 	if err := ic.updateEmbeddedDockerReference(); err != nil {
 		return nil, "", "", err
@@ -710,10 +757,10 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 		}
 		// If the original MIME type is acceptable, determineManifestConversion always uses it as preferredManifestMIMEType.
 		// So if we are here, we will definitely be trying to convert the manifest.
-		// With !ic.canModifyManifest, that would just be a string of repeated failures for the same reason,
+		// With ic.cannotModifyManifestReason != "", that would just be a string of repeated failures for the same reason,
 		// so let’s bail out early and with a better error message.
-		if !ic.canModifyManifest {
-			return nil, "", "", errors.Wrap(err, "Writing manifest failed (and converting it is not possible, image is signed or the destination specifies a digest)")
+		if ic.cannotModifyManifestReason != "" {
+			return nil, "", "", errors.Wrapf(err, "Writing manifest failed and we cannot try conversions: %q", cannotModifyManifestReason)
 		}
 
 		// errs is a list of errors when trying various manifest types. Also serves as an "upload succeeded" flag when set to nil.
@@ -813,9 +860,9 @@ func (ic *imageCopier) updateEmbeddedDockerReference() error {
 		return nil // No reference embedded in the manifest, or it matches destRef already.
 	}
 
-	if !ic.canModifyManifest {
-		return errors.Errorf("Copying a schema1 image with an embedded Docker reference to %s (Docker reference %s) would change the manifest, which is not possible (image is signed or the destination specifies a digest)",
-			transports.ImageName(ic.c.dest.Reference()), destRef.String())
+	if ic.cannotModifyManifestReason != "" {
+		return errors.Errorf("Copying a schema1 image with an embedded Docker reference to %s (Docker reference %s) would change the manifest, which we cannot do: %q",
+			transports.ImageName(ic.c.dest.Reference()), destRef.String(), ic.cannotModifyManifestReason)
 	}
 	ic.manifestUpdates.EmbeddedDockerReference = destRef
 	return nil
@@ -833,7 +880,7 @@ func isTTY(w io.Writer) bool {
 	return false
 }
 
-// copyLayers copies layers from ic.src/ic.c.rawSource to dest, using and updating ic.manifestUpdates if necessary and ic.canModifyManifest.
+// copyLayers copies layers from ic.src/ic.c.rawSource to dest, using and updating ic.manifestUpdates if necessary and ic.cannotModifyManifestReason == "".
 func (ic *imageCopier) copyLayers(ctx context.Context) error {
 	srcInfos := ic.src.LayerInfos()
 	numLayers := len(srcInfos)
@@ -844,8 +891,8 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 	srcInfosUpdated := false
 	// If we only need to check authorization, no updates required.
 	if updatedSrcInfos != nil && !reflect.DeepEqual(srcInfos, updatedSrcInfos) {
-		if !ic.canModifyManifest {
-			return errors.Errorf("Copying this image requires changing layer representation, which is not possible (image is signed or the destination specifies a digest)")
+		if ic.cannotModifyManifestReason != "" {
+			return errors.Errorf("Copying this image would require changing layer representation, which we cannot do: %q", ic.cannotModifyManifestReason)
 		}
 		srcInfos = updatedSrcInfos
 		srcInfosUpdated = true
@@ -975,8 +1022,8 @@ func layerDigestsDiffer(a, b []types.BlobInfo) bool {
 func (ic *imageCopier) copyUpdatedConfigAndManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, digest.Digest, error) {
 	pendingImage := ic.src
 	if !ic.noPendingManifestUpdates() {
-		if !ic.canModifyManifest {
-			return nil, "", errors.Errorf("Internal error: copy needs an updated manifest but that was known to be forbidden")
+		if ic.cannotModifyManifestReason != "" {
+			return nil, "", errors.Errorf("Internal error: copy needs an updated manifest but that was known to be forbidden: %q", ic.cannotModifyManifestReason)
 		}
 		if !ic.diffIDsAreNeeded && ic.src.UpdatedImageNeedsLayerDiffIDs(*ic.manifestUpdates) {
 			// We have set ic.diffIDsAreNeeded based on the preferred MIME type returned by determineManifestConversion.
@@ -1359,7 +1406,7 @@ func (ic *imageCopier) copyLayerFromStream(ctx context.Context, srcStream io.Rea
 		}
 	}
 
-	blobInfo, err := ic.c.copyBlobFromStream(ctx, srcStream, srcInfo, getDiffIDRecorder, ic.canModifyManifest, false, toEncrypt, bar, layerIndex, emptyLayer) // Sets err to nil on success
+	blobInfo, err := ic.c.copyBlobFromStream(ctx, srcStream, srcInfo, getDiffIDRecorder, ic.cannotModifyManifestReason == "", false, toEncrypt, bar, layerIndex, emptyLayer) // Sets err to nil on success
 	return blobInfo, diffIDChan, err
 	// We need the defer … pipeWriter.CloseWithError() to happen HERE so that the caller can block on reading from diffIDChan
 }

--- a/vendor/github.com/containers/image/v5/copy/manifest.go
+++ b/vendor/github.com/containers/image/v5/copy/manifest.go
@@ -79,10 +79,10 @@ func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupp
 	if _, ok := supportedByDest[srcType]; ok {
 		prioritizedTypes.append(srcType)
 	}
-	if !ic.canModifyManifest {
-		// We could also drop the !ic.canModifyManifest check and have the caller
+	if ic.cannotModifyManifestReason != "" {
+		// We could also drop this check and have the caller
 		// make the choice; it is already doing that to an extent, to improve error
-		// messages.  But it is nice to hide the “if !ic.canModifyManifest, do no conversion”
+		// messages.  But it is nice to hide the “if we can't modify, do no conversion”
 		// special case in here; the caller can then worry (or not) only about a good UI.
 		logrus.Debugf("We can't modify the manifest, hoping for the best...")
 		return srcType, []string{}, nil // Take our chances - FIXME? Or should we fail without trying?

--- a/vendor/github.com/containers/image/v5/manifest/manifest.go
+++ b/vendor/github.com/containers/image/v5/manifest/manifest.go
@@ -110,7 +110,8 @@ func GuessMIMEType(manifest []byte) string {
 	}
 
 	switch meta.MediaType {
-	case DockerV2Schema2MediaType, DockerV2ListMediaType: // A recognized type.
+	case DockerV2Schema2MediaType, DockerV2ListMediaType,
+		imgspecv1.MediaTypeImageManifest, imgspecv1.MediaTypeImageIndex: // A recognized type.
 		return meta.MediaType
 	}
 	// this is the only way the function can return DockerV2Schema1MediaType, and recognizing that is essential for stripping the JWS signatures = computing the correct manifest digest.
@@ -121,9 +122,9 @@ func GuessMIMEType(manifest []byte) string {
 		}
 		return DockerV2Schema1MediaType
 	case 2:
-		// best effort to understand if this is an OCI image since mediaType
-		// isn't in the manifest for OCI anymore
-		// for docker v2s2 meta.MediaType should have been set. But given the data, this is our best guess.
+		// Best effort to understand if this is an OCI image since mediaType
+		// wasn't in the manifest for OCI image-spec < 1.0.2.
+		// For docker v2s2 meta.MediaType should have been set. But given the data, this is our best guess.
 		ociMan := struct {
 			Config struct {
 				MediaType string `json:"mediaType"`

--- a/vendor/github.com/containers/image/v5/manifest/oci.go
+++ b/vendor/github.com/containers/image/v5/manifest/oci.go
@@ -66,6 +66,7 @@ func OCI1FromComponents(config imgspecv1.Descriptor, layers []imgspecv1.Descript
 	return &OCI1{
 		imgspecv1.Manifest{
 			Versioned: specs.Versioned{SchemaVersion: 2},
+			MediaType: imgspecv1.MediaTypeImageManifest,
 			Config:    config,
 			Layers:    layers,
 		},

--- a/vendor/github.com/containers/image/v5/manifest/oci_index.go
+++ b/vendor/github.com/containers/image/v5/manifest/oci_index.go
@@ -119,6 +119,7 @@ func OCI1IndexFromComponents(components []imgspecv1.Descriptor, annotations map[
 	index := OCI1Index{
 		imgspecv1.Index{
 			Versioned:   imgspec.Versioned{SchemaVersion: 2},
+			MediaType:   imgspecv1.MediaTypeImageIndex,
 			Manifests:   make([]imgspecv1.Descriptor, len(components)),
 			Annotations: dupStringStringMap(annotations),
 		},
@@ -195,6 +196,7 @@ func OCI1IndexFromManifest(manifest []byte) (*OCI1Index, error) {
 	index := OCI1Index{
 		Index: imgspecv1.Index{
 			Versioned:   imgspec.Versioned{SchemaVersion: 2},
+			MediaType:   imgspecv1.MediaTypeImageIndex,
 			Manifests:   []imgspecv1.Descriptor{},
 			Annotations: make(map[string]string),
 		},

--- a/vendor/github.com/containers/image/v5/pkg/shortnames/shortnames.go
+++ b/vendor/github.com/containers/image/v5/pkg/shortnames/shortnames.go
@@ -118,6 +118,7 @@ type Resolved struct {
 }
 
 func (r *Resolved) addCandidate(named reference.Named) {
+	named = reference.TagNameOnly(named) // Make sure to add ":latest" if needed
 	r.PullCandidates = append(r.PullCandidates, PullCandidate{named, false, r})
 }
 
@@ -138,6 +139,8 @@ const (
 	rationaleUSR
 	// Resolved value has been selected by the user (via the prompt).
 	rationaleUserSelection
+	// Resolved value has been enforced to use Docker Hub (via SystemContext).
+	rationaleEnforcedDockerHub
 )
 
 // Description returns a human-readable description about the resolution
@@ -152,6 +155,8 @@ func (r *Resolved) Description() string {
 		return fmt.Sprintf("Resolved %q as an alias (%s)", r.userInput, r.originDescription)
 	case rationaleUSR:
 		return fmt.Sprintf("Resolving %q using unqualified-search registries (%s)", r.userInput, r.originDescription)
+	case rationaleEnforcedDockerHub:
+		return fmt.Sprintf("Resolving %q to docker.io (%s)", r.userInput, r.originDescription)
 	case rationaleUserSelection, rationaleNone:
 		fallthrough
 	default:
@@ -265,8 +270,20 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 		return nil, err
 	}
 	if !isShort { // no short name
-		named := reference.TagNameOnly(shortRef) // Make sure to add ":latest" if needed
+		resolved.addCandidate(shortRef)
+		return resolved, nil
+	}
+
+	// Resolve to docker.io only if enforced by the caller (e.g., Podman's
+	// Docker-compatible REST API).
+	if ctx != nil && ctx.PodmanOnlyShortNamesIgnoreRegistriesConfAndForceDockerHub {
+		named, err := reference.ParseNormalizedNamed(name)
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot normalize input: %q", name)
+		}
 		resolved.addCandidate(named)
+		resolved.rationale = rationaleEnforcedDockerHub
+		resolved.originDescription = "enforced by caller"
 		return resolved, nil
 	}
 
@@ -295,9 +312,6 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 				return nil, err
 			}
 		}
-		// Make sure to add ":latest" if needed
-		namedAlias = reference.TagNameOnly(namedAlias)
-
 		resolved.addCandidate(namedAlias)
 		resolved.rationale = rationaleAlias
 		resolved.originDescription = aliasOriginDescription
@@ -325,9 +339,6 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "creating reference with unqualified-search registry %q", reg)
 		}
-		// Make sure to add ":latest" if needed
-		named = reference.TagNameOnly(named)
-
 		resolved.addCandidate(named)
 	}
 
@@ -412,6 +423,23 @@ func ResolveLocally(ctx *types.SystemContext, name string) ([]reference.Named, e
 
 	var candidates []reference.Named
 
+	// Complete the candidates with the specified registries.
+	completeCandidates := func(registries []string) ([]reference.Named, error) {
+		for _, reg := range registries {
+			named, err := reference.ParseNormalizedNamed(fmt.Sprintf("%s/%s", reg, name))
+			if err != nil {
+				return nil, errors.Wrapf(err, "creating reference with unqualified-search registry %q", reg)
+			}
+			named = reference.TagNameOnly(named) // Make sure to add ":latest" if needed
+			candidates = append(candidates, named)
+		}
+		return candidates, nil
+	}
+
+	if ctx != nil && ctx.PodmanOnlyShortNamesIgnoreRegistriesConfAndForceDockerHub {
+		return completeCandidates([]string{"docker.io"})
+	}
+
 	// Strip off the tag to normalize the short name for looking it up in
 	// the config files.
 	isTagged, isDigested, shortNameRepo, tag, digest := splitUserInput(shortRef)
@@ -434,9 +462,7 @@ func ResolveLocally(ctx *types.SystemContext, name string) ([]reference.Named, e
 				return nil, err
 			}
 		}
-		// Make sure to add ":latest" if needed
-		namedAlias = reference.TagNameOnly(namedAlias)
-
+		namedAlias = reference.TagNameOnly(namedAlias) // Make sure to add ":latest" if needed
 		candidates = append(candidates, namedAlias)
 	}
 
@@ -447,16 +473,5 @@ func ResolveLocally(ctx *types.SystemContext, name string) ([]reference.Named, e
 	}
 
 	// Note that "localhost" has precedence over the unqualified-search registries.
-	for _, reg := range append([]string{"localhost"}, unqualifiedSearchRegistries...) {
-		named, err := reference.ParseNormalizedNamed(fmt.Sprintf("%s/%s", reg, name))
-		if err != nil {
-			return nil, errors.Wrapf(err, "creating reference with unqualified-search registry %q", reg)
-		}
-		// Make sure to add ":latest" if needed
-		named = reference.TagNameOnly(named)
-
-		candidates = append(candidates, named)
-	}
-
-	return candidates, nil
+	return completeCandidates(append([]string{"localhost"}, unqualifiedSearchRegistries...))
 }

--- a/vendor/github.com/containers/image/v5/types/types.go
+++ b/vendor/github.com/containers/image/v5/types/types.go
@@ -561,6 +561,11 @@ type SystemContext struct {
 	UserShortNameAliasConfPath string
 	// If set, short-name resolution in pkg/shortnames must follow the specified mode
 	ShortNameMode *ShortNameMode
+	// If set, short names will resolve in pkg/shortnames to docker.io only, and unqualified-search registries and
+	// short-name aliases in registries.conf are ignored.  Note that this field is only intended to help enforce
+	// resolving to Docker Hub in the Docker-compatible REST API of Podman; it should never be used outside this
+	// specific context.
+	PodmanOnlyShortNamesIgnoreRegistriesConfAndForceDockerHub bool
 	// If not "", overrides the default path for the authentication file, but only new format files
 	AuthFilePath string
 	// if not "", overrides the default path for the authentication file, but with the legacy format;

--- a/vendor/github.com/containers/image/v5/version/version.go
+++ b/vendor/github.com/containers/image/v5/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 17
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -50,7 +50,7 @@ github.com/containerd/containerd/platforms
 # github.com/containerd/stargz-snapshotter/estargz v0.10.1
 github.com/containerd/stargz-snapshotter/estargz
 github.com/containerd/stargz-snapshotter/estargz/errorutil
-# github.com/containers/image/v5 v5.17.0
+# github.com/containers/image/v5 v5.17.1-0.20211201214147-603ec1341d58
 ## explicit
 github.com/containers/image/v5/copy
 github.com/containers/image/v5/directory


### PR DESCRIPTION
This is an alternative to #757 <s>, depends on UNMERGED https://github.com/containers/image/pull/1373</s> .

Now that `GetCredentials` allows looking up namespaced credentials, use that instead of `GetCredentialsForRef`, which avoids the `docker.io/vendor`→`docker.io/library/vendor` normalization issue; use reference parsing only to validate the syntax.

Also refactor a bit of the argument length handling and `logout --all`.

See individual commit messages for details.

Warning: Only unit-tested, and the actual functionality does not have test coverage. I didn’t actually try this in practice.