### PR TITLE
Backports for Podman 3.3.2

### DIFF
--- a/libimage/disk_usage.go
+++ b/libimage/disk_usage.go
@@ -52,6 +52,10 @@ func (r *Runtime) DiskUsage(ctx context.Context) ([]ImageDiskUsage, error) {
 
 // diskUsageForImage returns the disk-usage baseistics for the specified image.
 func diskUsageForImage(ctx context.Context, image *Image, tree *layerTree) ([]ImageDiskUsage, error) {
+	if err := image.isCorrupted(""); err != nil {
+		return nil, err
+	}
+
 	base := ImageDiskUsage{
 		ID:         image.ID(),
 		Created:    image.Created(),

--- a/libimage/image.go
+++ b/libimage/image.go
@@ -74,7 +74,10 @@ func (i *Image) isCorrupted(name string) error {
 	}
 
 	if _, err := ref.NewImage(context.Background(), nil); err != nil {
-		return errors.Errorf("Image %s exists in local storage but may be corrupted: %v", name, err)
+		if name == "" {
+			name = i.ID()[:12]
+		}
+		return errors.Errorf("Image %s exists in local storage but may be corrupted (remove the image to resolve the issue): %v", name, err)
 	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -167,7 +167,7 @@ type ContainersConfig struct {
 
 	// RootlessNetworking depicts the "kind" of networking for rootless
 	// containers.  Valid options are `slirp4netns` and `cni`. Default is
-	// `slirp4netns`
+	// `slirp4netns` on Linux, and `cni` on non-Linux OSes.
 	RootlessNetworking string `toml:"rootless_networking,omitempty"`
 
 	// SeccompProfile is the seccomp.json profile path which is used as the

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -82,10 +82,6 @@ var (
 		"/usr/local/lib/cni",
 		"/opt/cni/bin",
 	}
-
-	// DefaultRootlessNetwork is the kind of of rootless networking
-	// for containers
-	DefaultRootlessNetwork = "slirp4netns"
 )
 
 const (
@@ -197,7 +193,7 @@ func DefaultConfig() (*Config, error) {
 			NoHosts:            false,
 			PidsLimit:          DefaultPidsLimit,
 			PidNS:              "private",
-			RootlessNetworking: DefaultRootlessNetwork,
+			RootlessNetworking: getDefaultRootlessNetwork(),
 			ShmSize:            DefaultShmSize,
 			TZ:                 "",
 			Umask:              "0022",

--- a/pkg/config/default_linux.go
+++ b/pkg/config/default_linux.go
@@ -13,6 +13,12 @@ const (
 	oldMaxSize = uint64(1048576)
 )
 
+// getDefaultRootlessNetwork returns the default rootless network configuration.
+// It is "slirp4netns" for Linux.
+func getDefaultRootlessNetwork() string {
+	return "slirp4netns"
+}
+
 // getDefaultProcessLimits returns the nproc for the current process in ulimits format
 // Note that nfile sometimes cannot be set to unlimited, and the limit is hardcoded
 // to (oldMaxSize) 1048576 (2^20), see: http://stackoverflow.com/a/1213069/1811501

--- a/pkg/config/default_unsupported.go
+++ b/pkg/config/default_unsupported.go
@@ -2,6 +2,12 @@
 
 package config
 
+// getDefaultRootlessNetwork returns the default rootless network configuration.
+// It is "cni" for non-Linux OSes (to better support `podman-machine` usecases).
+func getDefaultRootlessNetwork() string {
+	return "cni"
+}
+
 // isCgroup2UnifiedMode returns whether we are running in cgroup2 mode.
 func isCgroup2UnifiedMode() (isUnified bool, isUnifiedErr error) {
 	return false, nil

--- a/pkg/config/util_supported.go
+++ b/pkg/config/util_supported.go
@@ -48,7 +48,7 @@ func getRuntimeDir() (string, error) {
 			}
 		}
 		if runtimeDir == "" {
-			tmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("run-%s", uid))
+			tmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("podman-run-%s", uid))
 			if err := os.MkdirAll(tmpDir, 0700); err != nil {
 				logrus.Debugf("unable to make temp dir %v", err)
 			}


### PR DESCRIPTION
#759 Fix the fallback runtime path 
66fee592b112e40e7a9178d2f39ed48994cf0c9c

#754 Switch default Rootless Networking to "CNI" for OSX
854253d305b4c4fe0df19af74d4833b71afeb7af

#752 libimage: disk usage: catch corrupted images
ade9985425d4c3ad57cef2eb19c7b1e70994b7c0