### PR TITLE
Add support for the krun (runc running in KVM) OCI Runtime

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -502,15 +502,15 @@ Default OCI specific runtime in runtimes that will be used by default. Must
 refer to a member of the runtimes table. Default runtime will be searched for
 on the system using the priority: "crun", "runc", "kata".
 
-**runtime_supports_json**=["crun", "runc", "kata", "runsc"]
+**runtime_supports_json**=["crun", "runc", "kata", "runsc", "krun"]
 
 The list of the OCI runtimes that support `--format=json`.
 
-**runtime_supports_kvm**=["kata"]
+**runtime_supports_kvm**=["kata", "krun"]
 
 The list of OCI runtimes that support running containers with KVM separation.
 
-**runtime_supports_nocgroups**=["crun"]
+**runtime_supports_nocgroups**=["crun", "krun"]
 
 The list of OCI runtimes that support running containers without CGroups.
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -183,6 +183,10 @@ image_copy_tmp_dir="storage"`
 					"/sbin/runsc",
 					"/run/current-system/sw/bin/runsc",
 				},
+				"krun": {
+					"/usr/bin/krun",
+					"/usr/local/bin/krun",
+				},
 			}
 
 			pluginDirs := []string{

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -451,15 +451,15 @@ default_sysctls = [
 # List of the OCI runtimes that support --format=json.  When json is supported
 # engine will use it for reporting nicer errors.
 #
-#runtime_supports_json = ["crun", "runc", "kata", "runsc"]
+#runtime_supports_json = ["crun", "runc", "kata", "runsc", "krun"]
 
 # List of the OCI runtimes that supports running containers with KVM Separation.
 #
-#runtime_supports_kvm = ["kata"]
+#runtime_supports_kvm = ["kata", "krun"]
 
 # List of the OCI runtimes that supports running containers without cgroups.
 #
-#runtime_supports_nocgroups = ["crun"]
+#runtime_supports_nocgroups = ["crun", "krun"]
 
 # Default location for storing temporary container image content.  Can be overridden with the TMPDIR environment
 # variable.  If you specify "storage", then the location of the
@@ -503,7 +503,7 @@ default_sysctls = [
 #
 #volume_path = "/var/lib/containers/storage/volumes"
 
-# Paths to look for a valid OCI runtime (crun, runc, kata, runsc, etc)
+# Paths to look for a valid OCI runtime (crun, runc, kata, runsc, krun, etc)
 [engine.runtimes]
 #crun = [
 #  "/usr/bin/crun",
@@ -544,6 +544,16 @@ default_sysctls = [
 #  "/bin/runsc",
 #  "/sbin/runsc",
 #  "/run/current-system/sw/bin/runsc",
+#]
+
+#krun = [
+#  "/usr/bin/krun",
+#  "/usr/sbin/krun",
+#  "/usr/local/bin/krun",
+#  "/usr/local/sbin/krun",
+#  "/sbin/krun",
+#  "/bin/krun",
+#  "/run/current-system/sw/bin/krun",
 #]
 
 [engine.volume_plugins]

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -548,12 +548,7 @@ default_sysctls = [
 
 #krun = [
 #  "/usr/bin/krun",
-#  "/usr/sbin/krun",
 #  "/usr/local/bin/krun",
-#  "/usr/local/sbin/krun",
-#  "/sbin/krun",
-#  "/bin/krun",
-#  "/run/current-system/sw/bin/krun",
 #]
 
 [engine.volume_plugins]

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -301,12 +301,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 		},
 		"krun": {
 			"/usr/bin/krun",
-			"/usr/sbin/krun",
 			"/usr/local/bin/krun",
-			"/usr/local/sbin/krun",
-			"/sbin/krun",
-			"/bin/krun",
-			"/run/current-system/sw/bin/krun",
 		},
 	}
 	// Needs to be called after populating c.OCIRuntimes

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -299,6 +299,15 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 			"/sbin/runsc",
 			"/run/current-system/sw/bin/runsc",
 		},
+		"krun": {
+			"/usr/bin/krun",
+			"/usr/sbin/krun",
+			"/usr/local/bin/krun",
+			"/usr/local/sbin/krun",
+			"/sbin/krun",
+			"/bin/krun",
+			"/run/current-system/sw/bin/krun",
+		},
 	}
 	// Needs to be called after populating c.OCIRuntimes
 	c.OCIRuntime = c.findRuntime()
@@ -322,9 +331,10 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 		"runc",
 		"kata",
 		"runsc",
+		"krun",
 	}
-	c.RuntimeSupportsNoCgroups = []string{"crun"}
-	c.RuntimeSupportsKVM = []string{"kata", "kata-runtime", "kata-qemu", "kata-fc"}
+	c.RuntimeSupportsNoCgroups = []string{"crun", "krun"}
+	c.RuntimeSupportsKVM = []string{"kata", "kata-runtime", "kata-qemu", "kata-fc", "krun"}
 	c.InitPath = DefaultInitPath
 	c.NoPivotRoot = false
 


### PR DESCRIPTION
Signed-off-by: Frederic Crozat <fcrozat@suse.com>

Allow to use krun (symlink to crun, when built with libkrun support) as OCI runtime
