### PR TITLE
UserNS should default to '' rather then host

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -329,6 +329,7 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal(apparmor.Profile))
 			gomega.Expect(config.Containers.PidsLimit).To(gomega.BeEquivalentTo(2048))
 			gomega.Expect(config.Containers.Env).To(gomega.BeEquivalentTo(envs))
+			gomega.Expect(config.Containers.UserNS).To(gomega.BeEquivalentTo(""))
 			gomega.Expect(config.Network.CNIPluginDirs).To(gomega.Equal(DefaultCNIPluginDirs))
 			gomega.Expect(config.Engine.NumLocks).To(gomega.BeEquivalentTo(2048))
 			gomega.Expect(config.Engine.OCIRuntimes["runc"]).To(gomega.Equal(OCIRuntimeMap["runc"]))

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -198,7 +198,6 @@ func DefaultConfig() (*Config, error) {
 			TZ:                 "",
 			Umask:              "0022",
 			UTSNS:              "private",
-			UserNS:             "host",
 			UserNSSize:         DefaultUserNSSize,
 		},
 		Network: NetworkConfig{


### PR DESCRIPTION
If you use this field in rootless mode, it will blow up,
since rootless mode can not use the host user namespace.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
