### PR TITLE
(*libimage.Image).HasDifferentDigest: add authentication

### DIFF
--- a/libimage/image_test.go
+++ b/libimage/image_test.go
@@ -134,14 +134,14 @@ func TestImageFunctions(t *testing.T) {
 	// Same image -> same digest
 	remoteRef, err := alltransports.ParseImageName("docker://" + busyboxDigest)
 	require.NoError(t, err)
-	hasDifferentDigest, err := image.HasDifferentDigest(ctx, remoteRef)
+	hasDifferentDigest, err := image.HasDifferentDigest(ctx, remoteRef, nil)
 	require.NoError(t, err)
 	require.False(t, hasDifferentDigest, "image with same digest should have the same manifest (and hence digest)")
 
 	// Different images -> different digests
 	remoteRef, err = alltransports.ParseImageName("docker://docker.io/library/alpine:latest")
 	require.NoError(t, err)
-	hasDifferentDigest, err = image.HasDifferentDigest(ctx, remoteRef)
+	hasDifferentDigest, err = image.HasDifferentDigest(ctx, remoteRef, nil)
 	require.NoError(t, err)
 	require.True(t, hasDifferentDigest, "another image should have a different digest")
 

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -561,7 +561,7 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 		}
 
 		if pullPolicy == config.PullPolicyNewer && localImage != nil {
-			isNewer, err := localImage.HasDifferentDigest(ctx, srcRef)
+			isNewer, err := localImage.hasDifferentDigestWithSystemContext(ctx, srcRef, c.systemContext)
 			if err != nil {
 				pullErrors = append(pullErrors, err)
 				continue


### PR DESCRIPTION
Allow for passing down credentials when comparing a local image with a
remote one.  The linked BZ relates to a regression in `podman auto-update`
but while reading the code I noticed it's also impacting pull policies.

BZ: bugzilla.redhat.com/show_bug.cgi?id=2000943
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
