### PR TITLE
[0.42] (*libimage.Image).HasDifferentDigest: add authentication

### DIFF
--- a/libimage/image.go
+++ b/libimage/image.go
@@ -694,10 +694,18 @@ func (i *Image) Size() (int64, error) {
 	return i.runtime.store.ImageSize(i.ID())
 }
 
+// HasDifferentDigestOptions allows for customizing the check if another
+// (remote) image has a different digest.
+type HasDifferentDigestOptions struct {
+	// containers-auth.json(5) file to use when authenticating against
+	// container registries.
+	AuthFilePath string
+}
+
 // HasDifferentDigest returns true if the image specified by `remoteRef` has a
 // different digest than the local one.  This check can be useful to check for
 // updates on remote registries.
-func (i *Image) HasDifferentDigest(ctx context.Context, remoteRef types.ImageReference) (bool, error) {
+func (i *Image) HasDifferentDigest(ctx context.Context, remoteRef types.ImageReference, options *HasDifferentDigestOptions) (bool, error) {
 	// We need to account for the arch that the image uses.  It seems
 	// common on ARM to tweak this option to pull the correct image.  See
 	// github.com/containers/podman/issues/6613.
@@ -717,6 +725,14 @@ func (i *Image) HasDifferentDigest(ctx context.Context, remoteRef types.ImageRef
 		sys.VariantChoice = inspectInfo.Variant
 	}
 
+	if options != nil && options.AuthFilePath != "" {
+		sys.AuthFilePath = options.AuthFilePath
+	}
+
+	return i.hasDifferentDigestWithSystemContext(ctx, remoteRef, sys)
+}
+
+func (i *Image) hasDifferentDigestWithSystemContext(ctx context.Context, remoteRef types.ImageReference, sys *types.SystemContext) (bool, error) {
 	remoteImg, err := remoteRef.NewImage(ctx, sys)
 	if err != nil {
 		return false, err

--- a/libimage/image_test.go
+++ b/libimage/image_test.go
@@ -134,14 +134,14 @@ func TestImageFunctions(t *testing.T) {
 	// Same image -> same digest
 	remoteRef, err := alltransports.ParseImageName("docker://" + busyboxDigest)
 	require.NoError(t, err)
-	hasDifferentDigest, err := image.HasDifferentDigest(ctx, remoteRef)
+	hasDifferentDigest, err := image.HasDifferentDigest(ctx, remoteRef, nil)
 	require.NoError(t, err)
 	require.False(t, hasDifferentDigest, "image with same digest should have the same manifest (and hence digest)")
 
 	// Different images -> different digests
 	remoteRef, err = alltransports.ParseImageName("docker://docker.io/library/alpine:latest")
 	require.NoError(t, err)
-	hasDifferentDigest, err = image.HasDifferentDigest(ctx, remoteRef)
+	hasDifferentDigest, err = image.HasDifferentDigest(ctx, remoteRef, nil)
 	require.NoError(t, err)
 	require.True(t, hasDifferentDigest, "another image should have a different digest")
 

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -561,7 +561,7 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 		}
 
 		if pullPolicy == config.PullPolicyNewer && localImage != nil {
-			isNewer, err := localImage.HasDifferentDigest(ctx, srcRef)
+			isNewer, err := localImage.hasDifferentDigestWithSystemContext(ctx, srcRef, c.systemContext)
 			if err != nil {
 				pullErrors = append(pullErrors, err)
 				continue

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.42.3-dev"
+const Version = "0.42.3"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.42.3"
+const Version = "0.42.4-dev"


### PR DESCRIPTION
Allow for passing down credentials when comparing a local image with a
remote one.  The linked BZ relates to a regression in `podman auto-update`
but while reading the code I noticed it's also impacting pull policies.

BZ: bugzilla.redhat.com/show_bug.cgi?id=2000943
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

Note the version bump.

DO NOT MERGE BEFORE https://github.com/containers/common/pull/775

@nalind @rhatdan PTAL
