### PR TITLE
libimage: accept CompressionFormat/CompressionLevel

### DIFF
--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/common/pkg/retry"
 	"github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/signature"
 	storageTransport "github.com/containers/image/v5/storage"
 	"github.com/containers/image/v5/types"
@@ -40,6 +41,10 @@ type CopyOptions struct {
 	// Allows for customizing the destination reference lookup.  This can
 	// be used to use custom blob caches.
 	DestinationLookupReferenceFunc LookupReferenceFunc
+	// CompressionFormat is the format to use for the compression of the blobs
+	CompressionFormat *compression.Algorithm
+	// CompressionLevel specifies what compression level is used
+	CompressionLevel *int
 
 	// containers-auth.json(5) file to use when authenticating against
 	// container registries.
@@ -240,6 +245,14 @@ func (r *Runtime) newCopier(options *CopyOptions) (*copier, error) {
 
 	if options.CertDirPath != "" {
 		c.systemContext.DockerCertPath = options.CertDirPath
+	}
+
+	if options.CompressionFormat != nil {
+		c.systemContext.CompressionFormat = options.CompressionFormat
+	}
+
+	if options.CompressionLevel != nil {
+		c.systemContext.CompressionLevel = options.CompressionLevel
 	}
 
 	policy, err := signature.DefaultPolicy(c.systemContext)


### PR DESCRIPTION
allow to specify the compression format and compression level.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
