### PR TITLE
Export no such secret error

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -24,8 +24,8 @@ const secretIDLength = 25
 // errInvalidPath indicates that the secrets path is invalid
 var errInvalidPath = errors.New("invalid secrets path")
 
-// errNoSuchSecret indicates that the secret does not exist
-var errNoSuchSecret = errors.New("no such secret")
+// ErrNoSuchSecret indicates that the secret does not exist
+var ErrNoSuchSecret = errors.New("no such secret")
 
 // errSecretNameInUse indicates that the secret name is already in use
 var errSecretNameInUse = errors.New("secret name in use")
@@ -152,7 +152,7 @@ func (s *SecretsManager) Store(name string, data []byte, driverType string, driv
 		newID = newID[0:secretIDLength]
 		_, err := s.lookupSecret(newID)
 		if err != nil {
-			if errors.Cause(err) == errNoSuchSecret {
+			if errors.Cause(err) == ErrNoSuchSecret {
 				secr.ID = newID
 				break
 			} else {

--- a/pkg/secrets/secretsdb.go
+++ b/pkg/secrets/secretsdb.go
@@ -71,14 +71,14 @@ func (s *SecretsManager) getNameAndID(nameOrID string) (name, id string, err err
 	name, id, err = s.getExactNameAndID(nameOrID)
 	if err == nil {
 		return name, id, nil
-	} else if errors.Cause(err) != errNoSuchSecret {
+	} else if errors.Cause(err) != ErrNoSuchSecret {
 		return "", "", err
 	}
 
 	// ID prefix may have been given, iterate through all IDs.
 	// ID and partial ID has a max length of 25, so we return if its greater than that.
 	if len(nameOrID) > secretIDLength {
-		return "", "", errors.Wrapf(errNoSuchSecret, "no secret with name or id %q", nameOrID)
+		return "", "", errors.Wrapf(ErrNoSuchSecret, "no secret with name or id %q", nameOrID)
 	}
 	exists := false
 	var foundID, foundName string
@@ -96,7 +96,7 @@ func (s *SecretsManager) getNameAndID(nameOrID string) (name, id string, err err
 	if exists {
 		return foundName, foundID, nil
 	}
-	return "", "", errors.Wrapf(errNoSuchSecret, "no secret with name or id %q", nameOrID)
+	return "", "", errors.Wrapf(ErrNoSuchSecret, "no secret with name or id %q", nameOrID)
 }
 
 // getExactNameAndID takes a secret's name or ID and returns both its name and full ID.
@@ -115,7 +115,7 @@ func (s *SecretsManager) getExactNameAndID(nameOrID string) (name, id string, er
 		return name, id, nil
 	}
 
-	return "", "", errors.Wrapf(errNoSuchSecret, "no secret with name or id %q", nameOrID)
+	return "", "", errors.Wrapf(ErrNoSuchSecret, "no secret with name or id %q", nameOrID)
 }
 
 // exactSecretExists checks if the secret exists, given a name or ID
@@ -123,7 +123,7 @@ func (s *SecretsManager) getExactNameAndID(nameOrID string) (name, id string, er
 func (s *SecretsManager) exactSecretExists(nameOrID string) (bool, error) {
 	_, _, err := s.getExactNameAndID(nameOrID)
 	if err != nil {
-		if errors.Cause(err) == errNoSuchSecret {
+		if errors.Cause(err) == ErrNoSuchSecret {
 			return false, nil
 		}
 		return false, err
@@ -158,7 +158,7 @@ func (s *SecretsManager) lookupSecret(nameOrID string) (*Secret, error) {
 		return &secret, nil
 	}
 
-	return nil, errors.Wrapf(errNoSuchSecret, "no secret with name or id %q", nameOrID)
+	return nil, errors.Wrapf(ErrNoSuchSecret, "no secret with name or id %q", nameOrID)
 }
 
 // Store creates a new secret in the secrets database.


### PR DESCRIPTION
There is code in podman which uses `errors.Cause(err).Error() != "no such secret"`,
this is just bad code. Common should expose this error so podman
can check with `errors.Is()`.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
