### PR TITLE
Add machine table to containers.conf

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -446,11 +446,6 @@ Indicates if Podman is running inside a VM via Podman Machine.
 Podman uses this value to do extra setup around networking from the
 container inside the VM to to host.
 
-**machine_image**="testing"
-
-Default image used when creating a new VM using `podman machine init`.
-Options: `testing`, `stable`, or a custom path or download URL to an image
-
 **multi_image_archive**=false
 
 Allows for creating archives (e.g., tarballs) with more than one image.  Some container engines, such as Podman, interpret additional arguments as tags for one image and hence do not store more than one image.  The default behavior can be altered with this option.
@@ -606,6 +601,25 @@ Currently valid values are:
 **[secrets.opts]**
 
 The driver specific options object.
+
+## MACHINE TABLE
+The `machine` table contains configurations for podman machine VMs
+
+**cpus**=1
+Number of CPU's a machine is created with.
+
+**disk_size**=10
+
+The size of the disk in GB created when init-ing a podman-machine VM
+
+**image**="testing"
+
+Default image used when creating a new VM using `podman machine init`.
+Options: `testing`, `stable`, `next`, or a custom path or download URL to an image
+
+**memory**=2048
+
+Memory in MB a machine is created with.
 
 # FILES
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,6 +54,8 @@ type Config struct {
 	Containers ContainersConfig `toml:"containers"`
 	// Engine specifies how the container engine based on Engine will run
 	Engine EngineConfig `toml:"engine"`
+	// Machine specifies configurations of podman machine VMs
+	Machine MachineConfig `toml:"machine"`
 	// Network section defines the configuration of CNI Plugins
 	Network NetworkConfig `toml:"network"`
 	// Secret section defines configurations for the secret management
@@ -281,9 +283,6 @@ type EngineConfig struct {
 	// MachineEnabled indicates if Podman is running in a podman-machine VM
 	MachineEnabled bool `toml:"machine_enabled,omitempty"`
 
-	// MachineImage is the image used when creating a podman-machine VM
-	MachineImage string `toml:"machine_image,omitempty"`
-
 	// MultiImageArchive - if true, the container engine allows for storing
 	// archives (e.g., of the docker-archive transport) with multiple
 	// images.  By default, Podman creates single-image archives.
@@ -488,6 +487,18 @@ type SecretConfig struct {
 	Driver string `toml:"driver,omitempty"`
 	// Opts contains driver specific options
 	Opts map[string]string `toml:"opts,omitempty"`
+}
+
+// MachineConfig represents the "machine" TOML config table
+type MachineConfig struct {
+	// Number of CPU's a machine is created with.
+	CPUs uint64 `toml:"cpus,omitempty"`
+	// DiskSize is the size of the disk in GB created when init-ing a podman-machine VM
+	DiskSize uint64 `toml:"disk_size,omitempty"`
+	// MachineImage is the image used when init-ing a podman-machine VM
+	Image string `toml:"image,omitempty"`
+	// Memory in MB a machine is created with.
+	Memory uint64 `toml:"memory,omitempty"`
 }
 
 // Destination represents destination for remote service

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -374,12 +374,46 @@ var _ = Describe("Config Local", func() {
 		// Given
 		config, err := NewConfig("")
 		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config.Engine.MachineImage).To(gomega.Equal("testing"))
+		gomega.Expect(config.Machine.Image).To(gomega.Equal("testing"))
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config2.Engine.MachineImage).To(gomega.Equal("stable"))
+		gomega.Expect(config2.Machine.Image).To(gomega.Equal("stable"))
+	})
+
+	It("Set machine disk", func() {
+		// Given
+		config, err := NewConfig("")
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config.Machine.DiskSize).To(gomega.Equal(uint64(10)))
+		// When
+		config2, err := NewConfig("testdata/containers_default.conf")
+		// Then
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config2.Machine.DiskSize).To(gomega.Equal(uint64(20)))
+	})
+	It("Set machine CPUs", func() {
+		// Given
+		config, err := NewConfig("")
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config.Machine.CPUs).To(gomega.Equal(uint64(1)))
+		// When
+		config2, err := NewConfig("testdata/containers_default.conf")
+		// Then
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config2.Machine.CPUs).To(gomega.Equal(uint64(2)))
+	})
+	It("Set machine memory", func() {
+		// Given
+		config, err := NewConfig("")
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config.Machine.Memory).To(gomega.Equal(uint64(2048)))
+		// When
+		config2, err := NewConfig("testdata/containers_default.conf")
+		// Then
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config2.Machine.Memory).To(gomega.Equal(uint64(1024)))
 	})
 
 })

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -396,10 +396,6 @@ default_sysctls = [
 #
 #machine_enabled = false
 
-# The image used when creating a podman-machine VM.
-#
-#machine_image = "testing"
-
 # MultiImageArchive - if true, the container engine allows for storing archives
 # (e.g., of the docker-archive transport) with multiple images.  By default,
 # Podman creates single-image archives.
@@ -559,8 +555,25 @@ default_sysctls = [
 [engine.volume_plugins]
 #testplugin = "/run/podman/plugins/test.sock"
 
-# The [engine.volume_plugins] table MUST be the last entry in this file.
+[machine]
+# Number of CPU's a machine is created with.
+#
+#cpus=1
+
+# The size of the disk in GB created when init-ing a podman-machine VM.
+#
+#disk_size=10
+
+# The image used when creating a podman-machine VM.
+#
+#image = "testing"
+
+# Memory in MB a machine is created with.
+#
+#memory=2048
+
+# The [machine] table MUST be the last entry in this file.
 # (Unless another table is added)
 # TOML does not provide a way to end a table other than a further table being
-# defined, so every key hereafter will be part of [volume_plugins] and not the
+# defined, so every key hereafter will be part of [machine] and not the
 # main config.

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -208,6 +208,7 @@ func DefaultConfig() (*Config, error) {
 		},
 		Engine:  *defaultEngineConfig,
 		Secrets: defaultSecretConfig(),
+		Machine: defaultMachineConfig(),
 	}, nil
 }
 
@@ -216,6 +217,16 @@ func DefaultConfig() (*Config, error) {
 func defaultSecretConfig() SecretConfig {
 	return SecretConfig{
 		Driver: "file",
+	}
+}
+
+// defaultMachineConfig returns the default machine configuration.
+func defaultMachineConfig() MachineConfig {
+	return MachineConfig{
+		CPUs:     1,
+		DiskSize: 10,
+		Image:    "testing",
+		Memory:   2048,
 	}
 }
 
@@ -345,8 +356,6 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	// constants.
 	c.LockType = "shm"
 	c.MachineEnabled = false
-	c.MachineImage = "testing"
-
 	c.ChownCopiedFiles = true
 
 	return c, nil
@@ -565,10 +574,4 @@ func (c *Config) MachineEnabled() bool {
 // rootless containers should use
 func (c *Config) RootlessNetworking() string {
 	return c.Containers.RootlessNetworking
-}
-
-// MachineImage returns the image to be
-// used when creating a podman-machine VM
-func (c *Config) MachineImage() string {
-	return c.Engine.MachineImage
 }

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -153,9 +153,6 @@ tmp_dir = "/run/libpod"
 
 machine_enabled = true
 
-# The image used when creating a podman-machine VM.
-machine_image = "stable"
-
 # Whether to use chroot instead of pivot_root in the runtime
 no_pivot_root = false
 
@@ -246,8 +243,22 @@ crun = [
 	    "/usr/local/bin/crun",
 ]
 
-# The [engine.runtimes] table MUST be the last thing in this file.
+[machine]
+# Number of CPU's a machine is created with.
+cpus=2
+
+# The size of the disk in GB created when init-ing a podman-machine VM
+disk_size = 20
+
+# The image used when creating a podman-machine VM.
+image = "stable"
+# Memory in MB a machine is created with.
+
+memory=1024
+
+
+# The [machine] table MUST be the last thing in this file.
 # (Unless another table is added)
 # TOML does not provide a way to end a table other than a further table being
-# defined, so every key hereafter will be part of [runtimes] and not the main
+# defined, so every key hereafter will be part of [machine] and not the main
 # config.


### PR DESCRIPTION
Add machine teable to configure podman machine options. Move
machine_image to the machine table, and add disk size to the machine
table.

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
