### PR TITLE
libimage: Return the full registry domain when searching

### DIFF
--- a/libimage/search.go
+++ b/libimage/search.go
@@ -244,7 +244,7 @@ func (r *Runtime) searchImageInRegistry(ctx context.Context, term, registry stri
 			name = index + "/library/" + results[i].Name
 		}
 		params := SearchResult{
-			Index:       index,
+			Index:       registry,
 			Name:        name,
 			Description: description,
 			Official:    official,


### PR DESCRIPTION
Searching for images in registry.fedoraproject.org returns
fedoraproject.org as registry in the search results. When relying on the
Index to group results from different registries this is an issue.

Signed-off-by: Jelle van der Waa <jvanderwaa@redhat.com>

