### PR TITLE
libimage: Pull: fix logs

### DIFF
--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -477,10 +477,10 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 
 	if pullPolicy == config.PullPolicyNever {
 		if localImage != nil {
-			logrus.Debugf("Pull policy %q but no local image has been found for %s", pullPolicy, imageName)
+			logrus.Debugf("Pull policy %q and %s resolved to local image %s", pullPolicy, imageName, resolvedImageName)
 			return []string{resolvedImageName}, nil
 		}
-		logrus.Debugf("Pull policy %q and %s resolved to local image %s", pullPolicy, imageName, resolvedImageName)
+		logrus.Debugf("Pull policy %q but no local image has been found for %s", pullPolicy, imageName)
 		return nil, errors.Wrap(storage.ErrImageUnknown, imageName)
 	}
 


### PR DESCRIPTION
Exchange two debug logs in the pull-never policy.  Those were probably
not moved along with the code and could lead to confusions when reading
debug logs.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
