### PR TITLE
containers.conf: unknown keys: reduce to Debug level

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -574,7 +574,7 @@ func readConfigFromFile(path string, config *Config) error {
 	}
 	keys := meta.Undecoded()
 	if len(keys) > 0 {
-		logrus.Warningf("Failed to decode the keys %q from %q.", keys, path)
+		logrus.Debugf("Failed to decode the keys %q from %q.", keys, path)
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -702,6 +702,7 @@ image_copy_tmp_dir="storage"`
 			conf := Config{}
 			content := bytes.NewBufferString("")
 			logrus.SetOutput(content)
+			logrus.SetLevel(logrus.DebugLevel)
 			err := readConfigFromFile("testdata/containers_broken.conf", &conf)
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(conf.Containers.NetNS).To(gomega.Equal("bridge"))


### PR DESCRIPTION
Reduce the logs for unknown keys from Warn to Debug level.
The containers.conf continuously receives new keys, and some consumers
(e.g., Podman) are updating it at runtime.  Even small divergences in
the vendored versions of containers/common can let one tool run fine and
the other print warnings for each invocation.  Reducing the log-level to
debug works around that problem at the cost of honest typos not being
as easy to detect as before.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
