### PR TITLE
libimage: Inspect: add InspectOptions

### DIFF
--- a/libimage/corrupted_test.go
+++ b/libimage/corrupted_test.go
@@ -33,7 +33,7 @@ func TestCorruptedLayers(t *testing.T) {
 	image := pulledImages[0]
 
 	// Inpsecting a healthy image should work.
-	_, err = image.Inspect(ctx, false)
+	_, err = image.Inspect(ctx, nil)
 	require.NoError(t, err, "inspecting healthy image should work")
 
 	exists, err = runtime.Exists(imageName)
@@ -64,7 +64,7 @@ func TestCorruptedLayers(t *testing.T) {
 	image.reload() // clear the cached data
 
 	// Now inspecting the image must fail!
-	_, err = image.Inspect(ctx, false)
+	_, err = image.Inspect(ctx, nil)
 	require.Error(t, err, "inspecting corrupted image should fail")
 
 	err = image.isCorrupted(imageName)
@@ -87,6 +87,6 @@ func TestCorruptedLayers(t *testing.T) {
 	image = pulledImages[0]
 
 	// Inspecting a repaired image should work.
-	_, err = image.Inspect(ctx, false)
+	_, err = image.Inspect(ctx, nil)
 	require.NoError(t, err, "inspecting repaired image should work")
 }

--- a/libimage/image_test.go
+++ b/libimage/image_test.go
@@ -157,7 +157,7 @@ func TestImageFunctions(t *testing.T) {
 	require.True(t, size > 0)
 
 	// Now compare the inspect data to what we expect.
-	imageData, err := image.Inspect(ctx, true)
+	imageData, err := image.Inspect(ctx, &InspectOptions{WithParent: true, WithSize: true})
 	require.NoError(t, err)
 	require.Equal(t, image.ID(), imageData.ID, "inspect data should match")
 	require.Equal(t, repoTags, imageData.RepoTags, "inspect data should match")

--- a/libimage/inspect.go
+++ b/libimage/inspect.go
@@ -50,18 +50,38 @@ type RootFS struct {
 	Layers []digest.Digest `json:"Layers"`
 }
 
-// Inspect inspects the image.  Use `withSize` to also perform the
-// comparatively expensive size computation of the image.
-func (i *Image) Inspect(ctx context.Context, withSize bool) (*ImageData, error) {
+// InspectOptions allow for customizing inspecting images.
+type InspectOptions struct {
+	// Compute the size of the image (expensive).
+	WithSize bool
+	// Compute the parent of the image (expensive).
+	WithParent bool
+}
+
+// Inspect inspects the image.
+func (i *Image) Inspect(ctx context.Context, options *InspectOptions) (*ImageData, error) {
 	logrus.Debugf("Inspecting image %s", i.ID())
 
+	if options == nil {
+		options = &InspectOptions{}
+	}
+
 	if i.cached.completeInspectData != nil {
-		if withSize && i.cached.completeInspectData.Size == int64(-1) {
+		if options.WithSize && i.cached.completeInspectData.Size == int64(-1) {
 			size, err := i.Size()
 			if err != nil {
 				return nil, err
 			}
 			i.cached.completeInspectData.Size = size
+		}
+		if options.WithParent && i.cached.completeInspectData.Parent == "" {
+			parentImage, err := i.Parent(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if parentImage != nil {
+				i.cached.completeInspectData.Parent = parentImage.ID()
+			}
 		}
 		return i.cached.completeInspectData, nil
 	}
@@ -75,10 +95,7 @@ func (i *Image) Inspect(ctx context.Context, withSize bool) (*ImageData, error) 
 	if err != nil {
 		return nil, err
 	}
-	parentImage, err := i.Parent(ctx)
-	if err != nil {
-		return nil, err
-	}
+
 	repoTags, err := i.RepoTags()
 	if err != nil {
 		return nil, err
@@ -93,7 +110,7 @@ func (i *Image) Inspect(ctx context.Context, withSize bool) (*ImageData, error) 
 	}
 
 	size := int64(-1)
-	if withSize {
+	if options.WithSize {
 		size, err = i.Size()
 		if err != nil {
 			return nil, err
@@ -124,8 +141,14 @@ func (i *Image) Inspect(ctx context.Context, withSize bool) (*ImageData, error) 
 		NamesHistory: i.NamesHistory(),
 	}
 
-	if parentImage != nil {
-		data.Parent = parentImage.ID()
+	if options.WithParent {
+		parentImage, err := i.Parent(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if parentImage != nil {
+			data.Parent = parentImage.ID()
+		}
 	}
 
 	// Determine the format of the image.  How we determine certain data

--- a/libimage/push_test.go
+++ b/libimage/push_test.go
@@ -80,7 +80,7 @@ func TestPushOtherPlatform(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, pulledImages, 1)
 
-	data, err := pulledImages[0].Inspect(ctx, false)
+	data, err := pulledImages[0].Inspect(ctx, nil)
 	require.NoError(t, err)
 	require.Equal(t, "arm64", data.Architecture)
 


### PR DESCRIPTION
Add an InspectOptions struct for inspecting images.  This is a breaking
change but I think it's worth it since a considerable amount of CPU time
is spent in computing the image's parent (i.e., computing the layer is
costly) while this data is oftentimes not needed.

This cuts off 10ms of container-creation time in Podman.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>