### PR TITLE
libimage: speed up image filters

### DIFF
--- a/libimage/image.go
+++ b/libimage/image.go
@@ -128,10 +128,16 @@ func (i *Image) IsReadOnly() bool {
 // IsDangling returns true if the image is dangling, that is an untagged image
 // without children.
 func (i *Image) IsDangling(ctx context.Context) (bool, error) {
+	return i.isDangling(ctx, nil)
+}
+
+// isDangling returns true if the image is dangling, that is an untagged image
+// without children.  If tree is nil, it will created for this invocation only.
+func (i *Image) isDangling(ctx context.Context, tree *layerTree) (bool, error) {
 	if len(i.Names()) > 0 {
 		return false, nil
 	}
-	children, err := i.getChildren(ctx, false)
+	children, err := i.getChildren(ctx, false, tree)
 	if err != nil {
 		return false, err
 	}
@@ -141,10 +147,17 @@ func (i *Image) IsDangling(ctx context.Context) (bool, error) {
 // IsIntermediate returns true if the image is an intermediate image, that is
 // an untagged image with children.
 func (i *Image) IsIntermediate(ctx context.Context) (bool, error) {
+	return i.isIntermediate(ctx, nil)
+}
+
+// isIntermediate returns true if the image is an intermediate image, that is
+// an untagged image with children.  If tree is nil, it will created for this
+// invocation only.
+func (i *Image) isIntermediate(ctx context.Context, tree *layerTree) (bool, error) {
 	if len(i.Names()) > 0 {
 		return false, nil
 	}
-	children, err := i.getChildren(ctx, false)
+	children, err := i.getChildren(ctx, false, tree)
 	if err != nil {
 		return false, err
 	}
@@ -189,7 +202,7 @@ func (i *Image) Parent(ctx context.Context) (*Image, error) {
 
 // HasChildren returns indicates if the image has children.
 func (i *Image) HasChildren(ctx context.Context) (bool, error) {
-	children, err := i.getChildren(ctx, false)
+	children, err := i.getChildren(ctx, false, nil)
 	if err != nil {
 		return false, err
 	}
@@ -198,7 +211,7 @@ func (i *Image) HasChildren(ctx context.Context) (bool, error) {
 
 // Children returns the image's children.
 func (i *Image) Children(ctx context.Context) ([]*Image, error) {
-	children, err := i.getChildren(ctx, true)
+	children, err := i.getChildren(ctx, true, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -206,13 +219,16 @@ func (i *Image) Children(ctx context.Context) ([]*Image, error) {
 }
 
 // getChildren returns a list of imageIDs that depend on the image. If all is
-// false, only the first child image is returned.
-func (i *Image) getChildren(ctx context.Context, all bool) ([]*Image, error) {
-	tree, err := i.runtime.layerTree()
-	if err != nil {
-		return nil, err
+// false, only the first child image is returned.  If tree is nil, it will be
+// created for this invocation only.
+func (i *Image) getChildren(ctx context.Context, all bool, tree *layerTree) ([]*Image, error) {
+	if tree == nil {
+		t, err := i.runtime.layerTree()
+		if err != nil {
+			return nil, err
+		}
+		tree = t
 	}
-
 	return tree.children(ctx, i, all)
 }
 


### PR DESCRIPTION
With commit 86afb94e0054 the dangling checks have been changed to be
compatible with Docker.  Since then, the dangling also need to compute
children.

Speed up the dangling and intermediate checks by computing the layer
tree *once* instead of for each filter invocation.

**Before:**
real    0m10.837s
user    0m11.308s
sys     0m4.231s

**After:**
real    0m0.476s
user    0m0.478s
sys     0m0.151s

Context: github.com/containers/podman/issues/11997
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
