### PR TITLE
Add a hint to resolve a misconfigured helper_binaries_dir

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1151,7 +1151,7 @@ func (c *Config) FindHelperBinary(name string, searchPATH bool) (string, error) 
 	if searchPATH {
 		return exec.LookPath(name)
 	}
-	configHint := "To resolve this error, set the helper_binaries_dir key in the `[engine]` section of containers.conf to directory containing your helper binaries."
+	configHint := "To resolve this error, set the helper_binaries_dir key in the `[engine]` section of containers.conf to the directory containing your helper binaries."
 	if len(c.Engine.HelperBinariesDir) == 0 {
 		return "", errors.Errorf("could not find %q because there are no helper binary directories configured.  %s", name, configHint)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1151,10 +1151,11 @@ func (c *Config) FindHelperBinary(name string, searchPATH bool) (string, error) 
 	if searchPATH {
 		return exec.LookPath(name)
 	}
+	configHint := "To resolve this error, set the helper_binaries_dir key in the `[engine]` section of containers.conf to directory containing your helper binaries."
 	if len(c.Engine.HelperBinariesDir) == 0 {
-		return "", errors.Errorf("could not find %q because there are no helper binary directories configured", name)
+		return "", errors.Errorf("could not find %q because there are no helper binary directories configured.  %s", name, configHint)
 	}
-	return "", errors.Errorf("could not find %q in one of %v", name, c.Engine.HelperBinariesDir)
+	return "", errors.Errorf("could not find %q in one of %v.  %s", name, c.Engine.HelperBinariesDir, configHint)
 }
 
 // ImageCopyTmpDir default directory to store tempory image files during copy


### PR DESCRIPTION
This change is based on discussion in containers/podman#11960.  I don't especially like the way the multi-sentence style clashes with other log messages, especially since this is typically encapsulated within a higher-level error, but couldn't think of a better way to convey the relevant information.  I'm open to suggestions on a better approach.