### PR TITLE
Default sysctl to "net.ipv6.conf.all.accept_dad=0",

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,6 +22,10 @@ var _ = Describe("Config", func() {
 		It("should succeed with default config", func() {
 			// Given
 			// When
+			defaultSysctls := []string{
+				"net.ipv4.ping_group_range=0 0",
+				"net.ipv6.conf.all.accept_dad=0",
+			}
 			defaultConfig, err := NewConfig("")
 
 			// Then
@@ -32,6 +36,7 @@ var _ = Describe("Config", func() {
 			path, err := defaultConfig.ImageCopyTmpDir()
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(path).To(gomega.BeEquivalentTo("/var/tmp"))
+			gomega.Expect(defaultConfig.Containers.DefaultSysctls).To(gomega.BeEquivalentTo(defaultSysctls))
 		})
 
 		It("should succeed with devices", func() {

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -65,6 +65,7 @@ default_capabilities = [
 #
 default_sysctls = [
   "net.ipv4.ping_group_range=0 0",
+  "net.ipv6.conf.all.accept_dad=0",
 ]
 
 # A list of ulimits to be set in containers by default, specified as


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/11062

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
