### PR TITLE
libimage/manifests.list.Add(): pull variant info from configs

### DIFF
--- a/libimage/manifests/manifests.go
+++ b/libimage/manifests/manifests.go
@@ -353,9 +353,12 @@ func (l *list) Add(ctx context.Context, sys *types.SystemContext, ref types.Imag
 			}
 			if instanceInfo.OS == "" {
 				instanceInfo.OS = config.OS
+				instanceInfo.OSVersion = config.OSVersion
+				instanceInfo.OSFeatures = config.OSFeatures
 			}
 			if instanceInfo.Architecture == "" {
 				instanceInfo.Architecture = config.Architecture
+				instanceInfo.Variant = config.Variant
 			}
 		}
 		manifestBytes, manifestType, err := src.GetManifest(ctx, instanceInfo.instanceDigest)


### PR DESCRIPTION
When we're given an image reference to add to a manifest list, if we're setting the instance info's architecture using information from the image, set its variant field, too.  Likewise, if we're setting the OS using information from the image, set the OS version and features fields.