### PR TITLE
Don't use Docker adjective if we don't have to

### DIFF
--- a/libimage/image_test.go
+++ b/libimage/image_test.go
@@ -14,8 +14,8 @@ import (
 func TestImageFunctions(t *testing.T) {
 	// Note: this will resolve pull from the GCR registry (see
 	// testdata/registries.conf).
-	busyboxLatest := "docker.io/library/busybox:latest"
-	busyboxDigest := "docker.io/library/busybox@"
+	busyboxLatest := "quay.io/libpod/busybox:latest"
+	busyboxDigest := "quay.io/libpod/busybox@"
 
 	runtime, cleanup := testNewRuntime(t)
 	defer cleanup()
@@ -142,7 +142,7 @@ func TestImageFunctions(t *testing.T) {
 	require.False(t, hasDifferentDigest, "image with same digest should have the same manifest (and hence digest)")
 
 	// Different images -> different digests
-	remoteRef, err = alltransports.ParseImageName("docker://docker.io/library/alpine:latest")
+	remoteRef, err = alltransports.ParseImageName("docker://quay.io/libpod/alpine:latest")
 	require.NoError(t, err)
 	hasDifferentDigest, err = image.HasDifferentDigest(ctx, remoteRef, nil)
 	require.NoError(t, err)
@@ -191,7 +191,7 @@ func TestInspectHealthcheck(t *testing.T) {
 func TestTag(t *testing.T) {
 	// Note: this will resolve pull from the GCR registry (see
 	// testdata/registries.conf).
-	busyboxLatest := "docker.io/library/busybox:latest"
+	busyboxLatest := "quay.io/libpod/busybox:latest"
 
 	runtime, cleanup := testNewRuntime(t)
 	defer cleanup()
@@ -242,7 +242,7 @@ func TestTag(t *testing.T) {
 func TestUntag(t *testing.T) {
 	// Note: this will resolve pull from the GCR registry (see
 	// testdata/registries.conf).
-	busyboxLatest := "docker.io/library/busybox:latest"
+	busyboxLatest := "quay.io/libpod/busybox:latest"
 
 	runtime, cleanup := testNewRuntime(t)
 	defer cleanup()

--- a/libimage/push_test.go
+++ b/libimage/push_test.go
@@ -18,7 +18,7 @@ func TestPush(t *testing.T) {
 	// Prefetch alpine.
 	pullOptions := &PullOptions{}
 	pullOptions.Writer = os.Stdout
-	_, err := runtime.Pull(ctx, "docker.io/library/alpine:latest", config.PullPolicyAlways, pullOptions)
+	_, err := runtime.Pull(ctx, "quay.io/libpod/alpine:latest", config.PullPolicyAlways, pullOptions)
 	require.NoError(t, err)
 
 	pushOptions := &PushOptions{}
@@ -76,7 +76,7 @@ func TestPushOtherPlatform(t *testing.T) {
 	pullOptions := &PullOptions{}
 	pullOptions.Writer = os.Stdout
 	pullOptions.Architecture = "arm64"
-	pulledImages, err := runtime.Pull(ctx, "docker.io/library/alpine:latest", config.PullPolicyAlways, pullOptions)
+	pulledImages, err := runtime.Pull(ctx, "quay.io/libpod/alpine:latest", config.PullPolicyAlways, pullOptions)
 	require.NoError(t, err)
 	require.Len(t, pulledImages, 1)
 
@@ -90,6 +90,6 @@ func TestPushOtherPlatform(t *testing.T) {
 	require.NoError(t, err)
 	tmp.Close()
 	defer os.Remove(tmp.Name())
-	_, err = runtime.Push(ctx, "docker.io/library/alpine:latest", "docker-archive:"+tmp.Name(), pushOptions)
+	_, err = runtime.Push(ctx, "quay.io/libpod/alpine:latest", "docker-archive:"+tmp.Name(), pushOptions)
 	require.NoError(t, err)
 }

--- a/libimage/remove_test.go
+++ b/libimage/remove_test.go
@@ -12,7 +12,7 @@ import (
 func TestRemoveImages(t *testing.T) {
 	// Note: this will resolve pull from the GCR registry (see
 	// testdata/registries.conf).
-	busyboxLatest := "docker.io/library/busybox:latest"
+	busyboxLatest := "quay.io/libpod/busybox:latest"
 
 	runtime, cleanup := testNewRuntime(t)
 	defer cleanup()


### PR DESCRIPTION
Start using dir instead of docker-dir for podman save.

Use compat-archive rather then docker-archive.

Use docker-dir and docker-archive for compatibility only.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
