### PR TITLE
libimage: inspect: extract healthchecks from configs

### DIFF
--- a/libimage/inspect.go
+++ b/libimage/inspect.go
@@ -187,7 +187,12 @@ func (i *Image) Inspect(ctx context.Context, options *InspectOptions) (*ImageDat
 			return nil, err
 		}
 		data.Comment = dockerManifest.Comment
+		// NOTE: Health checks may be listed in the container config or
+		// the config.
 		data.HealthCheck = dockerManifest.ContainerConfig.Healthcheck
+		if data.HealthCheck == nil {
+			data.HealthCheck = dockerManifest.Config.Healthcheck
+		}
 	}
 
 	if data.Annotations == nil {


### PR DESCRIPTION
buildkit is setting the health check in the image's config while Docker
and Podman set it in the image's container config.  Hence, if the
container config's healthcheck is nil, have a look at the config.

Fixes: #containers/podman/issues/12226
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>
