### PR TITLE
FindHelperBinary(): allow override via envariable

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1146,7 +1146,14 @@ func (c *Config) ActiveDestination() (uri, identity string, err error) {
 // FindHelperBinary will search the given binary name in the configured directories.
 // If searchPATH is set to true it will also search in $PATH.
 func (c *Config) FindHelperBinary(name string, searchPATH bool) (string, error) {
-	for _, path := range c.Engine.HelperBinariesDir {
+	dir_list := c.Engine.HelperBinariesDir
+
+	// If set, search this directory first. This is used in testing.
+	if dir, found := os.LookupEnv("CONTAINERS_HELPER_BINARY_DIR"); found {
+		dir_list = append([]string{dir}, dir_list...)
+	}
+
+	for _, path := range dir_list {
 		fullpath := filepath.Join(path, name)
 		if fi, err := os.Stat(fullpath); err == nil && fi.Mode().IsRegular() {
 			return fullpath, nil


### PR DESCRIPTION
 When searching for helpers, check $CONTAINERS_HELPER_BINARY_DIR.
If it points at an existing directory, prepend it to the
search path for binaries.

Intention is to use this for developer testing: a way to run make
(e.g. in podman) then use the locally-built rootlessport and pause
images

Signed-off-by: Ed Santiago <santiago@redhat.com>