### PR TITLE
Add network_backend field for switching to netavark

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -278,6 +278,12 @@ Options are:
 The `network` table contains settings pertaining to the management of CNI
 plugins.
 
+**network_backend**="cni"
+
+Network backend determines what network driver will be used to set up and tear down container networks.
+Valid values are "cni" and "netavark".
+Changing this value may require restarting all running containers.
+
 **cni_plugin_dirs**=[]
 
 List of paths to directories where CNI plugin binaries are located.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -461,6 +461,10 @@ type SetOptions struct {
 
 // NetworkConfig represents the "network" TOML config table
 type NetworkConfig struct {
+	// NetworkBackend determines what backend should be used for Podman's
+	// networking.
+	NetworkBackend string `toml:"network_backend,omitempty"`
+
 	// CNIPluginDirs is where CNI plugin binaries are stored.
 	CNIPluginDirs []string `toml:"cni_plugin_dirs,omitempty"`
 

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -260,6 +260,10 @@ default_sysctls = [
 
 [network]
 
+# Network backend to use. Default "CNI".
+#
+#network_backend = "cni"
+
 # Path to directory where CNI plugin binaries are located.
 #
 #cni_plugin_dirs = [

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -201,6 +201,7 @@ func DefaultConfig() (*Config, error) {
 			UserNSSize:         DefaultUserNSSize,
 		},
 		Network: NetworkConfig{
+			NetworkBackend:   "cni",
 			DefaultNetwork:   "podman",
 			DefaultSubnet:    DefaultSubnet,
 			NetworkConfigDir: cniConfig,


### PR DESCRIPTION
This field determines whether CNI or netavark will be used to create container networks. Default presently set to "cni".
