### PR TITLE
Set the environment variables for the engine

### DIFF
--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -203,12 +203,15 @@ var _ = Describe("Config Local", func() {
 
 	It("should return containers engine env", func() {
 		// Given
-		expectedEnv := []string{"http_proxy=internal.proxy.company.com", "foo=bar"}
+		expectedEnv := []string{"super=duper", "foo=bar"}
 		// When
 		config, err := NewConfig("testdata/containers_default.conf")
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config.Engine.Env).To(gomega.BeEquivalentTo(expectedEnv))
+		gomega.Expect(os.Getenv("super")).To(gomega.BeEquivalentTo("duper"))
+		gomega.Expect(os.Getenv("foo")).To(gomega.BeEquivalentTo("bar"))
+
 	})
 
 	It("Expect Remote to be False", func() {

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -137,7 +137,7 @@ conmon_path = [
 # For example "http_proxy=internal.proxy.company.com".
 # Note these environment variables will not be used within the container.
 # Set the env section under [containers] table, if you want to set environment variables for the container.
-env = ["http_proxy=internal.proxy.company.com", "foo=bar"]
+env = ["super=duper", "foo=bar"]
 
 # Container init binary
 #init_path = "/usr/libexec/podman/catatonit"


### PR DESCRIPTION
The Engine.Env needs to be set very early in the setup process
to make sure no one attempts to use the environment.

Fixes: https://github.com/containers/podman/issues/12296

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
