### PR TITLE
containers.conf: add option to enforce docker.io for compat API

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -215,6 +215,12 @@ type EngineConfig struct {
 	// The first path pointing to a valid file will be used.
 	ConmonPath []string `toml:"conmon_path,omitempty"`
 
+	// CompatAPIEnforceDockerHub enforces using docker.io for completing
+	// short names in Podman's compatibility REST API.  Note that this will
+	// ignore unqualified-search-registries and short-name aliases defined
+	// in containers-registries.conf(5).
+	CompatAPIEnforceDockerHub bool `toml:"compat_api_enforce_docker_hub,omitempty"`
+
 	// DetachKeys is the sequence of keys used to detach a container.
 	DetachKeys string `toml:"detach_keys,omitempty"`
 

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -385,6 +385,18 @@ var _ = Describe("Config Local", func() {
 		gomega.Expect(config2.Machine.Image).To(gomega.Equal("stable"))
 	})
 
+	It("CompatAPIEnforceDockerHub", func() {
+		// Given
+		config, err := NewConfig("")
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config.Engine.CompatAPIEnforceDockerHub).To(gomega.Equal(true))
+		// When
+		config2, err := NewConfig("testdata/containers_default.conf")
+		// Then
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config2.Engine.CompatAPIEnforceDockerHub).To(gomega.Equal(false))
+	})
+
 	It("Set machine disk", func() {
 		// Given
 		config, err := NewConfig("")

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -317,6 +317,11 @@ default_sysctls = [
 #  "/usr/local/sbin/conmon"
 #]
 
+# Enforces using docker.io for completing short names in Podman's compatibility
+# REST API. Note that this will ignore unqualified-search-registries and
+# short-name aliases defined in containers-registries.conf(5).
+#compat_api_enforce_docker_hub = true
+
 # Specify the keys sequence used to detach a container.
 # Format is a single character [a-Z] or a comma separated sequence of
 # `ctrl-<value>`, where `<value>` is one of:

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -243,6 +243,8 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 
 	c.EventsLogFilePath = filepath.Join(c.TmpDir, "events", "events.log")
 
+	c.CompatAPIEnforceDockerHub = true
+
 	if path, ok := os.LookupEnv("CONTAINERS_STORAGE_CONF"); ok {
 		types.SetDefaultConfigFilePath(path)
 	}

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -17,7 +17,6 @@ devices = [
 # profile name is "container-default".
 apparmor_profile = "container-default"
 
-
 # List of default capabilities for containers. If it is empty or commented out,
 # only the capabilities defined in the containers json file by the user/kube
 # will be added.
@@ -132,6 +131,11 @@ conmon_path = [
 	    "/usr/local/bin/conmon",
 	    "/usr/local/sbin/conmon"
 ]
+
+# Enforces using docker.io for completing short names in Podman's compatibility
+# REST API. Note that this will ignore unqualified-search-registries and
+# short-name aliases defined in containers-registries.conf(5).
+compat_api_enforce_docker_hub = false
 
 # Environment variables to be used when running the container engine (e.g., Podman, Buildah).
 # For example "http_proxy=internal.proxy.company.com".


### PR DESCRIPTION
Add an option to containers.conf as a knob to enforce short-name
resolution to Docker Hub in Podman's compatibility REST API.

By popular request, turn it on by default.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan @mtrmac PTAL