### PR TITLE
libimage: enforce "latest" tag when looking up images

### DIFF
--- a/libimage/image.go
+++ b/libimage/image.go
@@ -624,8 +624,7 @@ func (i *Image) NamedRepoTags() ([]reference.Named, error) {
 }
 
 // inRepoTags looks for the specified name/tag pair in the image's repo tags.
-// Note that tag may be empty.
-func (i *Image) inRepoTags(name, tag string) (reference.Named, error) {
+func (i *Image) inRepoTags(namedTagged reference.NamedTagged) (reference.Named, error) {
 	repoTags, err := i.NamedRepoTags()
 	if err != nil {
 		return nil, err
@@ -636,8 +635,10 @@ func (i *Image) inRepoTags(name, tag string) (reference.Named, error) {
 		return nil, err
 	}
 
+	name := namedTagged.Name()
+	tag := namedTagged.Tag()
 	for _, pair := range pairs {
-		if tag != "" && tag != pair.Tag {
+		if tag != pair.Tag {
 			continue
 		}
 		if !strings.HasSuffix(pair.Name, name) {

--- a/libimage/pull_test.go
+++ b/libimage/pull_test.go
@@ -85,35 +85,40 @@ func TestPullPlatforms(t *testing.T) {
 	localArch := goruntime.GOARCH
 	localOS := goruntime.GOOS
 
-	pulledImages, err := runtime.Pull(ctx, "busybox", config.PullPolicyAlways, pullOptions)
+	withTag := "busybox:musl"
+
+	pulledImages, err := runtime.Pull(ctx, withTag, config.PullPolicyAlways, pullOptions)
 	require.NoError(t, err, "pull busybox")
 	require.Len(t, pulledImages, 1)
 
-	image, _, err := runtime.LookupImage("busybox", nil)
+	image, _, err := runtime.LookupImage(withTag, nil)
 	require.NoError(t, err, "lookup busybox")
 	require.NotNil(t, image, "lookup busybox")
 
-	image, _, err = runtime.LookupImage("busybox", &LookupImageOptions{Architecture: localArch})
+	_, _, err = runtime.LookupImage("busybox", nil)
+	require.Error(t, err, "untagged image resolves to non-existent :latest")
+
+	image, _, err = runtime.LookupImage(withTag, &LookupImageOptions{Architecture: localArch})
 	require.NoError(t, err, "lookup busybox - by local arch")
 	require.NotNil(t, image, "lookup busybox - by local arch")
 
-	image, _, err = runtime.LookupImage("busybox", &LookupImageOptions{OS: localOS})
+	image, _, err = runtime.LookupImage(withTag, &LookupImageOptions{OS: localOS})
 	require.NoError(t, err, "lookup busybox - by local arch")
 	require.NotNil(t, image, "lookup busybox - by local arch")
 
-	_, _, err = runtime.LookupImage("busybox", &LookupImageOptions{Architecture: "bogus"})
+	_, _, err = runtime.LookupImage(withTag, &LookupImageOptions{Architecture: "bogus"})
 	require.Error(t, err, "lookup busybox - bogus arch")
 
-	_, _, err = runtime.LookupImage("busybox", &LookupImageOptions{OS: "bogus"})
+	_, _, err = runtime.LookupImage(withTag, &LookupImageOptions{OS: "bogus"})
 	require.Error(t, err, "lookup busybox - bogus OS")
 
 	pullOptions.Architecture = "arm"
-	pulledImages, err = runtime.Pull(ctx, "busybox", config.PullPolicyAlways, pullOptions)
+	pulledImages, err = runtime.Pull(ctx, withTag, config.PullPolicyAlways, pullOptions)
 	require.NoError(t, err, "pull busybox - arm")
 	require.Len(t, pulledImages, 1)
 	pullOptions.Architecture = ""
 
-	image, _, err = runtime.LookupImage("busybox", &LookupImageOptions{Architecture: "arm"})
+	image, _, err = runtime.LookupImage(withTag, &LookupImageOptions{Architecture: "arm"})
 	require.NoError(t, err, "lookup busybox - by arm")
 	require.NotNil(t, image, "lookup busybox - by local arch")
 }


### PR DESCRIPTION
Make sure to enforce the "latest" tag when looking up images in the
local storage.  Also make sure that digested short-names are subject
to the extended digest lookups.

Context: containers/podman/issues/11964
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
