### PR TITLE
Check accessibility to journal without sdjournal library

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -336,10 +336,13 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(config.Engine.OCIRuntimes["runc"]).To(gomega.Equal(OCIRuntimeMap["runc"]))
 			if useSystemd() {
 				gomega.Expect(config.Engine.CgroupManager).To(gomega.BeEquivalentTo("systemd"))
-				gomega.Expect(config.Engine.EventsLogger).To(gomega.BeEquivalentTo("journald"))
-				gomega.Expect(config.Containers.LogDriver).To(gomega.BeEquivalentTo("k8s-file"))
 			} else {
 				gomega.Expect(config.Engine.CgroupManager).To(gomega.BeEquivalentTo("cgroupfs"))
+			}
+			if useJournald() {
+				gomega.Expect(config.Engine.EventsLogger).To(gomega.BeEquivalentTo("journald"))
+				gomega.Expect(config.Containers.LogDriver).To(gomega.BeEquivalentTo("journald"))
+			} else {
 				gomega.Expect(config.Engine.EventsLogger).To(gomega.BeEquivalentTo("file"))
 				gomega.Expect(config.Containers.LogDriver).To(gomega.BeEquivalentTo("k8s-file"))
 			}

--- a/pkg/config/nosystemd.go
+++ b/pkg/config/nosystemd.go
@@ -22,3 +22,7 @@ func defaultLogDriver() string {
 func useSystemd() bool {
 	return false
 }
+
+func useJournald() bool {
+	return false
+}


### PR DESCRIPTION
Because `sdjournal` library just ignores directories which are not
accessible, `journald` log driver is set as the default for a user who
cannot access the journal. As a result, the user cannot see logs of
containers via `podman logs`.

This change verifies accessibility of journal directories without
the library.

Signed-off-by: Hironori Shiina <shiina.hironori@jp.fujitsu.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
