### PR TITLE
config: add CompressionFormat option

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -567,6 +567,10 @@ not be by other drivers.
 Determines whether file copied into a container will have changed ownership to
 the primary uid/gid of the container.
 
+**compression_format**=""
+
+Specifies the compression format to use when pushing an image.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.
+
 ## SERVICE DESTINATION TABLE
 The `service_destinations` table contains configuration options used to set up remote connections to the podman service for the podman API.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -420,6 +420,9 @@ type EngineConfig struct {
 	// ChownCopiedFiles tells the container engine whether to chown files copied
 	// into a container to the container's primary uid/gid.
 	ChownCopiedFiles bool `toml:"chown_copied_files,omitempty"`
+
+	// CompressionFormat is the compression format used to compress image layers.
+	CompressionFormat string `toml:"compression_format,omitempty"`
 }
 
 // SetOptions contains a subset of options in a Config. It's used to indicate if

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -294,6 +294,12 @@ default_sysctls = [
 #
 #active_service = production
 
+# The compression format to use when pushing an image.
+# Valid options are: `gzip`, `zstd` and `zstd:chunked`.
+#
+#compression_format = "gzip"
+
+
 # Cgroup management implementation used for the runtime.
 # Valid options "systemd" or "cgroupfs"
 #


### PR DESCRIPTION
support changing the default compression format in the containers.conf
config file.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
