### PR TITLE
Cirrus: Switch to VMs for CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,8 @@ env:
     GOPATH: &gopath "/var/tmp/go"
     GOBIN: "${GOPATH}/bin"
     GOCACHE: "${GOPATH}/cache"
-    GOSRC: &gosrc "/var/tmp/go/src/github.com/containers/common"
+    GOLANGCI_LINT_CACHE: "$GOCACHE"
+    GOSRC: &gosrc "${GOPATH}/src/github.com/containers/common"
     CIRRUS_WORKING_DIR: *gosrc
     # The default is 'sh' if unspecified
     CIRRUS_SHELL: "/bin/bash"
@@ -19,27 +20,64 @@ env:
     ####
     FEDORA_NAME: "fedora-35"
     IMAGE_SUFFIX: "c6226133906620416"
+    FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
 
 
 # Default, hard-coded max timeout is 2-hours.
 timeout_in: 30m  # no need to wait 2-hours before timing out
 
+gcp_credentials: ENCRYPTED[dd6a042d1805167e38d8b79494f691b86637e68f072eba24220901435afd8d71c63f9006803142447326319102f68b7f]
+
+# Default VM for tasks, unless otherwise specified
+gce_instance:
+    image_project: libpod-218412
+    zone: "us-central1-a"
+    cpu: 2
+    memory: "4Gb"
+    # Required to be 200gig, do not modify - has i/o performance impact
+    # according to gcloud CLI tool warning messages.
+    disk: 200
+    image_name: "${FEDORA_CACHE_IMAGE_NAME}"  # from stdenvars
+
 
 testing_task:
   alias: testing
   name: "Testing on $FEDORA_NAME"
 
-  container:
-    image: "${FEDORA_CONTAINER_FQIN}"
-
   test_script:
+    - mkdir "$GOLANGCI_LINT_CACHE"
+    - export PATH="$PATH:$GOPATH/bin"
     - gpg --batch --passphrase '' --quick-gen-key tester@localhost default default never
     - make vendor
     - make build
     - make install.tools
     - make validate
     - make test
+
+
+# This task is critical.  It updates the "last-used by" timestamp stored
+# in metadata for all VM images.  This mechanism functions in tandem with
+# an out-of-band pruning operation to remove disused VM images.
+meta_task:
+    name: "VM img. keepalive"
+    alias: meta
+    container:
+        cpu: 2
+        memory: 2
+        image: quay.io/libpod/imgts:$IMAGE_SUFFIX
+    env:
+        # Space-separated list of images used by this repository state
+        IMGNAMES: >-
+            ${FEDORA_CACHE_IMAGE_NAME}
+        BUILDID: "${CIRRUS_BUILD_ID}"
+        REPOREF: "${CIRRUS_REPO_NAME}"
+        GCPJSON: ENCRYPTED[0543d694d609dc873cabc00eca59269497918419351b692f4b587db8ac2c0a1b29692a9a03a22aa3af45398d3da6c045]
+        GCPNAME: ENCRYPTED[772577bdd866247038baf5ae5c43a4189401a4860fa8d8959f1eb01f835756af882ec7c5e5a8f0a8af4075ec8a2f56f9]
+        GCPPROJECT: libpod-218412
+    clone_script: &noop mkdir -p "$CIRRUS_WORKING_DIR"
+    script: /usr/local/bin/entrypoint.sh
+
 
 
 # Status aggregator for all tests.  This task simply ensures a defined
@@ -49,9 +87,10 @@ success_task:
 
     depends_on:
         - "testing"
+        - "meta"
 
     container:
         image: "${FEDORA_CONTAINER_FQIN}"
 
-    clone_script: &noop mkdir -p "$CIRRUS_WORKING_DIR"
+    clone_script: *noop
     script: *noop


### PR DESCRIPTION
***Depends on:*** https://github.com/containers/common/pull/846

***BIG FAT NOTE:*** This VM setup is reusing the same GCP backend (project) as for the https://github.com/containers/BuildSourceImage repo.  Though the service account keys are separate, so I made notes in their respective descriptions indicating which is for which.  