### PR TITLE
libimage: fix reference filters

### DIFF
--- a/libimage/filters.go
+++ b/libimage/filters.go
@@ -3,6 +3,7 @@ package libimage
 import (
 	"context"
 	"fmt"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -136,7 +137,7 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 			filterFuncs = append(filterFuncs, filterReadOnly(readOnly))
 
 		case "reference":
-			filterFuncs = append(filterFuncs, filterReference(value))
+			filterFuncs = append(filterFuncs, filterReferences(value))
 
 		case "until":
 			ts, err := timetype.GetTimestamp(value, time.Now())
@@ -158,20 +159,43 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 	return filterFuncs, nil
 }
 
-// filterReference creates a reference filter for matching the specified value.
-func filterReference(value string) filterFunc {
+// filterReferences creates a reference filter for matching the specified value.
+func filterReferences(value string) filterFunc {
 	return func(img *Image) (bool, error) {
 		refs, err := img.NamesReferences()
 		if err != nil {
 			return false, err
 		}
+
 		for _, ref := range refs {
-			match, err := reference.FamiliarMatch(value, ref)
-			if err != nil {
-				return false, err
+			refString := ref.String() // FQN with tag/digest
+			candidates := []string{refString}
+
+			// Split the reference into 3 components (twice if diggested/tagged):
+			// 1) Fully-qualified reference
+			// 2) Without domain
+			// 3) Without domain and path
+			if named, isNamed := ref.(reference.Named); isNamed {
+				candidates = append(candidates,
+					reference.Path(named),                           // path/name without tag/digest (Path() removes it)
+					refString[strings.LastIndex(refString, "/")+1:]) // name with tag/digest
+
+				trimmedString := reference.TrimNamed(named).String()
+				if refString != trimmedString {
+					tagOrDigest := refString[len(trimmedString):]
+					candidates = append(candidates,
+						trimmedString,                     // FQN without tag/digest
+						reference.Path(named)+tagOrDigest, // path/name with tag/digest
+						trimmedString[strings.LastIndex(trimmedString, "/")+1:]) // name without tag/digest
+				}
 			}
-			if match {
-				return true, nil
+
+			for _, candidate := range candidates {
+				// path.Match() is also used by Docker's reference.FamiliarMatch().
+				matched, _ := path.Match(value, candidate)
+				if matched {
+					return true, nil
+				}
 			}
 		}
 		return false, nil

--- a/libimage/filters_test.go
+++ b/libimage/filters_test.go
@@ -32,25 +32,35 @@ func TestFilterReference(t *testing.T) {
 
 	err = busybox.Tag("localhost/image:tag")
 	require.NoError(t, err)
-	err = alpine.Tag("localhost/image:another-tag")
+	err = alpine.Tag("localhost/another-image:tag")
+	require.NoError(t, err)
+	err = alpine.Tag("docker.io/library/image:another-tag")
 	require.NoError(t, err)
 
 	for _, test := range []struct {
 		filter  string
 		matches int
 	}{
-		{"image", 0},
-		{"localhost/image", 2},
+		{"image", 2},
+		{"*mage*", 2},
+		{"image:*", 2},
+		{"image:tag", 1},
+		{"image:another-tag", 1},
+		{"localhost/image", 1},
 		{"localhost/image:tag", 1},
-		{"localhost/image:another-tag", 1},
+		{"library/image", 1},
+		{"docker.io/library/image*", 1},
+		{"docker.io/library/image:*", 1},
+		{"docker.io/library/image:another-tag", 1},
 		{"localhost/*", 2},
-		{"localhost/image:*tag", 2},
-		{"busybox", 0},
-		{"alpine", 0},
+		{"localhost/image:*tag", 1},
+		{"localhost/*mage:*ag", 2},
 		{"quay.io/libpod/busybox", 1},
 		{"quay.io/libpod/alpine", 1},
 		{"quay.io/libpod", 0},
 		{"quay.io/libpod/*", 2},
+		{"busybox", 1},
+		{"alpine", 1},
 	} {
 		listOptions := &ListImagesOptions{
 			Filters: []string{"reference=" + test.filter},


### PR DESCRIPTION
It turns out that FamiliarMatch is only useful for matching Docker Hub
but we should not limit it to that and match values against registry.

For instance, FamiliarMatch is *not* able to match a FQN reference
against a Docker Hub image.  I am convinced that we should *not* behave
as Docker does in this case.

This brings us back to the behavior prior to commit 721661d9c60a but
with a fixed matching algorithm.  The specified value will now be
matched against 1) the FQN 2) without domain 3) without domain and path.
If specified also a second time without digest/tag.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan PTAL