### PR TITLE
Add image and repo defaults for podman machine

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -621,14 +621,22 @@ Number of CPU's a machine is created with.
 
 The size of the disk in GB created when init-ing a podman-machine VM
 
-**image**="testing"
+**image**=""
 
 Default image used when creating a new VM using `podman machine init`.
-Options: `testing`, `stable`, `next`, or a custom path or download URL to an image
+Options: On Linux/Mac, `testing`, `stable`, `next`. On Windows, the major
+version of the OS (e.g `35`). For all platforms you can alternatively specify
+a custom path or download URL to an image. The default is `testing` on
+Linux/Mac, and `35` on Windows.
 
 **memory**=2048
 
 Memory in MB a machine is created with.
+
+**user**=""
+
+Username to use and create on the podman machine OS for rootless container
+access. The default value is `user`. On Linux/Mac the default is`core`.
 
 # FILES
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -512,6 +512,8 @@ type MachineConfig struct {
 	Image string `toml:"image,omitempty"`
 	// Memory in MB a machine is created with.
 	Memory uint64 `toml:"memory,omitempty,omitzero"`
+	// Username to use for rootless podman when init-ing a podman machine VM
+	User string `toml:"user,omitempty"`
 }
 
 // Destination represents destination for remote service

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -587,6 +587,11 @@ default_sysctls = [
 #
 #memory=2048
 
+# The username to use and create on the podman machine OS for rootless
+# container access.
+#
+#user = "core"
+
 # The [machine] table MUST be the last entry in this file.
 # (Unless another table is added)
 # TOML does not provide a way to end a table other than a further table being

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -227,8 +227,9 @@ func defaultMachineConfig() MachineConfig {
 	return MachineConfig{
 		CPUs:     1,
 		DiskSize: 100,
-		Image:    "testing",
+		Image:    getDefaultMachineImage(),
 		Memory:   2048,
+		User:     getDefaultMachineUser(),
 	}
 }
 

--- a/pkg/config/default_linux.go
+++ b/pkg/config/default_linux.go
@@ -13,6 +13,17 @@ const (
 	oldMaxSize = uint64(1048576)
 )
 
+// getDefaultMachineImage returns the default machine image stream
+// On Linux/Mac, this returns the FCOS stream
+func getDefaultMachineImage() string {
+	return "testing"
+}
+
+// getDefaultMachineUser returns the user to use for rootless podman
+func getDefaultMachineUser() string {
+	return "core"
+}
+
 // getDefaultRootlessNetwork returns the default rootless network configuration.
 // It is "slirp4netns" for Linux.
 func getDefaultRootlessNetwork() string {

--- a/pkg/config/default_windows.go
+++ b/pkg/config/default_windows.go
@@ -1,16 +1,14 @@
-// +build !linux,!windows
-
 package config
 
-// getDefaultMachineImage returns the default machine image stream
-// On Linux/Mac, this returns the FCOS stream
+// getDefaultImage returns the default machine image stream
+// On Windows this refers to the Fedora major release number
 func getDefaultMachineImage() string {
-	return "testing"
+	return "35"
 }
 
 // getDefaultMachineUser returns the user to use for rootless podman
 func getDefaultMachineUser() string {
-	return "core"
+	return "user"
 }
 
 // getDefaultRootlessNetwork returns the default rootless network configuration.


### PR DESCRIPTION
This PR adds a new platform driven user setting used by the draft PR containers/podman#12503

Additionally it modifies "image" to also have a platform driven default.
