### PR TITLE
Support matching filters disjoint filters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,8 @@ build-cross:
 	$(call go-build,linux,ppc64le,${BUILDTAGS})
 	$(call go-build,linux,s390x,${BUILDTAGS})
 	$(call go-build,darwin,amd64,${BUILDTAGS})
-	$(call go-build,windows,amd64,remote ${BUILDTAGS})
-	$(call go-build,windows,386,remote ${BUILDTAGS})
+	$(call go-build,windows,amd64,${BUILDTAGS})
+	$(call go-build,windows,386,${BUILDTAGS})
 
 .PHONY: all
 all: build-amd64 build-386

--- a/libimage/filters.go
+++ b/libimage/filters.go
@@ -19,27 +19,44 @@ import (
 // indicates that the image matches the criteria.
 type filterFunc func(*Image) (bool, error)
 
-// filterImages returns a slice of images which are passing all specified
-// filters.
-func filterImages(images []*Image, filters []filterFunc) ([]*Image, error) {
-	if len(filters) == 0 {
-		return images, nil
-	}
-	result := []*Image{}
-	for i := range images {
-		include := true
-		var err error
-		for _, filter := range filters {
-			include, err = filter(images[i])
+func matches(image *Image, filters map[string][]filterFunc) (bool, error) {
+	for key := range filters { // and
+		matches := false
+		for _, filter := range filters[key] { // or
+			match, err := filter(image)
 			if err != nil {
-				return nil, err
+				return false, err
 			}
-			if !include {
-				break
+			if match {
+				return true, nil
 			}
 		}
-		if include {
-			result = append(result, images[i])
+		if !matches {
+			return false, nil
+		}
+	}
+	return false, nil
+}
+
+// filterImages returns a slice of images which are passing all specified
+// filters.
+func (r *Runtime) filterImages(ctx context.Context, images []*Image, options *ListImagesOptions) ([]*Image, error) {
+	if len(options.Filters) == 0 || len(images) == 0 {
+		return images, nil
+	}
+
+	filters, err := r.compileImageFilters(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+	result := []*Image{}
+	for _, i := range images {
+		match, err := matches(i, filters)
+		if err != nil {
+			return nil, err
+		}
+		if match {
+			result = append(result, i)
 		}
 	}
 	return result, nil
@@ -48,7 +65,7 @@ func filterImages(images []*Image, filters []filterFunc) ([]*Image, error) {
 // compileImageFilters creates `filterFunc`s for the specified filters.  The
 // required format is `key=value` with the following supported keys:
 //           after, since, before, containers, dangling, id, label, readonly, reference, intermediate
-func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOptions) ([]filterFunc, error) {
+func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOptions) (map[string][]filterFunc, error) {
 	logrus.Tracef("Parsing image filters %s", options.Filters)
 
 	var tree *layerTree
@@ -63,12 +80,14 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 		return tree, nil
 	}
 
-	filterFuncs := []filterFunc{}
-	for _, filter := range options.Filters {
+	filters := map[string][]filterFunc{}
+	duplicate := map[string]bool{}
+	for _, f := range options.Filters {
 		var key, value string
-		split := strings.SplitN(filter, "=", 2)
+		var filter filterFunc
+		split := strings.SplitN(f, "=", 2)
 		if len(split) != 2 {
-			return nil, errors.Errorf("invalid image filter %q: must be in the format %q", filter, "filter=value")
+			return nil, errors.Errorf("invalid image filter %q: must be in the format %q", f, "filter=value")
 		}
 
 		key = split[0]
@@ -76,87 +95,130 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 		switch key {
 
 		case "after", "since":
-			img, _, err := r.LookupImage(value, nil)
+			img, err := r.time(key, value)
 			if err != nil {
-				return nil, errors.Wrapf(err, "could not find local image for filter %q", filter)
+				return nil, err
 			}
-			filterFuncs = append(filterFuncs, filterAfter(img.Created()))
+			key = "since"
+			filter = filterAfter(img.Created())
 
 		case "before":
-			img, _, err := r.LookupImage(value, nil)
+			img, err := r.time(key, value)
 			if err != nil {
-				return nil, errors.Wrapf(err, "could not find local image for filter %q", filter)
+				return nil, err
 			}
-			filterFuncs = append(filterFuncs, filterBefore(img.Created()))
+			filter = filterBefore(img.Created())
 
 		case "containers":
-			switch value {
-			case "false", "true":
-			case "external":
-				if options.IsExternalContainerFunc == nil {
-					return nil, fmt.Errorf("libimage error: external containers filter without callback")
-				}
-			default:
-				return nil, fmt.Errorf("unsupported value %q for containers filter", value)
+			if err := r.containers(duplicate, key, value, options.IsExternalContainerFunc); err != nil {
+				return nil, err
 			}
-			filterFuncs = append(filterFuncs, filterContainers(value, options.IsExternalContainerFunc))
+			filter = filterContainers(value, options.IsExternalContainerFunc)
 
 		case "dangling":
-			dangling, err := strconv.ParseBool(value)
+			dangling, err := r.bool(duplicate, key, value)
 			if err != nil {
-				return nil, errors.Wrapf(err, "non-boolean value %q for dangling filter", value)
+				return nil, err
 			}
 			t, err := getTree()
 			if err != nil {
 				return nil, err
 			}
-			filterFuncs = append(filterFuncs, filterDangling(ctx, dangling, t))
+
+			filter = filterDangling(ctx, dangling, t)
 
 		case "id":
-			filterFuncs = append(filterFuncs, filterID(value))
+			filter = filterID(value)
 
 		case "intermediate":
-			intermediate, err := strconv.ParseBool(value)
+			intermediate, err := r.bool(duplicate, key, value)
 			if err != nil {
-				return nil, errors.Wrapf(err, "non-boolean value %q for intermediate filter", value)
+				return nil, err
 			}
 			t, err := getTree()
 			if err != nil {
 				return nil, err
 			}
-			filterFuncs = append(filterFuncs, filterIntermediate(ctx, intermediate, t))
+
+			filter = filterIntermediate(ctx, intermediate, t)
 
 		case "label":
-			filterFuncs = append(filterFuncs, filterLabel(ctx, value))
+			filter = filterLabel(ctx, value)
 
 		case "readonly":
-			readOnly, err := strconv.ParseBool(value)
+			readOnly, err := r.bool(duplicate, key, value)
 			if err != nil {
-				return nil, errors.Wrapf(err, "non-boolean value %q for readonly filter", value)
+				return nil, err
 			}
-			filterFuncs = append(filterFuncs, filterReadOnly(readOnly))
+			filter = filterReadOnly(readOnly)
 
 		case "reference":
-			filterFuncs = append(filterFuncs, filterReferences(value))
+			filter = filterReferences(value)
 
 		case "until":
-			ts, err := timetype.GetTimestamp(value, time.Now())
+			until, err := r.until(value)
 			if err != nil {
 				return nil, err
 			}
-			seconds, nanoseconds, err := timetype.ParseTimestamps(ts, 0)
-			if err != nil {
-				return nil, err
-			}
-			until := time.Unix(seconds, nanoseconds)
-			filterFuncs = append(filterFuncs, filterBefore(until))
+			filter = filterBefore(until)
 
 		default:
 			return nil, errors.Errorf("unsupported image filter %q", key)
 		}
+		filters[key] = append(filters[key], filter)
 	}
 
-	return filterFuncs, nil
+	return filters, nil
+}
+
+func (r *Runtime) containers(duplicate map[string]bool, key, value string, externalFunc IsExternalContainerFunc) error {
+	if duplicate[key] {
+		return errors.Errorf("specifying %q filter more then once is not supported", key)
+	}
+	duplicate[key] = true
+	switch value {
+	case "false", "true":
+	case "external":
+		if externalFunc == nil {
+			return fmt.Errorf("libimage error: external containers filter without callback")
+		}
+	default:
+		return fmt.Errorf("unsupported value %q for containers filter", value)
+	}
+	return nil
+}
+
+func (r *Runtime) until(value string) (time.Time, error) {
+	var until time.Time
+	ts, err := timetype.GetTimestamp(value, time.Now())
+	if err != nil {
+		return until, err
+	}
+	seconds, nanoseconds, err := timetype.ParseTimestamps(ts, 0)
+	if err != nil {
+		return until, err
+	}
+	return time.Unix(seconds, nanoseconds), nil
+}
+
+func (r *Runtime) time(key, value string) (*Image, error) {
+	img, _, err := r.LookupImage(value, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not find local image for filter filter %q=%q", key, value)
+	}
+	return img, nil
+}
+
+func (r *Runtime) bool(duplicate map[string]bool, key, value string) (bool, error) {
+	if duplicate[key] {
+		return false, errors.Errorf("specifying %q filter more then once is not supported", key)
+	}
+	duplicate[key] = true
+	set, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, errors.Wrapf(err, "non-boolean value %q for %s filter", key, value)
+	}
+	return set, nil
 }
 
 // filterReferences creates a reference filter for matching the specified value.

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -551,16 +551,7 @@ func (r *Runtime) ListImages(ctx context.Context, names []string, options *ListI
 		}
 	}
 
-	var filters []filterFunc
-	if len(options.Filters) > 0 {
-		compiledFilters, err := r.compileImageFilters(ctx, options)
-		if err != nil {
-			return nil, err
-		}
-		filters = append(filters, compiledFilters...)
-	}
-
-	return filterImages(images, filters)
+	return r.filterImages(ctx, images, options)
 }
 
 // RemoveImagesOptions allow for customizing image removal.

--- a/pkg/seccomp/errno_list.go
+++ b/pkg/seccomp/errno_list.go
@@ -1,3 +1,5 @@
+// +build linux,seccomp
+
 package seccomp
 
 import (


### PR DESCRIPTION
The same filters types should be disjoint, while
each selected filter type is required. This will allow callers to pass
multiple reference filters and if an image matches it is returned.

Other filters the image has to match all filters to be returned.

Specifying "since", "after", "before", "containers", "dangling","intermediate",  "readonly", "until" more then once is an error.

[NO NEW TESTS NEEDED] I will open up a validation against buildah to
make sure this passes before merging.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
