### PR TITLE
Fix build failure on Podman vendor

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/containers/storage/pkg/unshare"
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
@@ -19,7 +18,6 @@ import (
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 var (
@@ -509,43 +507,6 @@ func dbusAuthConnection(uid int, createBus func(opts ...dbus.ConnOption) (*dbus.
 // Delete cleans a cgroup
 func (c *CgroupControl) Delete() error {
 	return c.DeleteByPath(c.path)
-}
-
-// rmDirRecursively delete recursively a cgroup directory.
-// It differs from os.RemoveAll as it doesn't attempt to unlink files.
-// On cgroupfs we are allowed only to rmdir empty directories.
-func rmDirRecursively(path string) error {
-	if err := os.Remove(path); err == nil || os.IsNotExist(err) {
-		return nil
-	}
-	entries, err := ioutil.ReadDir(path)
-	if err != nil {
-		return err
-	}
-	for _, i := range entries {
-		if i.IsDir() {
-			if err := rmDirRecursively(filepath.Join(path, i.Name())); err != nil {
-				return err
-			}
-		}
-	}
-
-	attempts := 0
-	for {
-		err := os.Remove(path)
-		if err == nil || os.IsNotExist(err) {
-			return nil
-		}
-		if errors.Is(err, unix.EBUSY) {
-			// attempt up to 5 seconds if the cgroup is busy
-			if attempts < 500 {
-				time.Sleep(time.Millisecond * 10)
-				attempts++
-				continue
-			}
-		}
-		return errors.Wrapf(err, "remove %s", path)
-	}
 }
 
 // DeleteByPathConn deletes the specified cgroup path using the specified

--- a/pkg/cgroups/cgroups_unsupported.go
+++ b/pkg/cgroups/cgroups_unsupported.go
@@ -2,6 +2,10 @@
 
 package cgroups
 
+import (
+	"os"
+)
+
 // IsCgroup2UnifiedMode returns whether we are running in cgroup 2 cgroup2 mode.
 func IsCgroup2UnifiedMode() (bool, error) {
 	return false, nil
@@ -11,4 +15,8 @@ func IsCgroup2UnifiedMode() (bool, error) {
 // current cgroup.
 func UserOwnsCurrentSystemdCgroup() (bool, error) {
 	return false, nil
+}
+
+func rmDirRecursively(path string) error {
+	return os.RemoveAll(path)
 }


### PR DESCRIPTION
Basically Windows build is failing when hitting unix contants in
cgroups.

[NO NEW TESTS ADDED] Just shifting code around.

Added build-cross to cirrus tests, which looks like it was not being
run.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>