### PR TITLE
cgroups: do not create $ROOT/pids on cgroupv2

### DIFF
--- a/pkg/cgroups/pids.go
+++ b/pkg/cgroups/pids.go
@@ -34,6 +34,9 @@ func (c *pidHandler) Apply(ctr *CgroupControl, res *spec.LinuxResources) error {
 
 // Create the cgroup
 func (c *pidHandler) Create(ctr *CgroupControl) (bool, error) {
+	if ctr.cgroup2 {
+		return false, nil
+	}
 	return ctr.createCgroupDirectory(Pids)
 }
 


### PR DESCRIPTION
add the same check we already have for other controllers, since
`createCgroupDirectory` is meant to be used on cgroup v1 only.

Closes: https://github.com/containers/common/issues/862

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
