### PR TITLE
fix: fixup memory usage for cgroup v2

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -365,6 +365,29 @@ func readFileAsUint64(path string) (uint64, error) {
 	return ret, nil
 }
 
+func readFileByKeyAsUint64(path, key string) (uint64, error) {
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	for _, line := range strings.Split(string(content), "\n") {
+		fields := strings.SplitN(line, " ", 2)
+		if fields[0] == key {
+			v := cleanString(string(fields[1]))
+			if v == "max" {
+				return math.MaxUint64, nil
+			}
+			ret, err := strconv.ParseUint(v, 10, 64)
+			if err != nil {
+				return ret, errors.Wrapf(err, "parse %s from %s", v, path)
+			}
+			return ret, nil
+		}
+	}
+
+	return 0, fmt.Errorf("no key named %s from %s", key, path)
+}
+
 // New creates a new cgroup control
 func New(path string, resources *spec.LinuxResources) (*CgroupControl, error) {
 	cgroup2, err := IsCgroup2UnifiedMode()


### PR DESCRIPTION
`podman stats` show the `usage` memory is wrong.

it shows container memory usage is `12GB` while it only uses `1.5GB`.

because it contains network traffic.

podman related PR:  https://github.com/containers/podman/pull/12703


related podman issue:  https://github.com/containers/podman/issues/12702
