### PR TITLE
libnetwork: add function to get the default network backend 

### DIFF
--- a/libnetwork/cni/cni_suite_test.go
+++ b/libnetwork/cni/cni_suite_test.go
@@ -29,7 +29,6 @@ func getNetworkInterface(cniConfDir string) (types.ContainerNetwork, error) {
 	return cni.NewCNINetworkInterface(&cni.InitConfig{
 		CNIConfigDir:  cniConfDir,
 		CNIPluginDirs: cniPluginDirs,
-		LockFile:      filepath.Join(cniConfDir, "cni.lock"),
 	})
 }
 

--- a/libnetwork/cni/network.go
+++ b/libnetwork/cni/network.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -63,16 +64,13 @@ type InitConfig struct {
 
 	// IsMachine describes whenever podman runs in a podman machine environment.
 	IsMachine bool
-
-	// LockFile is the path to lock file.
-	LockFile string
 }
 
 // NewCNINetworkInterface creates the ContainerNetwork interface for the CNI backend.
 // Note: The networks are not loaded from disk until a method is called.
 func NewCNINetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
 	// TODO: consider using a shared memory lock
-	lock, err := lockfile.GetLockfile(conf.LockFile)
+	lock, err := lockfile.GetLockfile(filepath.Join(conf.CNIConfigDir, "cni.lock"))
 	if err != nil {
 		return nil, err
 	}

--- a/libnetwork/netavark/ipam_test.go
+++ b/libnetwork/netavark/ipam_test.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
-	"path/filepath"
 
 	"github.com/containers/common/libnetwork/types"
 	. "github.com/onsi/ginkgo"
@@ -37,7 +36,7 @@ var _ = Describe("IPAM", func() {
 	JustBeforeEach(func() {
 		libpodNet, err := NewNetworkInterface(&InitConfig{
 			NetworkConfigDir: networkConfDir,
-			IPAMDBPath:       filepath.Join(networkConfDir, "ipam.db"),
+			NetworkRunDir:    networkConfDir,
 		})
 		if err != nil {
 			Fail("Failed to create NewCNINetworkInterface")

--- a/libnetwork/netavark/ipam_test.go
+++ b/libnetwork/netavark/ipam_test.go
@@ -38,7 +38,6 @@ var _ = Describe("IPAM", func() {
 		libpodNet, err := NewNetworkInterface(&InitConfig{
 			NetworkConfigDir: networkConfDir,
 			IPAMDBPath:       filepath.Join(networkConfDir, "ipam.db"),
-			LockFile:         filepath.Join(networkConfDir, "netavark.lock"),
 		})
 		if err != nil {
 			Fail("Failed to create NewCNINetworkInterface")

--- a/libnetwork/netavark/netavark_suite_test.go
+++ b/libnetwork/netavark/netavark_suite_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -36,7 +35,7 @@ func getNetworkInterface(confDir string) (types.ContainerNetwork, error) {
 	return netavark.NewNetworkInterface(&netavark.InitConfig{
 		NetworkConfigDir: confDir,
 		NetavarkBinary:   netavarkBinary,
-		IPAMDBPath:       filepath.Join(confDir, "ipam.db"),
+		NetworkRunDir:    confDir,
 	})
 }
 

--- a/libnetwork/netavark/netavark_suite_test.go
+++ b/libnetwork/netavark/netavark_suite_test.go
@@ -37,7 +37,6 @@ func getNetworkInterface(confDir string) (types.ContainerNetwork, error) {
 		NetworkConfigDir: confDir,
 		NetavarkBinary:   netavarkBinary,
 		IPAMDBPath:       filepath.Join(confDir, "ipam.db"),
-		LockFile:         filepath.Join(confDir, "netavark.lock"),
 	})
 }
 

--- a/libnetwork/netavark/network.go
+++ b/libnetwork/netavark/network.go
@@ -33,9 +33,6 @@ type netavarkNetwork struct {
 	// ipamDBPath is the path to the ip allocation bolt db
 	ipamDBPath string
 
-	// isMachine describes whenever podman runs in a podman machine environment.
-	isMachine bool
-
 	// syslog describes whenever the netavark debbug output should be log to the syslog as well.
 	// This will use logrus to do so, make sure logrus is set up to log to the syslog.
 	syslog bool
@@ -66,12 +63,6 @@ type InitConfig struct {
 	// DefaultSubnet is the default subnet for the default network.
 	DefaultSubnet string
 
-	// IsMachine describes whenever podman runs in a podman machine environment.
-	IsMachine bool
-
-	// LockFile is the path to lock file.
-	LockFile string
-
 	// Syslog describes whenever the netavark debbug output should be log to the syslog as well.
 	// This will use logrus to do so, make sure logrus is set up to log to the syslog.
 	Syslog bool
@@ -81,7 +72,7 @@ type InitConfig struct {
 // Note: The networks are not loaded from disk until a method is called.
 func NewNetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
 	// TODO: consider using a shared memory lock
-	lock, err := lockfile.GetLockfile(conf.LockFile)
+	lock, err := lockfile.GetLockfile(filepath.Join(conf.NetworkConfigDir, "netavark.lock"))
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +118,6 @@ func NewNetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
 		ipamDBPath:       ipamdbPath,
 		defaultNetwork:   defaultNetworkName,
 		defaultSubnet:    defaultNet,
-		isMachine:        conf.IsMachine,
 		lock:             lock,
 		syslog:           conf.Syslog,
 	}

--- a/libnetwork/network/interface.go
+++ b/libnetwork/network/interface.go
@@ -124,6 +124,5 @@ func getCniInterface(conf *config.Config) (types.ContainerNetwork, error) {
 		DefaultNetwork: conf.Network.DefaultNetwork,
 		DefaultSubnet:  conf.Network.DefaultSubnet,
 		IsMachine:      conf.Engine.MachineEnabled,
-		LockFile:       filepath.Join(conf.Network.NetworkConfigDir, "cni.lock"),
 	})
 }

--- a/libnetwork/network/interface.go
+++ b/libnetwork/network/interface.go
@@ -43,6 +43,7 @@ func NetworkBackend(store storage.Store, conf *config.Config, syslog bool) (type
 		}
 		netInt, err := netavark.NewNetworkInterface(&netavark.InitConfig{
 			NetworkConfigDir: filepath.Join(store.GraphRoot(), "networks"),
+			NetworkRunDir:    filepath.Join(store.RunRoot(), "networks"),
 			NetavarkBinary:   netavarkBin,
 			DefaultNetwork:   conf.Network.DefaultNetwork,
 			DefaultSubnet:    conf.Network.DefaultSubnet,

--- a/libnetwork/network/interface.go
+++ b/libnetwork/network/interface.go
@@ -1,0 +1,129 @@
+// +build linux
+
+package network
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/containers/common/libnetwork/cni"
+	"github.com/containers/common/libnetwork/netavark"
+	"github.com/containers/common/libnetwork/types"
+	"github.com/containers/common/pkg/config"
+	"github.com/containers/storage"
+	"github.com/sirupsen/logrus"
+)
+
+const defaultNetworkBackendFileName = "defaultNetworkBackend"
+
+// NetworkBackend returns the network backend name and interface
+// It returns either the CNI or netavark backend depending on what is set in the config.
+// If the the backend is set to "" we will automatically assign the backend on the following conditions:
+//   1. read ${graphroot}/defaultNetworkBackend
+//   2. find netavark binary (if not installed use CNI)
+//   3. check containers, images and CNI networks and if there are some we have an existing install and should continue to use CNI
+func NetworkBackend(store storage.Store, conf *config.Config, syslog bool) (types.NetworkBackend, types.ContainerNetwork, error) {
+	backend := types.NetworkBackend(conf.Network.NetworkBackend)
+	if backend == "" {
+		var err error
+		backend, err = defaultNetworkBackend(store, conf)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to get default network backend: %w", err)
+		}
+	}
+
+	switch backend {
+	case types.Netavark:
+		netavarkBin, err := conf.FindHelperBinary("netavark", false)
+		if err != nil {
+			return "", nil, err
+		}
+		netInt, err := netavark.NewNetworkInterface(&netavark.InitConfig{
+			NetworkConfigDir: filepath.Join(store.GraphRoot(), "networks"),
+			NetavarkBinary:   netavarkBin,
+			DefaultNetwork:   conf.Network.DefaultNetwork,
+			DefaultSubnet:    conf.Network.DefaultSubnet,
+			Syslog:           syslog,
+		})
+		return types.Netavark, netInt, err
+	case types.CNI:
+		netInt, err := getCniInterface(conf)
+		return types.CNI, netInt, err
+
+	default:
+		return "", nil, fmt.Errorf("unsupported network backend %q, check network_backend in containers.conf", backend)
+	}
+}
+
+func defaultNetworkBackend(store storage.Store, conf *config.Config) (backend types.NetworkBackend, err error) {
+	// read defaultNetworkBackend file
+	file := filepath.Join(store.GraphRoot(), defaultNetworkBackendFileName)
+	b, err := ioutil.ReadFile(file)
+	if err == nil {
+		if string(b) == string(types.Netavark) {
+			return types.Netavark, nil
+		}
+		if string(b) == string(types.CNI) {
+			return types.CNI, nil
+		}
+		return "", fmt.Errorf("unknown network backend value in %q", file)
+	}
+	// fail for all errors except ENOENT
+	if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("could not read network backend value: %w", err)
+	}
+
+	// cache the network backend to make sure always the same one will be used
+	defer func() {
+		// only write when there is no error
+		if err == nil {
+			if err := ioutil.WriteFile(file, []byte(backend), 0644); err != nil {
+				logrus.Errorf("could not write network backend to file: %v", err)
+			}
+		}
+	}()
+
+	_, err = conf.FindHelperBinary("netavark", false)
+	if err != nil {
+		// if we cannot find netavark use CNI
+		return types.CNI, nil
+	}
+
+	// now check if there are already containers, images and CNI networks (new install?)
+	cons, err := store.Containers()
+	if err != nil {
+		return "", err
+	}
+	if len(cons) == 0 {
+		imgs, err := store.Images()
+		if err != nil {
+			return "", err
+		}
+		if len(imgs) == 0 {
+			cniInterface, err := getCniInterface(conf)
+			if err == nil {
+				nets, err := cniInterface.NetworkList()
+				// there is always a default network so check <= 1
+				if err == nil && len(nets) <= 1 {
+					// we have a fresh system so use netavark
+					return types.Netavark, nil
+				}
+			}
+		}
+	}
+	return types.CNI, nil
+}
+
+func getCniInterface(conf *config.Config) (types.ContainerNetwork, error) {
+	return cni.NewCNINetworkInterface(&cni.InitConfig{
+		CNIConfigDir:   conf.Network.NetworkConfigDir,
+		CNIPluginDirs:  conf.Network.CNIPluginDirs,
+		DefaultNetwork: conf.Network.DefaultNetwork,
+		DefaultSubnet:  conf.Network.DefaultSubnet,
+		IsMachine:      conf.Engine.MachineEnabled,
+		LockFile:       filepath.Join(conf.Network.NetworkConfigDir, "cni.lock"),
+	})
+}

--- a/libnetwork/types/const.go
+++ b/libnetwork/types/const.go
@@ -33,6 +33,13 @@ const (
 	IPVLANModeL3s = "l3s"
 )
 
+type NetworkBackend string
+
+const (
+	CNI      NetworkBackend = "cni"
+	Netavark NetworkBackend = "netavark"
+)
+
 // ValidMacVLANModes is the list of valid mode options for the macvlan driver
 var ValidMacVLANModes = []string{MacVLANModeBridge, MacVLANModePrivate, MacVLANModeVepa, MacVLANModePassthru}
 

--- a/libnetwork/types/network.go
+++ b/libnetwork/types/network.go
@@ -106,8 +106,8 @@ func (h *HardwareAddr) String() string {
 	return (*net.HardwareAddr)(h).String()
 }
 
-func (h *HardwareAddr) MarshalText() ([]byte, error) {
-	return []byte((*net.HardwareAddr)(h).String()), nil
+func (h HardwareAddr) MarshalText() ([]byte, error) {
+	return []byte(h.String()), nil
 }
 
 func (h *HardwareAddr) UnmarshalJSON(text []byte) error {

--- a/libnetwork/types/network_test.go
+++ b/libnetwork/types/network_test.go
@@ -2,6 +2,7 @@ package types_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -76,6 +77,40 @@ func TestUnmarshalMacAddress(t *testing.T) {
 			}
 			if !reflect.DeepEqual(mac, test.want) {
 				t.Errorf("types.HardwareAddress Unmarshal() got = %v, want %v", mac, test.want)
+			}
+		})
+	}
+}
+
+func TestMarshalMacAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     types.HardwareAddr
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "marshal mac",
+			arg:  types.HardwareAddr{0x44, 0x33, 0x22, 0x44, 0x33, 0x22},
+			want: `"44:33:22:44:33:22"`,
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			g, err := json.Marshal(test.arg)
+			got := string(g)
+			fmt.Println(got)
+			if (err != nil) != test.wantErr {
+				t.Errorf("types.HardwareAddress Marshal() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if test.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("types.HardwareAddress Marshal() got = %v, want %v", got, test.want)
 			}
 		})
 	}

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -203,7 +203,6 @@ func DefaultConfig() (*Config, error) {
 			UserNSSize:         DefaultUserNSSize,
 		},
 		Network: NetworkConfig{
-			NetworkBackend:   "cni",
 			DefaultNetwork:   "podman",
 			DefaultSubnet:    DefaultSubnet,
 			NetworkConfigDir: cniConfig,


### PR DESCRIPTION
When the network backend is unset in the config we have to to figure out
if we need CNI or netavark. New installs should use netavark while
existing installs should continue to use CNI to prevent breaking
systems.

We use the following conditions to determine what backend to use:
1. read ${graphroot}/defaultNetworkBackend
2. find netavark binary (if not installed use CNI)
3. check containers, images and CNI networks and if there are some
   we have an existing install and should continue to use CNI

