### PR TITLE
libnetwork: add method to get the default network name

### DIFF
--- a/libnetwork/cni/network.go
+++ b/libnetwork/cni/network.go
@@ -109,6 +109,11 @@ func (n *cniNetwork) Drivers() []string {
 	return []string{types.BridgeNetworkDriver, types.MacVLANNetworkDriver, types.IPVLANNetworkDriver}
 }
 
+// DefaultNetworkName will return the default cni network name.
+func (n *cniNetwork) DefaultNetworkName() string {
+	return n.defaultNetwork
+}
+
 func (n *cniNetwork) loadNetworks() error {
 	// check the mod time of the config dir
 	f, err := os.Stat(n.cniConfigDir)

--- a/libnetwork/netavark/network.go
+++ b/libnetwork/netavark/network.go
@@ -116,6 +116,11 @@ func (n *netavarkNetwork) Drivers() []string {
 	return []string{types.BridgeNetworkDriver, types.MacVLANNetworkDriver}
 }
 
+// DefaultNetworkName will return the default netavark network name.
+func (n *netavarkNetwork) DefaultNetworkName() string {
+	return n.defaultNetwork
+}
+
 func (n *netavarkNetwork) loadNetworks() error {
 	// check the mod time of the config dir
 	f, err := os.Stat(n.networkConfigDir)

--- a/libnetwork/types/network.go
+++ b/libnetwork/types/network.go
@@ -28,6 +28,10 @@ type ContainerNetwork interface {
 	// Drivers will return the list of supported network drivers
 	// for this interface.
 	Drivers() []string
+
+	// DefaultNetworkName will return the default network name
+	// for this interface.
+	DefaultNetworkName() string
 }
 
 // Network describes the Network attributes.


### PR DESCRIPTION
While we can store the default network name outside this network
interface it can become out of sync with the interface.

In buildah it can be useful to get the name from the interface.


<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
