### PR TITLE
image lookup: apply checks for matching digest

### DIFF
--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -406,9 +406,15 @@ func (r *Runtime) lookupImageInDigestsAndRepoTags(name string, options *LookupIm
 		digest := digested.Digest()
 		for _, image := range allImages {
 			for _, d := range image.Digests() {
-				if d == digest {
-					return image, name, nil
+				if d != digest {
+					continue
 				}
+				// Also make sure that the matching image fits all criteria (e.g., manifest list).
+				if _, err := r.lookupImageInLocalStorage(name, image.ID(), options); err != nil {
+					return nil, "", err
+				}
+				return image, name, nil
+
 			}
 		}
 		return nil, "", errors.Wrap(storage.ErrImageUnknown, name)


### PR DESCRIPTION
When looking up an image by digest, make sure that the matching image is
also subject to further attribute checks (e.g., manifest list checks) as
specified by the user.

Fixes: containers/podman/issues/12729
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
