### PR TITLE
libnetwork: verify static ip only for host-local ipam and allow mtu option for netavark macvlan driver

### DIFF
--- a/libnetwork/internal/util/validate.go
+++ b/libnetwork/internal/util/validate.go
@@ -109,14 +109,16 @@ func validatePerNetworkOpts(network *types.Network, netOpts *types.PerNetworkOpt
 	if netOpts.InterfaceName == "" {
 		return errors.Errorf("interface name on network %s is empty", network.Name)
 	}
-outer:
-	for _, ip := range netOpts.StaticIPs {
-		for _, s := range network.Subnets {
-			if s.Subnet.Contains(ip) {
-				continue outer
+	if network.IPAMOptions["driver"] == types.HostLocalIPAMDriver {
+	outer:
+		for _, ip := range netOpts.StaticIPs {
+			for _, s := range network.Subnets {
+				if s.Subnet.Contains(ip) {
+					continue outer
+				}
 			}
+			return errors.Errorf("requested static ip %s not in any subnet on network %s", ip.String(), network.Name)
 		}
-		return errors.Errorf("requested static ip %s not in any subnet on network %s", ip.String(), network.Name)
 	}
 	return nil
 }

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -910,6 +910,24 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(Equal("unsupported macvlan network option abc"))
 		})
 
+		It("create macvlan config with mtu", func() {
+			subnet := "10.1.0.0/24"
+			n, _ := types.ParseCIDR(subnet)
+			network := types.Network{
+				Driver: "macvlan",
+				Subnets: []types.Subnet{
+					{Subnet: n},
+				},
+				Options: map[string]string{
+					"mtu": "9000",
+				},
+			}
+			network1, err := libpodNet.NetworkCreate(network)
+			Expect(err).To(BeNil())
+			Expect(network1.Name).ToNot(BeEmpty())
+			Expect(network1.Options).To(HaveKeyWithValue("mtu", "9000"))
+		})
+
 	})
 
 	Context("network load valid existing ones", func() {


### PR DESCRIPTION
libnetwork: only validate static ip when ipam is host-local

If the dhcp ipam driver is used podman does not know any subnets so we
cannot verify if the given static ip is in the subnet.

Fixes containers/podman#12762


libnetwork: netavark allow mtu option for macvlan

We have to support the mtu option for netavark since it is also
supported by CNI.

