### PR TITLE
libimage: pull: platform checks for non-local platform

### DIFF
--- a/libimage/pull_test.go
+++ b/libimage/pull_test.go
@@ -94,6 +94,13 @@ func TestPullPlatforms(t *testing.T) {
 	require.NoError(t, err, "pull busybox")
 	require.Len(t, pulledImages, 1)
 
+	// Repulling with a bogus architecture should yield an error and not
+	// choose the local image.
+	pullOptions.Architecture = "bogus"
+	_, err = runtime.Pull(ctx, withTag, config.PullPolicyNewer, pullOptions)
+	require.Error(t, err, "pulling with a bogus architecture must fail even if there is a local image of another architecture")
+	require.Contains(t, err.Error(), "no image found in manifest list for architecture bogus")
+
 	image, _, err := runtime.LookupImage(withTag, nil)
 	require.NoError(t, err, "lookup busybox")
 	require.NotNil(t, image, "lookup busybox")


### PR DESCRIPTION
After containers/podman/issues/10682, we decided to always re-pull
images of non-local platforms and match *any* local image. Over time, we
refined this logic to not *always* pull the image but only if there is a
*newer* one. This has slightly changed the semantics and requires to
perform platform checks when looking up a local image. Otherwise, bogus
values would match a local image and mistakenly return it.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
