### PR TITLE
parse: extend `ValidateVolumeOpts` to support advanced `overlay` options

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -14,9 +14,27 @@ import (
 
 // ValidateVolumeOpts validates a volume's options
 func ValidateVolumeOpts(options []string) ([]string, error) {
-	var foundRootPropagation, foundRWRO, foundLabelChange, bindType, foundExec, foundDev, foundSuid, foundChown int
+	var foundRootPropagation, foundRWRO, foundLabelChange, bindType, foundExec, foundDev, foundSuid, foundChown, foundUpperDir, foundWorkDir int
 	finalOpts := make([]string, 0, len(options))
 	for _, opt := range options {
+		// support advanced options like upperdir=/path, workdir=/path
+		if strings.Contains(opt, "upperdir") {
+			foundUpperDir++
+			if foundUpperDir > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 upperdir per overlay", strings.Join(options, ", "))
+			}
+			finalOpts = append(finalOpts, opt)
+			continue
+		}
+		if strings.Contains(opt, "workdir") {
+			foundWorkDir++
+			if foundWorkDir > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 workdir per overlay", strings.Join(options, ", "))
+			}
+			finalOpts = append(finalOpts, opt)
+			continue
+		}
+
 		switch opt {
 		case "noexec", "exec":
 			foundExec++

--- a/pkg/parse/parse_test.go
+++ b/pkg/parse/parse_test.go
@@ -2,6 +2,7 @@ package parse
 
 import (
 	"os"
+	"reflect"
 	"runtime"
 	"syscall"
 	"testing"
@@ -67,6 +68,18 @@ func TestIsValidDeviceMode(t *testing.T) {
 	assert.True(t, isValidDeviceMode("rw"))
 	assert.True(t, isValidDeviceMode("rm"))
 	assert.True(t, isValidDeviceMode("rwm"))
+}
+
+func TestIsValidVolumeOption(t *testing.T) {
+	options, err := ValidateVolumeOpts([]string{"upperdir=test", "workdir=test2"})
+	assert.NoError(t, err)
+	assert.True(t, reflect.DeepEqual([]string{"upperdir=test", "workdir=test2"}, options))
+
+	_, err = ValidateVolumeOpts([]string{"workdir=test2", "workdir=test3"})
+	assert.Error(t, err)
+
+	_, err = ValidateVolumeOpts([]string{"upperdir=test2", "upperdir=test3"})
+	assert.Error(t, err)
 }
 
 func TestDeviceFromPath(t *testing.T) {


### PR DESCRIPTION
Relax ValidateVolumeOpts to support more verbose options for overlay
example `upperdir, workdir` and in future maybe `volatile`.

[NO NEW TESTS NEEDED]

Needed for: https://github.com/containers/podman/pull/12712
