### PR TITLE
netavark: use globally shared network config dir

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -310,7 +310,11 @@ If the default network does not exist, it will be automatically created the firs
 
 **network_config_dir**="/etc/cni/net.d/"
 
-Path to the directory where CNI configuration files are located.
+Path to the directory where network configuration files are located.
+For the CNI backend the default is "/etc/cni/net.d" as root
+and "$HOME/.config/cni/net.d" as rootless.
+For the netavark backend "/etc/containers/networks" is used as root
+and "$graphroot/networks" as rootless.
 
 **volumes**=[]
 

--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -278,11 +278,15 @@ Options are:
 The `network` table contains settings pertaining to the management of CNI
 plugins.
 
-**network_backend**="cni"
+**network_backend**=""
 
 Network backend determines what network driver will be used to set up and tear down container networks.
 Valid values are "cni" and "netavark".
-Changing this value may require restarting all running containers.
+The default value is empty which means that it will automatically choose CNI or netavark. If there are
+already containers/images or CNI networks preset it will choose CNI.
+
+Before changing this value all containers must be stopped otherwise it is likely that
+iptables rules and network interfaces might leak on the host. A reboot will fix this.
 
 **cni_plugin_dirs**=[]
 
@@ -301,11 +305,11 @@ cni_plugin_dirs = [
 
 **default_network**="podman"
 
-The network name of the default CNI network to attach pods to.
+The network name of the default network to attach pods to.
 
 **default_subnet**="10.88.0.0/16"
 
-The subnet to use for the default CNI network (named above in **default_network**).
+The subnet to use for the default network (named above in **default_network**).
 If the default network does not exist, it will be automatically created the first time a tool is run using this subnet.
 
 **network_config_dir**="/etc/cni/net.d/"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -822,21 +822,6 @@ func (c *ContainersConfig) Validate() error {
 // execution checks. It returns an `error` on validation failure, otherwise
 // `nil`.
 func (c *NetworkConfig) Validate() error {
-	expectedConfigDir := _cniConfigDir
-	if unshare.IsRootless() {
-		home, err := unshare.HomeDir()
-		if err != nil {
-			return err
-		}
-		expectedConfigDir = filepath.Join(home, _cniConfigDirRootless)
-	}
-	if c.NetworkConfigDir != expectedConfigDir {
-		err := isDirectory(c.NetworkConfigDir)
-		if err != nil && !os.IsNotExist(err) {
-			return errors.Wrapf(err, "invalid network_config_dir: %s", c.NetworkConfigDir)
-		}
-	}
-
 	if stringsEq(c.CNIPluginDirs, DefaultCNIPluginDirs) {
 		return nil
 	}

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -249,9 +249,6 @@ default_sysctls = [
 #
 #volumes = []
 
-# The network table contains settings pertaining to the management of
-# CNI plugins.
-
 [secrets]
 #driver = "file"
 
@@ -260,9 +257,15 @@ default_sysctls = [
 
 [network]
 
-# Network backend to use. Default "CNI".
+# Network backend determines what network driver will be used to set up and tear down container networks.
+# Valid values are "cni" and "netavark".
+# The default value is empty which means that it will automatically choose CNI or netavark. If there are
+# already containers/images or CNI networks preset it will choose CNI.
 #
-#network_backend = "cni"
+# Before changing this value all containers must be stopped otherwise it is likely that
+# iptables rules and network interfaces might leak on the host. A reboot will fix this.
+#
+#network_backend = ""
 
 # Path to directory where CNI plugin binaries are located.
 #
@@ -274,11 +277,11 @@ default_sysctls = [
 #  "/opt/cni/bin",
 #]
 
-# The network name of the default CNI network to attach pods to.
+# The network name of the default network to attach pods to.
 #
 #default_network = "podman"
 
-# The default subnet for the default CNI network given in default_network.
+# The default subnet for the default network given in default_network.
 # If a network with that name does not exist, a new network using that name and
 # this subnet will be created.
 # Must be a valid IPv4 CIDR prefix.

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -285,7 +285,11 @@ default_sysctls = [
 #
 #default_subnet = "10.88.0.0/16"
 
-# Path to the directory where CNI configuration files are located.
+# Path to the directory where network configuration files are located.
+# For the CNI backend the default is "/etc/cni/net.d" as root
+# and "$HOME/.config/cni/net.d" as rootless.
+# For the netavark backend "/etc/containers/networks" is used as root
+# and "$graphroot/networks" as rootless.
 #
 #network_config_dir = "/etc/cni/net.d/"
 

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -94,10 +94,6 @@ const (
 	// InstallPrefix is the prefix where podman will be installed.
 	// It can be overridden at build time.
 	_installPrefix = "/usr"
-	// _cniConfigDir is the directory where cni configuration is found
-	_cniConfigDir = "/etc/cni/net.d/"
-	// _cniConfigDirRootless is the directory in XDG_CONFIG_HOME for cni plugins
-	_cniConfigDirRootless = "cni/net.d/"
 	// CgroupfsCgroupsManager represents cgroupfs native cgroup manager
 	CgroupfsCgroupsManager = "cgroupfs"
 	// DefaultApparmorProfile  specifies the default apparmor profile for the container.
@@ -141,8 +137,6 @@ func DefaultConfig() (*Config, error) {
 		return nil, err
 	}
 
-	cniConfig := _cniConfigDir
-
 	defaultEngineConfig.SignaturePolicyPath = DefaultSignaturePolicyPath
 	if unshare.IsRootless() {
 		configHome, err := homedir.GetConfigHome()
@@ -156,7 +150,6 @@ func DefaultConfig() (*Config, error) {
 				defaultEngineConfig.SignaturePolicyPath = DefaultSignaturePolicyPath
 			}
 		}
-		cniConfig = filepath.Join(configHome, _cniConfigDirRootless)
 	}
 
 	cgroupNS := "host"
@@ -203,10 +196,9 @@ func DefaultConfig() (*Config, error) {
 			UserNSSize:         DefaultUserNSSize,
 		},
 		Network: NetworkConfig{
-			DefaultNetwork:   "podman",
-			DefaultSubnet:    DefaultSubnet,
-			NetworkConfigDir: cniConfig,
-			CNIPluginDirs:    DefaultCNIPluginDirs,
+			DefaultNetwork: "podman",
+			DefaultSubnet:  DefaultSubnet,
+			CNIPluginDirs:  DefaultCNIPluginDirs,
 		},
 		Engine:  *defaultEngineConfig,
 		Secrets: defaultSecretConfig(),


### PR DESCRIPTION
Since the network namespace is shared for all rootful libpod instances
we also need to make sure to use the same network config dir and run dir
to ensure that we do not use the same subnet or ip for more than one
container.

Also update the documentation about the network_config_dir field.

add network documentation for netavark

* change cni networks to just networks since they also refer to netavark
  networks
* add documentation about the network_backend key and what the empty
  value means
