### PR TITLE
libnetwork: support `rootless` network with netavark and relay `runRoot` with `tmpfs`

### DIFF
--- a/libnetwork/netavark/run.go
+++ b/libnetwork/netavark/run.go
@@ -5,6 +5,7 @@ package netavark
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/containers/common/libnetwork/internal/util"
 	"github.com/containers/common/libnetwork/types"
@@ -54,7 +55,7 @@ func (n *netavarkNetwork) Setup(namespacePath string, options types.SetupOptions
 	}
 
 	result := map[string]types.StatusBlock{}
-	err = n.execNetavark([]string{"setup", namespacePath}, netavarkOpts, &result)
+	err = n.execNetavark([]string{"--config", n.networkRunDir, "--rootless=" + strconv.FormatBool(n.networkRootless), "setup", namespacePath}, netavarkOpts, &result)
 	if err != nil {
 		// lets dealloc ips to prevent leaking
 		if err := n.deallocIPs(&options.NetworkOptions); err != nil {
@@ -94,7 +95,7 @@ func (n *netavarkNetwork) Teardown(namespacePath string, options types.TeardownO
 		return errors.Wrap(err, "failed to convert net opts")
 	}
 
-	retErr := n.execNetavark([]string{"teardown", namespacePath}, netavarkOpts, nil)
+	retErr := n.execNetavark([]string{"--config", n.networkRunDir, "--rootless=" + strconv.FormatBool(n.networkRootless), "teardown", namespacePath}, netavarkOpts, nil)
 
 	// when netavark returned an error we still free the used ips
 	// otherwise we could end up in a state where block the ips forever


### PR DESCRIPTION
* Tells netavark if invocation is for `rootful` or `rootless`
  containers.
* Pass `tmpfs` based runRoot to netavark so it can write/read configs
  from there.
  
  Needed by: containers/netavark#168
