### PR TITLE
remove rootless_networking field from containers.conf

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -222,11 +222,6 @@ is imposed.
 
 Copy the content from the underlying image into the newly created volume when the container is created instead of when it is started. If `false`, the container engine will not copy the content until the container is started. Setting it to `true` may have negative performance implications.
 
-**rootless_networking**="slirp4netns"
-
-Set type of networking rootless containers should use.  Valid options are `slirp4netns`
-or `cni`.
-
 **seccomp_profile**="/usr/share/containers/seccomp.json"
 
 Path to the seccomp.json profile which is used as the default seccomp profile

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -181,11 +181,6 @@ type ContainersConfig struct {
 	// performance implications.
 	PrepareVolumeOnCreate bool `toml:"prepare_volume_on_create,omitempty"`
 
-	// RootlessNetworking depicts the "kind" of networking for rootless
-	// containers.  Valid options are `slirp4netns` and `cni`. Default is
-	// `slirp4netns` on Linux, and `cni` on non-Linux OSes.
-	RootlessNetworking string `toml:"rootless_networking,omitempty"`
-
 	// SeccompProfile is the seccomp.json profile path which is used as the
 	// default for the runtime.
 	SeccompProfile string `toml:"seccomp_profile,omitempty"`

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -325,18 +325,6 @@ var _ = Describe("Config Local", func() {
 		gomega.Expect(config2.Engine.MachineEnabled).To(gomega.Equal(true))
 	})
 
-	It("Rootless networking", func() {
-		// Given
-		config, err := NewConfig("")
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config.Containers.RootlessNetworking).To(gomega.Equal("slirp4netns"))
-		// When
-		config2, err := NewConfig("testdata/containers_default.conf")
-		// Then
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config2.Containers.RootlessNetworking).To(gomega.Equal("cni"))
-	})
-
 	It("default netns", func() {
 		// Given
 		config, err := NewConfig("")

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -197,10 +197,6 @@ default_sysctls = [
 #
 #prepare_volume_on_create = false
 
-# Indicates the networking to be used for rootless containers
-#
-#rootless_networking = "slirp4netns"
-
 # Path to the seccomp.json profile which is used as the default seccomp profile
 # for the runtime.
 #

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -177,23 +177,22 @@ func DefaultConfig() (*Config, error) {
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 				"TERM=xterm",
 			},
-			EnvHost:            false,
-			HTTPProxy:          true,
-			Init:               false,
-			InitPath:           "",
-			IPCNS:              "private",
-			LogDriver:          defaultLogDriver(),
-			LogSizeMax:         DefaultLogSizeMax,
-			NetNS:              "private",
-			NoHosts:            false,
-			PidsLimit:          DefaultPidsLimit,
-			PidNS:              "private",
-			RootlessNetworking: getDefaultRootlessNetwork(),
-			ShmSize:            DefaultShmSize,
-			TZ:                 "",
-			Umask:              "0022",
-			UTSNS:              "private",
-			UserNSSize:         DefaultUserNSSize,
+			EnvHost:    false,
+			HTTPProxy:  true,
+			Init:       false,
+			InitPath:   "",
+			IPCNS:      "private",
+			LogDriver:  defaultLogDriver(),
+			LogSizeMax: DefaultLogSizeMax,
+			NetNS:      "private",
+			NoHosts:    false,
+			PidsLimit:  DefaultPidsLimit,
+			PidNS:      "private",
+			ShmSize:    DefaultShmSize,
+			TZ:         "",
+			Umask:      "0022",
+			UTSNS:      "private",
+			UserNSSize: DefaultUserNSSize,
 		},
 		Network: NetworkConfig{
 			DefaultNetwork: "podman",
@@ -565,10 +564,4 @@ func (c *Config) LogDriver() string {
 // MachineEnabled returns if podman is running inside a VM or not
 func (c *Config) MachineEnabled() bool {
 	return c.Engine.MachineEnabled
-}
-
-// RootlessNetworking returns the "kind" of networking
-// rootless containers should use
-func (c *Config) RootlessNetworking() string {
-	return c.Containers.RootlessNetworking
 }

--- a/pkg/config/default_linux.go
+++ b/pkg/config/default_linux.go
@@ -24,12 +24,6 @@ func getDefaultMachineUser() string {
 	return "core"
 }
 
-// getDefaultRootlessNetwork returns the default rootless network configuration.
-// It is "slirp4netns" for Linux.
-func getDefaultRootlessNetwork() string {
-	return "slirp4netns"
-}
-
 // getDefaultProcessLimits returns the nproc for the current process in ulimits format
 // Note that nfile sometimes cannot be set to unlimited, and the limit is hardcoded
 // to (oldMaxSize) 1048576 (2^20), see: http://stackoverflow.com/a/1213069/1811501

--- a/pkg/config/default_unsupported.go
+++ b/pkg/config/default_unsupported.go
@@ -13,12 +13,6 @@ func getDefaultMachineUser() string {
 	return "core"
 }
 
-// getDefaultRootlessNetwork returns the default rootless network configuration.
-// It is "cni" for non-Linux OSes (to better support `podman-machine` usecases).
-func getDefaultRootlessNetwork() string {
-	return "cni"
-}
-
 // isCgroup2UnifiedMode returns whether we are running in cgroup2 mode.
 func isCgroup2UnifiedMode() (isUnified bool, isUnifiedErr error) {
 	return false, nil

--- a/pkg/config/default_windows.go
+++ b/pkg/config/default_windows.go
@@ -11,12 +11,6 @@ func getDefaultMachineUser() string {
 	return "user"
 }
 
-// getDefaultRootlessNetwork returns the default rootless network configuration.
-// It is "cni" for non-Linux OSes (to better support `podman-machine` usecases).
-func getDefaultRootlessNetwork() string {
-	return "cni"
-}
-
 // isCgroup2UnifiedMode returns whether we are running in cgroup2 mode.
 func isCgroup2UnifiedMode() (isUnified bool, isUnifiedErr error) {
 	return false, nil

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -90,8 +90,6 @@ umask="0002"
 # default network mode
 netns="bridge"
 
-rootless_networking = "cni"
-
 # The network table containers settings pertaining to the management of
 # CNI plugins.
 [network]


### PR DESCRIPTION
This field was only needed for machine to force cni, however you can set
netns="bridge" in the config to have the same effect. This is already
done in the machine setup.

The field was more of a hack and just creates confusion for users so we
remove it.

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
