### PR TITLE
libnetwork fix subnet validation for macvlan

### DIFF
--- a/libnetwork/cni/config.go
+++ b/libnetwork/cni/config.go
@@ -60,7 +60,7 @@ func (n *cniNetwork) networkCreate(newNetwork *types.Network, defaultNet bool) (
 	// Therefore the next podman command tries to create the default net again and it would
 	// fail because it thinks the network is used on the host.
 	var usedNetworks []*net.IPNet
-	if !defaultNet {
+	if !defaultNet && newNetwork.Driver == types.BridgeNetworkDriver {
 		usedNetworks, err = internalutil.GetUsedSubnets(n)
 		if err != nil {
 			return nil, err

--- a/libnetwork/cni/config_test.go
+++ b/libnetwork/cni/config_test.go
@@ -249,6 +249,30 @@ var _ = Describe("Config", func() {
 			grepInFile(path, `"type": "host-local"`)
 		})
 
+		// https://github.com/containers/podman/issues/12971
+		It("create macvlan with a used subnet", func() {
+			subnet := "127.0.0.0/8"
+			n, _ := types.ParseCIDR(subnet)
+			network := types.Network{
+				Driver: "macvlan",
+				Subnets: []types.Subnet{
+					{Subnet: n},
+				},
+			}
+			network1, err := libpodNet.NetworkCreate(network)
+			Expect(err).To(BeNil())
+			Expect(network1.Name).ToNot(BeEmpty())
+			path := filepath.Join(cniConfDir, network1.Name+".conflist")
+			Expect(path).To(BeARegularFile())
+			Expect(network1.ID).ToNot(BeEmpty())
+			Expect(network1.Driver).To(Equal("macvlan"))
+			Expect(network1.Subnets).To(HaveLen(1))
+			Expect(network1.Subnets[0].Subnet.String()).To(Equal(subnet))
+			Expect(network1.Subnets[0].Gateway.String()).To(Equal("127.0.0.1"))
+			Expect(network1.IPAMOptions).To(HaveKeyWithValue("driver", "host-local"))
+			grepInFile(path, `"type": "host-local"`)
+		})
+
 		It("create ipvlan config with subnet", func() {
 			subnet := "10.1.0.0/24"
 			n, _ := types.ParseCIDR(subnet)

--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -74,7 +74,7 @@ func (n *netavarkNetwork) networkCreate(newNetwork *types.Network, defaultNet bo
 	// Therefore the next podman command tries to create the default net again and it would
 	// fail because it thinks the network is used on the host.
 	var usedNetworks []*net.IPNet
-	if !defaultNet {
+	if !defaultNet && newNetwork.Driver == types.BridgeNetworkDriver {
 		usedNetworks, err = internalutil.GetUsedSubnets(n)
 		if err != nil {
 			return nil, err

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -829,6 +829,27 @@ var _ = Describe("Config", func() {
 			Expect(network1.IPAMOptions).To(HaveKeyWithValue("driver", "host-local"))
 		})
 
+		// https://github.com/containers/podman/issues/12971
+		It("create macvlan with a used subnet", func() {
+			subnet := "127.0.0.0/8"
+			n, _ := types.ParseCIDR(subnet)
+			network := types.Network{
+				Driver: "macvlan",
+				Subnets: []types.Subnet{
+					{Subnet: n},
+				},
+			}
+			network1, err := libpodNet.NetworkCreate(network)
+			Expect(err).To(BeNil())
+			Expect(network1.Name).ToNot(BeEmpty())
+			Expect(network1.ID).ToNot(BeEmpty())
+			Expect(network1.Driver).To(Equal("macvlan"))
+			Expect(network1.Subnets).To(HaveLen(1))
+			Expect(network1.Subnets[0].Subnet.String()).To(Equal(subnet))
+			Expect(network1.Subnets[0].Gateway.String()).To(Equal("127.0.0.1"))
+			Expect(network1.IPAMOptions).To(HaveKeyWithValue("driver", "host-local"))
+		})
+
 		It("create macvlan config with subnet and device", func() {
 			subnet := "10.1.0.0/24"
 			n, _ := types.ParseCIDR(subnet)


### PR DESCRIPTION
When we create a macvlan network we should not check if the subnet is
already in use on the host since this is expected for macvlan networks.
Only bridge networks should use this check.

Fixes containers/podman#12971

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
