### PR TITLE
netavark: use aardvark-dns path from containers.conf

### DIFF
--- a/libnetwork/netavark/exec.go
+++ b/libnetwork/netavark/exec.go
@@ -107,7 +107,7 @@ func (n *netavarkNetwork) execNetavark(args []string, stdin, result interface{})
 		logWriter = io.MultiWriter(logWriter, &logrusNetavarkWriter{})
 	}
 
-	cmd := exec.Command(n.netavarkBinary, args...)
+	cmd := exec.Command(n.netavarkBinary, append(n.getCommonNetavarkOptions(), args...)...)
 	// connect the pipes to stdin and stdout
 	cmd.Stdin = stdinR
 	cmd.Stdout = stdoutW

--- a/libnetwork/netavark/network.go
+++ b/libnetwork/netavark/network.go
@@ -30,6 +30,8 @@ type netavarkNetwork struct {
 
 	// netavarkBinary is the path to the netavark binary.
 	netavarkBinary string
+	// aardvarkBinary is the path to the aardvark binary.
+	aardvarkBinary string
 
 	// defaultNetwork is the name for the default network.
 	defaultNetwork string
@@ -59,6 +61,8 @@ type InitConfig struct {
 
 	// NetavarkBinary is the path to the netavark binary.
 	NetavarkBinary string
+	// AardvarkBinary is the path to the aardvark binary.
+	AardvarkBinary string
 
 	// NetworkRunDir is where temporary files are stored, i.e.the ipam db, aardvark config
 	NetworkRunDir string
@@ -108,6 +112,7 @@ func NewNetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
 		networkConfigDir: conf.NetworkConfigDir,
 		networkRunDir:    conf.NetworkRunDir,
 		netavarkBinary:   conf.NetavarkBinary,
+		aardvarkBinary:   conf.AardvarkBinary,
 		networkRootless:  unshare.IsRootless(),
 		ipamDBPath:       filepath.Join(conf.NetworkRunDir, "ipam.db"),
 		defaultNetwork:   defaultNetworkName,

--- a/libnetwork/netavark/run.go
+++ b/libnetwork/netavark/run.go
@@ -55,7 +55,7 @@ func (n *netavarkNetwork) Setup(namespacePath string, options types.SetupOptions
 	}
 
 	result := map[string]types.StatusBlock{}
-	err = n.execNetavark([]string{"--config", n.networkRunDir, "--rootless=" + strconv.FormatBool(n.networkRootless), "setup", namespacePath}, netavarkOpts, &result)
+	err = n.execNetavark([]string{"setup", namespacePath}, netavarkOpts, &result)
 	if err != nil {
 		// lets dealloc ips to prevent leaking
 		if err := n.deallocIPs(&options.NetworkOptions); err != nil {
@@ -95,7 +95,7 @@ func (n *netavarkNetwork) Teardown(namespacePath string, options types.TeardownO
 		return errors.Wrap(err, "failed to convert net opts")
 	}
 
-	retErr := n.execNetavark([]string{"--config", n.networkRunDir, "--rootless=" + strconv.FormatBool(n.networkRootless), "teardown", namespacePath}, netavarkOpts, nil)
+	retErr := n.execNetavark([]string{"teardown", namespacePath}, netavarkOpts, nil)
 
 	// when netavark returned an error we still free the used ips
 	// otherwise we could end up in a state where block the ips forever
@@ -109,6 +109,10 @@ func (n *netavarkNetwork) Teardown(namespacePath string, options types.TeardownO
 	}
 
 	return retErr
+}
+
+func (n *netavarkNetwork) getCommonNetavarkOptions() []string {
+	return []string{"--config", n.networkRunDir, "--rootless=" + strconv.FormatBool(n.networkRootless), "--aardvark-binary=" + n.aardvarkBinary}
 }
 
 func (n *netavarkNetwork) convertNetOpts(opts types.NetworkOptions) (*netavarkOptions, error) {


### PR DESCRIPTION
We need to use the configured path from containers.conf for the
aardvark-dns binary location.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
