### PR TITLE
changing value of DefaultInfraImage

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -46,7 +46,7 @@ var (
 	// DefaultInitPath is the default path to the container-init binary
 	DefaultInitPath = "/usr/libexec/podman/catatonit"
 	// DefaultInfraImage to use for infra container
-	DefaultInfraImage = "k8s.gcr.io/pause:3.5"
+	DefaultInfraImage = ""
 	// DefaultRootlessSHMLockPath is the default path for rootless SHM locks
 	DefaultRootlessSHMLockPath = "/libpod_rootless_lock"
 	// DefaultDetachKeys is the default keys sequence for detaching a


### PR DESCRIPTION
because of issue [containers/podman #12771](https://github.com/containers/podman/issues/12771#issuecomment-1021355022)

the new default image in 4.0.0-rc2 is a locally built one based on a local pause binary, build result e.g. "localhost/podman-pause:4.0.0-rc2-1642795764" and no longer the image "k8s.gcr.io/pause:3.5", but the command `podman pod create --help` does not yet support this feature for the output of the default infra-image

simplest solution - changing value of DefaultInfraImage

before correction
```
$ podman pod create --help | grep infra-image
      --infra-image string            The image of the infra container to associate with the pod (default "k8s.gcr.io/pause:3.5")
```

should be like this after correction
```
$ podman pod create --help | grep infra-image
      --infra-image string            The image of the infra container to associate with the pod (default "localhost/podman-pause:Version-Built")
```
<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
