### PR TITLE
Retract the v1.0.0 version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,3 +44,8 @@ require (
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 )
+
+retract (
+	v1.0.1 // This version is used only to publish retraction of v1.0.1.
+	v1.0.0 // We reverted to v0.… version numbers; the v1.0.0 tag was actually deleted.
+)


### PR DESCRIPTION
The v1.0.0 tag no longer exists, but the Go proxy still remembers it.

So, we see things like
```console
skopeo % go get -u ./...
go: downloading github.com/containers/image/v5 v5.19.1
github.com/containers/skopeo/cmd/skopeo imports
	github.com/containers/common/pkg/auth: cannot find module providing package github.com/containers/common/pkg/auth
github.com/containers/skopeo/cmd/skopeo imports
	github.com/containers/common/pkg/flag: cannot find module providing package github.com/containers/common/pkg/flag
github.com/containers/skopeo/cmd/skopeo imports
	github.com/containers/common/pkg/report: cannot find module providing package github.com/containers/common/pkg/report
github.com/containers/skopeo/cmd/skopeo imports
	github.com/containers/common/pkg/retry: cannot find module providing package github.com/containers/common/pkg/retry
```

Try to fix that, per https://go.dev/ref/mod#go-mod-file-retract and https://play-with-go.dev/retract-module-versions_go116_en/ .

The intent is to tag this commit with v1.0.1 (and then, later,
maybe delete it).
