### PR TITLE
Add libimage/manifests.PushOptions.SourceFilter

### DIFF
--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containers/common/libimage/manifests"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/retry"
 	"github.com/containers/image/v5/copy"
@@ -26,8 +27,10 @@ const (
 )
 
 // LookupReferenceFunc return an image reference based on the specified one.
-// This can be used to pass custom blob caches to the copy operation.
-type LookupReferenceFunc func(ref types.ImageReference) (types.ImageReference, error)
+// The returned reference can return custom ImageSource or ImageDestination
+// objects which intercept or filter blobs, manifests, and signatures as
+// they are read and written.
+type LookupReferenceFunc = manifests.LookupReferenceFunc
 
 // CopyOptions allow for customizing image-copy operations.
 type CopyOptions struct {

--- a/libimage/manifests/manifests.go
+++ b/libimage/manifests/manifests.go
@@ -27,6 +27,12 @@ import (
 
 const instancesData = "instances.json"
 
+// LookupReferenceFunc return an image reference based on the specified one.
+// The returned reference can return custom ImageSource or ImageDestination
+// objects which intercept or filter blobs, manifests, and signatures as
+// they are read and written.
+type LookupReferenceFunc func(ref types.ImageReference) (types.ImageReference, error)
+
 // ErrListImageUnknown is returned when we attempt to create an image reference
 // for a List that has not yet been saved to an image.
 var ErrListImageUnknown = stderrors.New("unable to determine which image holds the manifest list")
@@ -57,6 +63,7 @@ type PushOptions struct {
 	SignBy             string                // fingerprint of GPG key to use to sign images
 	RemoveSignatures   bool                  // true to discard signatures in images
 	ManifestType       string                // the format to use when saving the list - possible options are oci, v2s1, and v2s2
+	SourceFilter       LookupReferenceFunc   // filter the list source
 }
 
 // Create creates a new list containing information about the specified image,
@@ -220,6 +227,11 @@ func (l *list) Push(ctx context.Context, dest types.ImageReference, options Push
 	src, err := l.Reference(options.Store, options.ImageListSelection, options.Instances)
 	if err != nil {
 		return nil, "", err
+	}
+	if options.SourceFilter != nil {
+		if src, err = options.SourceFilter(src); err != nil {
+			return nil, "", err
+		}
 	}
 	copyOptions := &cp.Options{
 		ImageListSelection:    options.ImageListSelection,


### PR DESCRIPTION
Add a `SourceFilter` hook that allows a caller to intercept and filter attempts to read source blobs when pushing a manifest list.