### PR TITLE
Fix console password reading on Windows

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -248,7 +248,7 @@ func getUserAndPass(opts *LoginOptions, password, userFromAuthFile string) (user
 	}
 	if password == "" {
 		fmt.Fprint(opts.Stdout, "Password: ")
-		pass, err := terminal.ReadPassword(0)
+		pass, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			return "", "", errors.Wrap(err, "reading password")
 		}


### PR DESCRIPTION
The windows handle is not on fd 0 (it's -10), so portably access through os.Stdin instead.

Signed-off-by: Jason T. Greene <jason.greene@redhat.com>

