### PR TITLE
netavark: add support for dns with internal

### DIFF
--- a/libnetwork/cni/config.go
+++ b/libnetwork/cni/config.go
@@ -82,7 +82,7 @@ func (n *cniNetwork) networkCreate(newNetwork *types.Network, defaultNet bool) (
 		return nil, errors.Wrapf(types.ErrInvalidArg, "unsupported driver %s", newNetwork.Driver)
 	}
 
-	err = internalutil.ValidateSubnets(newNetwork, usedNetworks)
+	err = internalutil.ValidateSubnets(newNetwork, !newNetwork.Internal, usedNetworks)
 	if err != nil {
 		return nil, err
 	}

--- a/libnetwork/internal/util/validate.go
+++ b/libnetwork/internal/util/validate.go
@@ -65,11 +65,11 @@ func ValidateSubnet(s *types.Subnet, addGateway bool, usedNetworks []*net.IPNet)
 }
 
 // ValidateSubnets will validate the subnets for this network.
-// It also sets the gateway if the gateway is empty and it sets
+// It also sets the gateway if the gateway is empty and addGateway is set to true
 // IPv6Enabled to true if at least one subnet is ipv6.
-func ValidateSubnets(network *types.Network, usedNetworks []*net.IPNet) error {
+func ValidateSubnets(network *types.Network, addGateway bool, usedNetworks []*net.IPNet) error {
 	for i := range network.Subnets {
-		err := ValidateSubnet(&network.Subnets[i], !network.Internal, usedNetworks)
+		err := ValidateSubnet(&network.Subnets[i], addGateway, usedNetworks)
 		if err != nil {
 			return err
 		}

--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -115,14 +115,11 @@ func (n *netavarkNetwork) networkCreate(newNetwork *types.Network, defaultNet bo
 		return nil, errors.Wrapf(types.ErrInvalidArg, "unsupported driver %s", newNetwork.Driver)
 	}
 
-	err = internalutil.ValidateSubnets(newNetwork, usedNetworks)
+	// add gatway when not internal or dns enabled
+	addGateway := !newNetwork.Internal || newNetwork.DNSEnabled
+	err = internalutil.ValidateSubnets(newNetwork, addGateway, usedNetworks)
 	if err != nil {
 		return nil, err
-	}
-
-	// FIXME: If we have a working solution for internal networks with dns this check should be removed.
-	if newNetwork.DNSEnabled && newNetwork.Internal {
-		return nil, errors.New("cannot set internal and dns enabled")
 	}
 
 	newNetwork.Created = time.Now()

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -616,7 +616,7 @@ var _ = Describe("Config", func() {
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.Subnets).To(HaveLen(1))
 			Expect(network1.Subnets[0].Subnet.String()).ToNot(BeEmpty())
-			Expect(network1.Subnets[0].Gateway).To(BeNil())
+			Expect(network1.Subnets[0].Gateway.String()).ToNot(BeEmpty())
 			Expect(network1.Internal).To(BeTrue())
 		})
 
@@ -729,9 +729,11 @@ var _ = Describe("Config", func() {
 				Internal:   true,
 				DNSEnabled: true,
 			}
-			_, err := libpodNet.NetworkCreate(network)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("cannot set internal and dns enabled"))
+			network1, err := libpodNet.NetworkCreate(network)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(network1.Driver).To(Equal("bridge"))
+			Expect(network1.Internal).To(Equal(true))
+			Expect(network1.DNSEnabled).To(Equal(true))
 		})
 
 		It("network inspect partial ID", func() {

--- a/libnetwork/netavark/network.go
+++ b/libnetwork/netavark/network.go
@@ -231,7 +231,9 @@ func parseNetwork(network *types.Network) error {
 		return errors.Errorf("invalid network ID %q", network.ID)
 	}
 
-	return util.ValidateSubnets(network, nil)
+	// add gatway when not internal or dns enabled
+	addGateway := !network.Internal || network.DNSEnabled
+	return util.ValidateSubnets(network, addGateway, nil)
 }
 
 func (n *netavarkNetwork) createDefaultNetwork() (*types.Network, error) {


### PR DESCRIPTION
netavark + aardvark support this when we add a gateway ip to the config
so that aardvark can use this address to bind on it.
We only add the gateway when not internal or when dns is enabled. If
internal without dns we do not need the gw address.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
