### PR TITLE
cni: do not add default route for internal networks

### DIFF
--- a/libnetwork/cni/config_test.go
+++ b/libnetwork/cni/config_test.go
@@ -847,6 +847,9 @@ var _ = Describe("Config", func() {
 			Expect(network1.Subnets[0].Subnet.String()).ToNot(BeEmpty())
 			Expect(network1.Subnets[0].Gateway).To(BeNil())
 			Expect(network1.Internal).To(BeTrue())
+			path := filepath.Join(cniConfDir, network1.Name+".conflist")
+			Expect(path).To(BeARegularFile())
+			grepNotFile(path, `"0.0.0.0/0"`)
 		})
 
 		It("create network with labels", func() {
@@ -1388,9 +1391,21 @@ var _ = Describe("Config", func() {
 })
 
 func grepInFile(path, match string) {
+	grepFile(false, path, match)
+}
+
+func grepNotFile(path, match string) {
+	grepFile(true, path, match)
+}
+
+func grepFile(not bool, path, match string) {
 	data, err := ioutil.ReadFile(path)
 	ExpectWithOffset(1, err).To(BeNil())
-	ExpectWithOffset(1, string(data)).To(ContainSubstring(match))
+	matcher := ContainSubstring(match)
+	if not {
+		matcher = Not(matcher)
+	}
+	ExpectWithOffset(1, string(data)).To(matcher)
 }
 
 // HaveNetworkName is a custom GomegaMatcher to match a network name


### PR DESCRIPTION
Since a internal network has no connectivity to the outside we should
not add a default route. Also make sure to not add the default route
more than once for ipv4/ipv6.

Ref containers/podman#13153

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
