### PR TITLE
parse: allow extra options for idmap

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -34,6 +34,10 @@ func ValidateVolumeOpts(options []string) ([]string, error) {
 			finalOpts = append(finalOpts, opt)
 			continue
 		}
+		if strings.HasPrefix(opt, "idmap") {
+			finalOpts = append(finalOpts, opt)
+			continue
+		}
 
 		switch opt {
 		case "noexec", "exec":
@@ -84,7 +88,6 @@ func ValidateVolumeOpts(options []string) ([]string, error) {
 			// are intended to be always safe to use, even not on OS
 			// X).
 			continue
-		case "idmap":
 		default:
 			return nil, errors.Errorf("invalid option type %q", opt)
 		}


### PR DESCRIPTION
allow to pass extra information for idmap down to the OCI runtime.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
