### PR TITLE
docs: move `volumes` under containers table

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -268,6 +268,12 @@ Options are:
   `private` Create private UTS Namespace for the container.
   `host`    Share host UTS Namespace with the container.
 
+**volumes**=[]
+
+List of volumes.
+Specified as "directory-on-host:directory-in-container:options".
+
+Example:  "/db:/var/lib/db:ro".
 
 ## NETWORK TABLE
 The `network` table contains settings pertaining to the management of CNI
@@ -314,13 +320,6 @@ For the CNI backend the default is "/etc/cni/net.d" as root
 and "$HOME/.config/cni/net.d" as rootless.
 For the netavark backend "/etc/containers/networks" is used as root
 and "$graphroot/networks" as rootless.
-
-**volumes**=[]
-
-List of volumes.
-Specified as "directory-on-host:directory-in-container:options".
-
-Example:  "/db:/var/lib/db:ro".
 
 ## ENGINE TABLE
 The `engine` table contains configuration options used to set up container engines such as Podman and Buildah.


### PR DESCRIPTION
`volumes` were mistakenly listed under the network table.

Fixes: #928
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
