### PR TITLE
Add support for seccomp filter flags

### DIFF
--- a/pkg/seccomp/seccomp_linux.go
+++ b/pkg/seccomp/seccomp_linux.go
@@ -1,3 +1,4 @@
+//go:build seccomp
 // +build seccomp
 
 // SPDX-License-Identifier: Apache-2.0
@@ -118,6 +119,10 @@ func setupSeccomp(config *Seccomp, rs *specs.Spec) (*specs.LinuxSeccomp, error) 
 
 	if err := getArchitectures(config, newConfig); err != nil {
 		return nil, err
+	}
+
+	for _, flag := range config.Flags {
+		newConfig.Flags = append(newConfig.Flags, specs.LinuxSeccompFlag(flag))
 	}
 
 	if len(config.ArchMap) != 0 {

--- a/pkg/seccomp/types.go
+++ b/pkg/seccomp/types.go
@@ -17,6 +17,7 @@ type Seccomp struct {
 	Architectures []Arch         `json:"architectures,omitempty"`
 	ArchMap       []Architecture `json:"archMap,omitempty"`
 	Syscalls      []*Syscall     `json:"syscalls"`
+	Flags         []string       `json:"flags,omitempty"`
 }
 
 // Architecture is used to represent a specific architecture


### PR DESCRIPTION
crun supports seccomp filter flags since https://github.com/containers/crun/commit/fefabffa2816ea343068ed036a86944393db189a
runc will get them with https://github.com/opencontainers/runc/pull/3390
youki will get them with https://github.com/containers/youki/pull/733

To support them generally, we now copy the flags during the seccomp
setup, otherwise they will get lost.
