### PR TITLE
Enable `SECCOMP_FILTER_FLAG_SPEC_ALLOW` per default

### DIFF
--- a/pkg/seccomp/default_linux.go
+++ b/pkg/seccomp/default_linux.go
@@ -47,6 +47,8 @@ func DefaultProfile() *Seccomp {
 	enosys := uint(unix.ENOSYS)
 	eperm := uint(unix.EPERM)
 
+	flags := []string{SeccompFilterFlagSpecALlow}
+
 	syscalls := []*Syscall{
 		{
 			Names: []string{
@@ -882,5 +884,6 @@ func DefaultProfile() *Seccomp {
 		DefaultErrnoRet: &enosys,
 		ArchMap:         arches(),
 		Syscalls:        syscalls,
+		Flags:           flags,
 	}
 }

--- a/pkg/seccomp/seccomp.json
+++ b/pkg/seccomp/seccomp.json
@@ -1037,5 +1037,8 @@
 			},
 			"excludes": {}
 		}
+	],
+	"flags": [
+		"SECCOMP_FILTER_FLAG_SPEC_ALLOW"
 	]
 }

--- a/pkg/seccomp/types.go
+++ b/pkg/seccomp/types.go
@@ -20,6 +20,18 @@ type Seccomp struct {
 	Flags         []string       `json:"flags,omitempty"`
 }
 
+const (
+	// SeccompFilterFlagLog is the filter to return actions except
+	// SECCOMP_RET_ALLOW should be logged. An administrator may override this
+	// filter flag by preventing specific actions from being logged via the
+	// /proc/sys/kernel/seccomp/actions_logged file. (since Linux 4.14)
+	SeccompFilterFlagLog = "SECCOMP_FILTER_FLAG_LOG"
+
+	// SeccompFilterFlagSpecALlow can be used to disable Speculative Store
+	// Bypass mitigation. (since Linux 4.17)
+	SeccompFilterFlagSpecALlow = "SECCOMP_FILTER_FLAG_SPEC_ALLOW"
+)
+
 // Architecture is used to represent a specific architecture
 // and its sub-architectures
 type Architecture struct {


### PR DESCRIPTION
We now enable the flag for the default seccomp profile.

/hold