### PR TITLE
Add ExitCommandDelay in containers.conf and set var and default

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -579,6 +579,10 @@ stores containers.
 
 Number of seconds to wait for container to exit before sending kill signal.
 
+**exit_command_delay**=300
+
+Number of seconds to wait for the API process for the exec call before sending exit command mimicing the Docker behavior of 5 minutes (in seconds).
+
 **tmp_dir**="/run/libpod"
 
 The path to a temporary directory to store per-boot container.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -406,6 +406,10 @@ type EngineConfig struct {
 	// before sending kill signal.
 	StopTimeout uint `toml:"stop_timeout,omitempty,omitzero"`
 
+	// ExitCommandDelay is the number of seconds to wait for the exit
+	// command to be send to the API process on the server.
+	ExitCommandDelay uint `toml:"exit_command_delay,omitempty,omitzero"`
+
 	// ImageCopyTmpDir is the default location for storing temporary
 	// container image content,  Can be overridden with the TMPDIR
 	// environment variable.  If you specify "storage", then the

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -515,6 +515,11 @@ default_sysctls = [
 #
 #stop_timeout = 10
 
+# Number of seconds to wait before exit command in API process is given to.
+# This mimics Docker's exec cleanup behaviour, where the default is 5 minutes (value is in seconds).
+#
+#exit_command_delay = 300
+
 # map of service destinations
 #
 #[service_destinations]

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -286,6 +286,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	c.CgroupManager = defaultCgroupManager()
 	c.ServiceTimeout = uint(5)
 	c.StopTimeout = uint(10)
+	c.ExitCommandDelay = uint(5 * 60)
 	c.NetworkCmdOptions = []string{
 		"enable_ipv6=true",
 	}


### PR DESCRIPTION
Working on issue [13222](https://github.com/containers/podman/issues/13222) to make the API `exec` calls configurable after how much time their processes are exited.

This MR adds this `ExitCommandDelay` configuration to `containers.conf`, adds it as field to `config.go` and sets a default of 5 minutes (as is the standard in Docker). 

Signed-off-by: Rover van der Noort <s.r.vandernoort@student.tudelft.nl>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
