### PR TITLE
libnetwork: macvlan allow internal networks

### DIFF
--- a/libnetwork/cni/config.go
+++ b/libnetwork/cni/config.go
@@ -187,9 +187,6 @@ func (n *cniNetwork) NetworkInspect(nameOrID string) (types.Network, error) {
 }
 
 func createIPMACVLAN(network *types.Network) error {
-	if network.Internal {
-		return errors.New("internal is not supported with macvlan")
-	}
 	if network.NetworkInterface != "" {
 		interfaceNames, err := internalutil.GetLiveNetworkNames()
 		if err != nil {
@@ -201,6 +198,9 @@ func createIPMACVLAN(network *types.Network) error {
 	}
 	if len(network.Subnets) == 0 {
 		network.IPAMOptions["driver"] = types.DHCPIPAMDriver
+		if network.Internal {
+			return errors.New("internal is not supported with macvlan and dhcp ipam driver")
+		}
 	} else {
 		network.IPAMOptions["driver"] = types.HostLocalIPAMDriver
 	}

--- a/libnetwork/cni/config_test.go
+++ b/libnetwork/cni/config_test.go
@@ -344,7 +344,25 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(ContainSubstring("parent interface idonotexists does not exist"))
 		})
 
-		It("create macvlan config with internal should fail", func() {
+		It("create macvlan config with internal and dhcp should fail", func() {
+			subnet := "10.1.0.0/24"
+			n, _ := types.ParseCIDR(subnet)
+			network := types.Network{
+				Driver:   "macvlan",
+				Internal: true,
+				Subnets: []types.Subnet{
+					{Subnet: n},
+				},
+			}
+			net1, err := libpodNet.NetworkCreate(network)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(net1.Internal).To(Equal(true))
+			path := filepath.Join(cniConfDir, net1.Name+".conflist")
+			Expect(path).To(BeARegularFile())
+			grepNotFile(path, `"0.0.0.0/0"`)
+		})
+
+		It("create macvlan config with internal and subnet should not fail", func() {
 			network := types.Network{
 				Driver:   "macvlan",
 				Internal: true,

--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -142,9 +142,6 @@ func (n *netavarkNetwork) networkCreate(newNetwork *types.Network, defaultNet bo
 }
 
 func createMacvlan(network *types.Network) error {
-	if network.Internal {
-		return errors.New("internal is not supported with macvlan")
-	}
 	if network.NetworkInterface != "" {
 		interfaceNames, err := internalutil.GetLiveNetworkNames()
 		if err != nil {

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -797,10 +797,15 @@ var _ = Describe("Config", func() {
 		})
 
 		It("create macvlan config with internal", func() {
-			network := types.Network{Driver: "macvlan", Internal: true}
-			_, err := libpodNet.NetworkCreate(network)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("internal is not supported with macvlan"))
+			subnet := "10.0.0.0/24"
+			n, _ := types.ParseCIDR(subnet)
+			network := types.Network{Driver: "macvlan",
+				Internal: true,
+				Subnets:  []types.Subnet{{Subnet: n}},
+			}
+			net1, err := libpodNet.NetworkCreate(network)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(net1.Internal).To(Equal(true))
 		})
 
 		It("create macvlan config with subnet", func() {


### PR DESCRIPTION
netavark: macvlan allow internal networks

When internal is used the default route will not be added,
see https://github.com/containers/netavark/pull/246

cni: macvlan allow internal networks

When we have the host-local ipam plugin we can support internal for
macvlan networks. In this case we just do not add the default route.
Since we cannot control this for dhcp we do not support internal there.

Fixes https://github.com/containers/podman/issues/13319