### PR TITLE
Add support for seccomp `ListenerPath` and `ListenerMetadata`

### DIFF
--- a/pkg/seccomp/seccomp_linux.go
+++ b/pkg/seccomp/seccomp_linux.go
@@ -125,6 +125,9 @@ func setupSeccomp(config *Seccomp, rs *specs.Spec) (*specs.LinuxSeccomp, error) 
 		newConfig.Flags = append(newConfig.Flags, specs.LinuxSeccompFlag(flag))
 	}
 
+	newConfig.ListenerPath = config.ListenerPath
+	newConfig.ListenerMetadata = config.ListenerMetadata
+
 	if len(config.ArchMap) != 0 {
 		for _, a := range config.ArchMap {
 			seccompArch, ok := nativeToSeccomp[arch]

--- a/pkg/seccomp/types.go
+++ b/pkg/seccomp/types.go
@@ -14,10 +14,12 @@ type Seccomp struct {
 
 	// Architectures is kept to maintain backward compatibility with the old
 	// seccomp profile.
-	Architectures []Arch         `json:"architectures,omitempty"`
-	ArchMap       []Architecture `json:"archMap,omitempty"`
-	Syscalls      []*Syscall     `json:"syscalls"`
-	Flags         []string       `json:"flags,omitempty"`
+	Architectures    []Arch         `json:"architectures,omitempty"`
+	ArchMap          []Architecture `json:"archMap,omitempty"`
+	Syscalls         []*Syscall     `json:"syscalls"`
+	Flags            []string       `json:"flags,omitempty"`
+	ListenerPath     string         `json:"listenerPath,omitempty"`
+	ListenerMetadata string         `json:"listenerMetadata,omitempty"`
 }
 
 // Architecture is used to represent a specific architecture


### PR DESCRIPTION
We have to copy both fields in the same way we did with the flags to
support them in container runtimes.
