### PR TITLE
Add additionalHelperBinariesDir

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -95,6 +95,10 @@ var (
 		parseSubnetPool("10.96.0.0/11", 24),
 		parseSubnetPool("10.128.0.0/9", 24),
 	}
+	// additionalHelperBinariesDir is an extra helper binaries directory that
+	// should be set during link-time, if different packagers put their
+	// helper binary in a different location
+	additionalHelperBinariesDir string
 )
 
 // nolint:unparam
@@ -277,6 +281,9 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	c.VolumePath = filepath.Join(storeOpts.GraphRoot, "volumes")
 
 	c.HelperBinariesDir = defaultHelperBinariesDir
+	if additionalHelperBinariesDir != "" {
+		c.HelperBinariesDir = append(c.HelperBinariesDir, additionalHelperBinariesDir)
+	}
 	c.HooksDir = DefaultHooksDirs
 	c.ImageDefaultTransport = _defaultTransport
 	c.StateType = BoltDBStateStore


### PR DESCRIPTION
Different packaging for different distributions have their own prefix for where helper binaries should live. additionalHelperBinariesDir is a variable that can be set during link-time so that a packager can change the location without having to carry patches for their default location.

[NO NEW TESTS NEEDED]
I have no idea how to test this.


Signed-off-by: Ashley Cui <acui@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
