### PR TITLE
libnetwork: warn only if network has `DNSEnabled` and `aardvark-dns` binary is not there.

### DIFF
--- a/libnetwork/netavark/run.go
+++ b/libnetwork/netavark/run.go
@@ -44,6 +44,16 @@ func (n *netavarkNetwork) Setup(namespacePath string, options types.SetupOptions
 		return nil, errors.Wrap(err, "failed to convert net opts")
 	}
 
+	// Warn users if one or more networks have dns enabled
+	// but aardvark-dns binary is not configured
+	for _, network := range netavarkOpts.Networks {
+		if network != nil && network.DNSEnabled && n.aardvarkBinary == "" {
+			// this is not a fatal error we can still use container without dns
+			logrus.Warnf("aardvark-dns binary not found, container dns will not be enabled")
+			break
+		}
+	}
+
 	// trace output to get the json
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
 		b, err := json.Marshal(&netavarkOpts)

--- a/libnetwork/network/interface.go
+++ b/libnetwork/network/interface.go
@@ -61,11 +61,7 @@ func NetworkBackend(store storage.Store, conf *config.Config, syslog bool) (type
 			return "", nil, err
 		}
 
-		aardvarkBin, err := conf.FindHelperBinary(aardvarkBinary, false)
-		if err != nil {
-			// this is not a fatal error we can still use netavark without dns
-			logrus.Warnf("%s binary not found, container dns will not be enabled", aardvarkBinary)
-		}
+		aardvarkBin, _ := conf.FindHelperBinary(aardvarkBinary, false)
 
 		confDir := conf.Network.NetworkConfigDir
 		if confDir == "" {

--- a/libnetwork/network/interface.go
+++ b/libnetwork/network/interface.go
@@ -64,7 +64,7 @@ func NetworkBackend(store storage.Store, conf *config.Config, syslog bool) (type
 		aardvarkBin, err := conf.FindHelperBinary(aardvarkBinary, false)
 		if err != nil {
 			// this is not a fatal error we can still use netavark without dns
-			logrus.Warnf("%s binary not found, container dns will not be enabled", aardvarkBin)
+			logrus.Warnf("%s binary not found, container dns will not be enabled", aardvarkBinary)
 		}
 
 		confDir := conf.Network.NetworkConfigDir


### PR DESCRIPTION
Use appropriate variable when producing warning for missing
aardvark-dns. Current output variable will always be empty when
aarvark-dns is missing.

Second commit overrides the first one:
Move generic warning to netavark/run and warns user if one or more
network has `DNSEnabled` and `aardvark-dns` binary is not set

Closes: https://github.com/containers/podman/issues/13412