### PR TITLE
Add new paths to FindHelperBinary searches

### DIFF
--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -19,8 +19,10 @@ func ifRootlessConfigPath() (string, error) {
 var defaultHelperBinariesDir = []string{
 	// Homebrew install paths
 	"/usr/local/opt/podman/libexec",
+	"/usr/local/opt/podman/libexec/bin",
 	"/opt/homebrew/bin",
 	"/opt/homebrew/opt/podman/libexec",
+	"/opt/homebrew/opt/podman/libexec/bin",
 	"/usr/local/bin",
 	// default paths
 	"/usr/local/libexec/podman",


### PR DESCRIPTION
In order to find qemu binaries for darwin, specifically qemu-img and
system-aarch64-qemu containers common must look in:

- "/opt/homebrew/opt/podman/libexec/bin" for Intel
- "/usr/local/opt/podman/libexec/bin" for Apple Silicon

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
