### PR TITLE
Fix ImageCopyTmpDir for windows

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -276,7 +276,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 		storeOpts.GraphRoot = _defaultGraphRoot
 	}
 	c.graphRoot = storeOpts.GraphRoot
-	c.ImageCopyTmpDir = "/var/tmp"
+	c.ImageCopyTmpDir = getDefaultTmpDir()
 	c.StaticDir = filepath.Join(storeOpts.GraphRoot, "libpod")
 	c.VolumePath = filepath.Join(storeOpts.GraphRoot, "volumes")
 

--- a/pkg/config/default_linux.go
+++ b/pkg/config/default_linux.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -47,4 +48,13 @@ func getDefaultProcessLimits() []string {
 		defaultLimits = append(defaultLimits, fmt.Sprintf("nproc=%d:%d", oldrlim.Cur, oldrlim.Max))
 	}
 	return defaultLimits
+}
+
+// getDefaultTmpDir for linux
+func getDefaultTmpDir() string {
+	// first check the TMPDIR env var
+	if path, found := os.LookupEnv("TMPDIR"); found {
+		return path
+	}
+	return "/var/tmp"
 }

--- a/pkg/config/default_unsupported.go
+++ b/pkg/config/default_unsupported.go
@@ -2,6 +2,8 @@
 
 package config
 
+import "os"
+
 // getDefaultMachineImage returns the default machine image stream
 // On Linux/Mac, this returns the FCOS stream
 func getDefaultMachineImage() string {
@@ -21,4 +23,13 @@ func isCgroup2UnifiedMode() (isUnified bool, isUnifiedErr error) {
 // getDefaultProcessLimits returns the nofile and nproc for the current process in ulimits format
 func getDefaultProcessLimits() []string {
 	return []string{}
+}
+
+// getDefaultTmpDir for linux
+func getDefaultTmpDir() string {
+	// first check the TMPDIR env var
+	if path, found := os.LookupEnv("TMPDIR"); found {
+		return path
+	}
+	return "/var/tmp"
 }

--- a/pkg/config/default_windows.go
+++ b/pkg/config/default_windows.go
@@ -1,5 +1,7 @@
 package config
 
+import "os"
+
 // getDefaultImage returns the default machine image stream
 // On Windows this refers to the Fedora major release number
 func getDefaultMachineImage() string {
@@ -19,4 +21,14 @@ func isCgroup2UnifiedMode() (isUnified bool, isUnifiedErr error) {
 // getDefaultProcessLimits returns the nofile and nproc for the current process in ulimits format
 func getDefaultProcessLimits() []string {
 	return []string{}
+}
+
+// getDefaultTmpDir for windows
+func getDefaultTmpDir() string {
+	// first check the Temp env var
+	// https://answers.microsoft.com/en-us/windows/forum/all/where-is-the-temporary-folder/44a039a5-45ba-48dd-84db-fd700e54fd56
+	if val, ok := os.LookupEnv("TEMP"); ok {
+		return val
+	}
+	return os.Getenv("LOCALAPPDATA") + "\\Temp"
 }


### PR DESCRIPTION
We cannot use /var/tmp on windows, instead use the temp var which is
defined on windows, of fall back to appdata.

Fixes containers/podman#13434


<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
