### PR TITLE
libnetwork/netavark.netavarkNetwork.networkCreate(): close the file

### DIFF
--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -130,6 +130,7 @@ func (n *netavarkNetwork) networkCreate(newNetwork *types.Network, defaultNet bo
 		if err != nil {
 			return nil, err
 		}
+		defer f.Close()
 		enc := json.NewEncoder(f)
 		enc.SetIndent("", "     ")
 		err = enc.Encode(newNetwork)


### PR DESCRIPTION
If we have to write a new configuration file, close the file handle when we finish writing to it, instead of just letting it pass out of scope.