### PR TITLE
libimage: RemoveImages: add Ignore field

### DIFF
--- a/libimage/remove_test.go
+++ b/libimage/remove_test.go
@@ -37,8 +37,20 @@ func TestRemoveImages(t *testing.T) {
 	require.False(t, rmReports[0].Removed)
 	require.Equal(t, []string{"localhost/foobar:latest"}, rmReports[0].Untagged)
 
+	// "foobar" has already been removed, so we'd get an error
+	_, rmErrors = runtime.RemoveImages(ctx, []string{"foobar"}, nil)
+	require.NotNil(t, rmErrors)
+	// ... unless we set Ignore=true
+	rmReports, rmErrors = runtime.RemoveImages(ctx, []string{"foobar"}, &RemoveImagesOptions{Ignore: true})
+	require.Nil(t, rmErrors)
+	require.Len(t, rmReports, 0)
+
 	// The busybox image is still present even if foobar was force removed.
 	exists, err := runtime.Exists(busyboxLatest)
 	require.NoError(t, err)
 	require.True(t, exists)
+
+	rmReports, rmErrors = runtime.RemoveImages(ctx, []string{"foobar", "busybox"}, &RemoveImagesOptions{Ignore: true})
+	require.Nil(t, rmErrors)
+	require.Len(t, rmReports, 1)
 }

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -592,6 +592,8 @@ type RemoveImagesOptions struct {
 	// containers using a specific image.  By default, all containers in
 	// the local containers storage will be removed (if Force is set).
 	RemoveContainerFunc RemoveContainerFunc
+	// Ignore if a specified image does not exist and do not throw an error.
+	Ignore bool
 	// IsExternalContainerFunc allows for checking whether the specified
 	// container is an external one (when containers=external filter is
 	// used).  The definition of an external container can be set by
@@ -677,6 +679,9 @@ func (r *Runtime) RemoveImages(ctx context.Context, names []string, options *Rem
 		for _, name := range names {
 			img, resolvedName, err := r.LookupImage(name, lookupOptions)
 			if err != nil {
+				if options.Ignore && errors.Is(err, storage.ErrImageUnknown) {
+					continue
+				}
 				appendError(err)
 				continue
 			}


### PR DESCRIPTION
Add a field to `RemoveImages` that would ingore if a specified image
does not exist and not throw an error.

The intended use case is adding a `podman rmi --ignore` flag.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

@containers/podman-maintainers PTAL
