### PR TITLE
libnetwork: allow new none ipam driver

### DIFF
--- a/libnetwork/cni/cni_types.go
+++ b/libnetwork/cni/cni_types.go
@@ -145,11 +145,13 @@ func newHostLocalBridge(name string, isGateWay, ipMasq bool, mtu, vlan int, ipam
 		MTU:         mtu,
 		HairpinMode: true,
 		Vlan:        vlan,
-		IPAM:        *ipamConf,
 	}
-	// if we use host-local set the ips cap to ensure we can set static ips via runtime config
-	if ipamConf.PluginType == types.HostLocalIPAMDriver {
-		bridge.Capabilities = caps
+	if ipamConf != nil {
+		bridge.IPAM = *ipamConf
+		// if we use host-local set the ips cap to ensure we can set static ips via runtime config
+		if ipamConf.PluginType == types.HostLocalIPAMDriver {
+			bridge.Capabilities = caps
+		}
 	}
 	return &bridge
 }
@@ -259,7 +261,9 @@ func hasDNSNamePlugin(paths []string) bool {
 func newVLANPlugin(pluginType, device, mode string, mtu int, ipam *ipamConfig) VLANConfig {
 	m := VLANConfig{
 		PluginType: pluginType,
-		IPAM:       *ipam,
+	}
+	if ipam != nil {
+		m.IPAM = *ipam
 	}
 	if mtu > 0 {
 		m.MTU = mtu

--- a/libnetwork/cni/config_test.go
+++ b/libnetwork/cni/config_test.go
@@ -1114,8 +1114,6 @@ var _ = Describe("Config", func() {
 			// check for the unsupported ipam plugin message
 			logString := logBuffer.String()
 			Expect(logString).ToNot(BeEmpty())
-			Expect(logString).To(ContainSubstring("unsupported ipam plugin \\\"\\\" in %s", cniConfDir+"/ipam-none.conflist"))
-			Expect(logString).To(ContainSubstring("unsupported ipam plugin \\\"\\\" in %s", cniConfDir+"/ipam-empty.conflist"))
 			Expect(logString).To(ContainSubstring("unsupported ipam plugin \\\"static\\\" in %s", cniConfDir+"/ipam-static.conflist"))
 		})
 
@@ -1258,6 +1256,27 @@ var _ = Describe("Config", func() {
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.Driver).To(Equal("bridge"))
 			Expect(network.Subnets).To(HaveLen(0))
+			Expect(network.IPAMOptions).To(HaveKeyWithValue("driver", "static"))
+		})
+
+		It("ipam none network", func() {
+			network, err := libpodNet.NetworkInspect("ipam-none")
+			Expect(err).To(BeNil())
+			Expect(network.Name).To(Equal("ipam-none"))
+			Expect(network.ID).To(HaveLen(64))
+			Expect(network.Driver).To(Equal("bridge"))
+			Expect(network.Subnets).To(HaveLen(0))
+			Expect(network.IPAMOptions).To(HaveKeyWithValue("driver", "none"))
+		})
+
+		It("ipam empty network", func() {
+			network, err := libpodNet.NetworkInspect("ipam-empty")
+			Expect(err).To(BeNil())
+			Expect(network.Name).To(Equal("ipam-empty"))
+			Expect(network.ID).To(HaveLen(64))
+			Expect(network.Driver).To(Equal("bridge"))
+			Expect(network.Subnets).To(HaveLen(0))
+			Expect(network.IPAMOptions).To(HaveKeyWithValue("driver", "none"))
 		})
 
 		It("network list with filters (name)", func() {

--- a/libnetwork/cni/run.go
+++ b/libnetwork/cni/run.go
@@ -125,34 +125,37 @@ func CNIResultToStatus(res cnitypes.Result) (types.StatusBlock, error) {
 	result.DNSSearchDomains = cniResult.DNS.Search
 
 	interfaces := make(map[string]types.NetInterface)
-	for _, ip := range cniResult.IPs {
-		if ip.Interface == nil {
-			// we do no expect ips without an interface
+	for intIndex, netInterface := range cniResult.Interfaces {
+		// we are only interested about interfaces in the container namespace
+		if netInterface.Sandbox == "" {
 			continue
 		}
-		if len(cniResult.Interfaces) <= *ip.Interface {
-			return result, errors.Errorf("invalid cni result, interface index %d out of range", *ip.Interface)
+
+		mac, err := net.ParseMAC(netInterface.Mac)
+		if err != nil {
+			return result, err
 		}
-		cniInt := cniResult.Interfaces[*ip.Interface]
-		netInt, ok := interfaces[cniInt.Name]
-		if ok {
-			netInt.Subnets = append(netInt.Subnets, types.NetAddress{
-				IPNet:   types.IPNet{IPNet: ip.Address},
-				Gateway: ip.Gateway,
-			})
-			interfaces[cniInt.Name] = netInt
-		} else {
-			mac, err := net.ParseMAC(cniInt.Mac)
-			if err != nil {
-				return result, err
+		subnets := make([]types.NetAddress, 0, len(cniResult.IPs))
+		for _, ip := range cniResult.IPs {
+			if ip.Interface == nil {
+				// we do no expect ips without an interface
+				continue
 			}
-			interfaces[cniInt.Name] = types.NetInterface{
-				MacAddress: types.HardwareAddr(mac),
-				Subnets: []types.NetAddress{{
+			if len(cniResult.Interfaces) <= *ip.Interface {
+				return result, errors.Errorf("invalid cni result, interface index %d out of range", *ip.Interface)
+			}
+
+			// when we have a ip for this interface add it to the subnets
+			if *ip.Interface == intIndex {
+				subnets = append(subnets, types.NetAddress{
 					IPNet:   types.IPNet{IPNet: ip.Address},
 					Gateway: ip.Gateway,
-				}},
+				})
 			}
+		}
+		interfaces[netInterface.Name] = types.NetInterface{
+			MacAddress: types.HardwareAddr(mac),
+			Subnets:    subnets,
 		}
 	}
 	result.Interfaces = interfaces

--- a/libnetwork/internal/util/bridge.go
+++ b/libnetwork/internal/util/bridge.go
@@ -27,7 +27,9 @@ func CreateBridge(n NetUtil, network *types.Network, usedNetworks []*net.IPNet, 
 		}
 	}
 
-	if network.IPAMOptions[types.Driver] != types.DHCPIPAMDriver {
+	ipamDriver := network.IPAMOptions[types.Driver]
+	// also do this when the driver is unset
+	if ipamDriver == "" || ipamDriver == types.HostLocalIPAMDriver {
 		if len(network.Subnets) == 0 {
 			freeSubnet, err := GetFreeIPv4NetworkSubnet(usedNetworks, subnetPools)
 			if err != nil {

--- a/libnetwork/netavark/ipam_test.go
+++ b/libnetwork/netavark/ipam_test.go
@@ -399,10 +399,10 @@ var _ = Describe("IPAM", func() {
 		}
 	})
 
-	It("ipam with dhcp driver should not set ips", func() {
+	It("ipam with none driver should not set ips", func() {
 		network, err := networkInterface.NetworkCreate(types.Network{
 			IPAMOptions: map[string]string{
-				"driver": types.DHCPIPAMDriver,
+				"driver": types.NoneIPAMDriver,
 			},
 		})
 		Expect(err).ToNot(HaveOccurred())

--- a/libnetwork/netavark/run_test.go
+++ b/libnetwork/netavark/run_test.go
@@ -700,6 +700,89 @@ var _ = Describe("run netavark", func() {
 			Expect(err.Error()).To(ContainSubstring("interface eth0 already exists on container namespace"))
 		})
 	})
+
+	It("setup ipam driver none network", func() {
+		runTest(func() {
+			network := types.Network{
+				IPAMOptions: map[string]string{
+					types.Driver: types.NoneIPAMDriver,
+				},
+			}
+			network1, err := libpodNet.NetworkCreate(network)
+			Expect(err).To(BeNil())
+
+			intName1 := "eth0"
+			netName1 := network1.Name
+
+			setupOpts := types.SetupOptions{
+				NetworkOptions: types.NetworkOptions{
+					ContainerID: stringid.GenerateNonCryptoID(),
+					Networks: map[string]types.PerNetworkOptions{
+						netName1: {
+							InterfaceName: intName1,
+						},
+					},
+				},
+			}
+
+			res, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
+			Expect(err).To(BeNil())
+			Expect(res).To(HaveLen(1))
+
+			Expect(res).To(HaveKey(netName1))
+			Expect(res[netName1].Interfaces).To(HaveKey(intName1))
+			Expect(res[netName1].Interfaces[intName1].Subnets).To(HaveLen(0))
+			macInt1 := res[netName1].Interfaces[intName1].MacAddress
+			Expect(macInt1).To(HaveLen(6))
+
+			// check in the container namespace if the settings are applied
+			err = netNSContainer.Do(func(_ ns.NetNS) error {
+				defer GinkgoRecover()
+				i, err := net.InterfaceByName(intName1)
+				Expect(err).To(BeNil())
+				Expect(i.Name).To(Equal(intName1))
+				Expect(i.HardwareAddr).To(Equal(net.HardwareAddr(macInt1)))
+				addrs, err := i.Addrs()
+				Expect(err).To(BeNil())
+				// we still have the ipv6 link local address
+				Expect(addrs).To(HaveLen(1))
+				addr, ok := addrs[0].(*net.IPNet)
+				Expect(ok).To(BeTrue(), "cast address to ipnet")
+				// make sure we are link local
+				Expect(addr.IP.IsLinkLocalUnicast()).To(BeTrue(), "ip is link local address")
+
+				// check loopback adapter
+				i, err = net.InterfaceByName("lo")
+				Expect(err).To(BeNil())
+				Expect(i.Name).To(Equal("lo"))
+				Expect(i.Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
+				Expect(i.Flags&net.FlagUp).To(Equal(net.FlagUp), "Loopback adapter should be up")
+				return nil
+			})
+			Expect(err).To(BeNil())
+
+			err = libpodNet.Teardown(netNSContainer.Path(), types.TeardownOptions(setupOpts))
+			Expect(err).To(BeNil())
+
+			// check in the container namespace that the interface is removed
+			err = netNSContainer.Do(func(_ ns.NetNS) error {
+				defer GinkgoRecover()
+				_, err := net.InterfaceByName(intName1)
+				Expect(err).To(HaveOccurred())
+
+				// check that only the loopback adapter is left
+				ints, err := net.Interfaces()
+				Expect(err).To(BeNil())
+				Expect(ints).To(HaveLen(1))
+				Expect(ints[0].Name).To(Equal("lo"))
+				Expect(ints[0].Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
+				Expect(ints[0].Flags&net.FlagUp).To(Equal(net.FlagUp), "Loopback adapter should be up")
+
+				return nil
+			})
+			Expect(err).To(BeNil())
+		})
+	})
 })
 
 func runNetListener(wg *sync.WaitGroup, protocol, ip string, port int, expectedData string) {

--- a/libnetwork/types/const.go
+++ b/libnetwork/types/const.go
@@ -12,10 +12,12 @@ const (
 
 	// IPAM drivers
 	Driver = "driver"
-	// HostLocalIPAMDriver store the ip
+	// HostLocalIPAMDriver store the ip locally in a db
 	HostLocalIPAMDriver = "host-local"
 	// DHCPIPAMDriver get subnet and ip from dhcp server
 	DHCPIPAMDriver = "dhcp"
+	// NoneIPAMDriver do not provide ipam management
+	NoneIPAMDriver = "none"
 
 	// DefaultSubnet is the name that will be used for the default CNI network.
 	DefaultNetworkName = "podman"


### PR DESCRIPTION
Network create now uses the ipam driver. This allows the user to
configure the ipam driver manually instead of choosing a fixed default.
If the ipam driver is `none` no ips will be assigned to this container.
This means that only the interfaces are created.

This will require a patch in netavark since it rejects the config when
no static ips are provided.

Ref https://github.com/containers/podman/issues/13521