### PR TITLE
go fmt: use go 1.18 conditional-build syntax

### DIFF
--- a/cmd/seccomp/generate.go
+++ b/cmd/seccomp/generate.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main

--- a/libnetwork/cni/cni_conversion.go
+++ b/libnetwork/cni/cni_conversion.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cni

--- a/libnetwork/cni/cni_exec.go
+++ b/libnetwork/cni/cni_exec.go
@@ -16,6 +16,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build linux
 // +build linux
 
 package cni

--- a/libnetwork/cni/cni_suite_test.go
+++ b/libnetwork/cni/cni_suite_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cni_test

--- a/libnetwork/cni/cni_types.go
+++ b/libnetwork/cni/cni_types.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cni

--- a/libnetwork/cni/config.go
+++ b/libnetwork/cni/config.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cni

--- a/libnetwork/cni/config_test.go
+++ b/libnetwork/cni/config_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cni_test

--- a/libnetwork/cni/network.go
+++ b/libnetwork/cni/network.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cni

--- a/libnetwork/cni/run.go
+++ b/libnetwork/cni/run.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cni

--- a/libnetwork/cni/run_test.go
+++ b/libnetwork/cni/run_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cni_test

--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netavark

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netavark_test

--- a/libnetwork/netavark/const.go
+++ b/libnetwork/netavark/const.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netavark

--- a/libnetwork/netavark/exec.go
+++ b/libnetwork/netavark/exec.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netavark

--- a/libnetwork/netavark/ipam.go
+++ b/libnetwork/netavark/ipam.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netavark

--- a/libnetwork/netavark/ipam_test.go
+++ b/libnetwork/netavark/ipam_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netavark

--- a/libnetwork/netavark/netavark_suite_test.go
+++ b/libnetwork/netavark/netavark_suite_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netavark_test

--- a/libnetwork/netavark/network.go
+++ b/libnetwork/netavark/network.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netavark

--- a/libnetwork/netavark/run.go
+++ b/libnetwork/netavark/run.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netavark

--- a/libnetwork/netavark/run_test.go
+++ b/libnetwork/netavark/run_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netavark_test

--- a/libnetwork/network/interface.go
+++ b/libnetwork/network/interface.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package network

--- a/pkg/apparmor/apparmor_linux.go
+++ b/pkg/apparmor/apparmor_linux.go
@@ -1,3 +1,4 @@
+//go:build linux && apparmor
 // +build linux,apparmor
 
 package apparmor

--- a/pkg/apparmor/apparmor_linux_template.go
+++ b/pkg/apparmor/apparmor_linux_template.go
@@ -1,3 +1,4 @@
+//go:build linux && apparmor
 // +build linux,apparmor
 
 package apparmor

--- a/pkg/apparmor/apparmor_linux_test.go
+++ b/pkg/apparmor/apparmor_linux_test.go
@@ -1,3 +1,4 @@
+//go:build linux && apparmor
 // +build linux,apparmor
 
 package apparmor

--- a/pkg/apparmor/apparmor_unsupported.go
+++ b/pkg/apparmor/apparmor_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux || !apparmor
 // +build !linux !apparmor
 
 package apparmor

--- a/pkg/cgroups/cgroups_supported.go
+++ b/pkg/cgroups/cgroups_supported.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cgroups

--- a/pkg/cgroups/cgroups_unsupported.go
+++ b/pkg/cgroups/cgroups_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package cgroups

--- a/pkg/cgroupv2/cgroups_unsupported.go
+++ b/pkg/cgroupv2/cgroups_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package cgroupv2

--- a/pkg/chown/chown_unix.go
+++ b/pkg/chown/chown_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package chown

--- a/pkg/config/config_local.go
+++ b/pkg/config/config_local.go
@@ -1,3 +1,4 @@
+//go:build !remote
 // +build !remote
 
 package config

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -1,3 +1,4 @@
+//go:build !remote
 // +build !remote
 
 package config

--- a/pkg/config/config_remote.go
+++ b/pkg/config/config_remote.go
@@ -1,3 +1,4 @@
+//go:build remote
 // +build remote
 
 package config

--- a/pkg/config/config_remote_test.go
+++ b/pkg/config/config_remote_test.go
@@ -1,3 +1,4 @@
+//go:build remote
 // +build remote
 
 package config

--- a/pkg/config/config_unsupported.go
+++ b/pkg/config/config_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package config

--- a/pkg/config/default_unsupported.go
+++ b/pkg/config/default_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows
 // +build !linux,!windows
 
 package config

--- a/pkg/config/nosystemd.go
+++ b/pkg/config/nosystemd.go
@@ -1,3 +1,4 @@
+//go:build !systemd || !cgo
 // +build !systemd !cgo
 
 package config

--- a/pkg/config/systemd.go
+++ b/pkg/config/systemd.go
@@ -1,3 +1,4 @@
+//go:build systemd && cgo
 // +build systemd,cgo
 
 package config

--- a/pkg/parse/parse_unix.go
+++ b/pkg/parse/parse_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package parse

--- a/pkg/retry/retry_unsupported.go
+++ b/pkg/retry/retry_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package retry

--- a/pkg/seccomp/errno_list.go
+++ b/pkg/seccomp/errno_list.go
@@ -1,3 +1,4 @@
+//go:build linux && seccomp
 // +build linux,seccomp
 
 package seccomp

--- a/pkg/seccomp/filter.go
+++ b/pkg/seccomp/filter.go
@@ -1,3 +1,4 @@
+//go:build seccomp
 // +build seccomp
 
 // NOTE: this package has originally been copied from

--- a/pkg/seccomp/filter_test.go
+++ b/pkg/seccomp/filter_test.go
@@ -1,3 +1,4 @@
+//go:build seccomp
 // +build seccomp
 
 package seccomp

--- a/pkg/seccomp/generate.go
+++ b/pkg/seccomp/generate.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 // Copyright 2013-2021 Docker, Inc.

--- a/pkg/seccomp/seccomp_test.go
+++ b/pkg/seccomp/seccomp_test.go
@@ -1,3 +1,4 @@
+//go:build seccomp
 // +build seccomp
 
 // SPDX-License-Identifier: Apache-2.0

--- a/pkg/seccomp/seccomp_unsupported.go
+++ b/pkg/seccomp/seccomp_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux || !seccomp
 // +build !linux !seccomp
 
 // SPDX-License-Identifier: Apache-2.0

--- a/pkg/seccomp/supported.go
+++ b/pkg/seccomp/supported.go
@@ -1,3 +1,4 @@
+//go:build linux && seccomp
 // +build linux,seccomp
 
 package seccomp

--- a/pkg/seccomp/validate.go
+++ b/pkg/seccomp/validate.go
@@ -1,3 +1,4 @@
+//go:build seccomp
 // +build seccomp
 
 package seccomp

--- a/pkg/seccomp/validate_test.go
+++ b/pkg/seccomp/validate_test.go
@@ -1,3 +1,4 @@
+//go:build seccomp
 // +build seccomp
 
 package seccomp

--- a/pkg/signal/signal_linux.go
+++ b/pkg/signal/signal_linux.go
@@ -1,5 +1,5 @@
-// +build linux
-// +build !mips,!mipsle,!mips64,!mips64le
+//go:build linux && !mips && !mipsle && !mips64 && !mips64le
+// +build linux,!mips,!mipsle,!mips64,!mips64le
 
 // Signal handling for Linux only.
 package signal

--- a/pkg/signal/signal_linux_mipsx.go
+++ b/pkg/signal/signal_linux_mipsx.go
@@ -1,3 +1,4 @@
+//go:build linux && (mips || mipsle || mips64 || mips64le)
 // +build linux
 // +build mips mipsle mips64 mips64le
 

--- a/pkg/signal/signal_unsupported.go
+++ b/pkg/signal/signal_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 // Signal handling for Linux only.

--- a/pkg/sysinfo/numcpu.go
+++ b/pkg/sysinfo/numcpu.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows
 // +build !linux,!windows
 
 package sysinfo

--- a/pkg/sysinfo/numcpu_linux.go
+++ b/pkg/sysinfo/numcpu_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package sysinfo

--- a/pkg/sysinfo/numcpu_windows.go
+++ b/pkg/sysinfo/numcpu_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package sysinfo

--- a/pkg/sysinfo/nummem_linux.go
+++ b/pkg/sysinfo/nummem_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package sysinfo

--- a/pkg/sysinfo/nummem_unsupported.go
+++ b/pkg/sysinfo/nummem_unsupported.go
@@ -1,4 +1,5 @@
-// +build windows, osx
+//go:build (windows && ignore) || osx
+// +build windows,ignore osx
 
 package sysinfo
 

--- a/pkg/sysinfo/sysinfo_solaris.go
+++ b/pkg/sysinfo/sysinfo_solaris.go
@@ -1,3 +1,4 @@
+//go:build solaris && cgo
 // +build solaris,cgo
 
 package sysinfo

--- a/pkg/sysinfo/sysinfo_unix.go
+++ b/pkg/sysinfo/sysinfo_unix.go
@@ -1,3 +1,4 @@
+//go:build !linux && !solaris && !windows
 // +build !linux,!solaris,!windows
 
 package sysinfo

--- a/pkg/sysinfo/sysinfo_windows.go
+++ b/pkg/sysinfo/sysinfo_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package sysinfo

--- a/pkg/umask/umask_unix.go
+++ b/pkg/umask/umask_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package umask

--- a/pkg/umask/umask_unsupported.go
+++ b/pkg/umask/umask_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux && !darwin
 // +build !linux,!darwin
 
 package umask

--- a/pkg/util/util_supported.go
+++ b/pkg/util/util_supported.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package util

--- a/pkg/util/util_windows.go
+++ b/pkg/util/util_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package util


### PR DESCRIPTION
Also bump golangci-lint to v1.44.2. It still doesn't run correctly on go 1.18 so I didn't test it.

**Update**: removed the commit to bump golangci-lint