### PR TITLE
Revert "Allow rootless containers to use AppArmor profiles"

### DIFF
--- a/pkg/apparmor/apparmor.go
+++ b/pkg/apparmor/apparmor.go
@@ -17,4 +17,6 @@ const (
 var (
 	// ErrApparmorUnsupported indicates that AppArmor support is not supported.
 	ErrApparmorUnsupported = errors.New("AppArmor is not supported")
+	// ErrApparmorRootless indicates that AppArmor support is not supported in rootless mode.
+	ErrApparmorRootless = errors.New("AppArmor is not supported in rootless mode")
 )

--- a/pkg/apparmor/apparmor_linux.go
+++ b/pkg/apparmor/apparmor_linux.go
@@ -15,6 +15,7 @@ import (
 	"text/template"
 
 	"github.com/containers/common/pkg/apparmor/internal/supported"
+	"github.com/containers/storage/pkg/unshare"
 	runcaa "github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -77,6 +78,10 @@ func macroExists(m string) bool {
 // InstallDefault generates a default profile and loads it into the kernel
 // using 'apparmor_parser'.
 func InstallDefault(name string) error {
+	if unshare.IsRootless() {
+		return ErrApparmorRootless
+	}
+
 	p := profileData{
 		Name: name,
 	}
@@ -133,9 +138,12 @@ func DefaultContent(name string) ([]byte, error) {
 }
 
 // IsLoaded checks if a profile with the given name has been loaded into the
-// kernel. This function checks for the existence of a profile by reading
-// /sys/kernel/security/apparmor/profiles, and hence requires root permissions.
+// kernel.
 func IsLoaded(name string) (bool, error) {
+	if name != "" && unshare.IsRootless() {
+		return false, errors.Wrapf(ErrApparmorRootless, "cannot load AppArmor profile %q", name)
+	}
+
 	file, err := os.Open("/sys/kernel/security/apparmor/profiles")
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -231,11 +239,23 @@ func parseAAParserVersion(output string) (int, error) {
 // CheckProfileAndLoadDefault checks if the specified profile is loaded and
 // loads the DefaultLibpodProfile if the specified on is prefixed by
 // DefaultLipodProfilePrefix.  This allows to always load and apply the latest
-// default AppArmor profile. If it's a default profile, return
-// DefaultLipodProfilePrefix, otherwise the specified one.
+// default AppArmor profile.  Note that AppArmor requires root.  If it's a
+// default profile, return DefaultLipodProfilePrefix, otherwise the specified
+// one.
 func CheckProfileAndLoadDefault(name string) (string, error) {
 	if name == "unconfined" {
 		return name, nil
+	}
+
+	// AppArmor is not supported in rootless mode as it requires root
+	// privileges.  Return an error in case a specific profile is specified.
+	if unshare.IsRootless() {
+		if name != "" {
+			return "", errors.Wrapf(ErrApparmorRootless, "cannot load AppArmor profile %q", name)
+		} else {
+			logrus.Debug("Skipping loading default AppArmor profile (rootless mode)")
+			return "", nil
+		}
 	}
 
 	// Check if AppArmor is disabled and error out if a profile is to be set.
@@ -252,6 +272,13 @@ func CheckProfileAndLoadDefault(name string) (string, error) {
 	} else if !strings.HasPrefix(name, ProfilePrefix) {
 		// If the specified name is not a default one, ignore it and return the
 		// name.
+		isLoaded, err := IsLoaded(name)
+		if err != nil {
+			return "", errors.Wrapf(err, "verify if profile %s is loaded", name)
+		}
+		if !isLoaded {
+			return "", errors.Errorf("AppArmor profile %q specified but not loaded", name)
+		}
 		return name, nil
 	}
 

--- a/pkg/apparmor/internal/supported/supported.go
+++ b/pkg/apparmor/internal/supported/supported.go
@@ -40,6 +40,9 @@ func NewAppArmorVerifier() *ApparmorVerifier {
 // - AppArmor is disabled by the host system
 // - the `apparmor_parser` binary is not discoverable
 func (a *ApparmorVerifier) IsSupported() error {
+	if a.impl.UnshareIsRootless() {
+		return errors.New("AppAmor is not supported on rootless containers")
+	}
 	if !a.impl.RuncIsEnabled() {
 		return errors.New("AppArmor not supported by the host system")
 	}


### PR DESCRIPTION
This reverts commit 55d217f7dd9ef4721cf32b32d0d8b8b029e877b3 since
it does not pass Podman CI (i.e., the rootless Ubuntu job fails).

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

@containers/podman-maintainers PTAL

@kernelmethod, we need to (temporarily) revert your previous changes as they are not passing Podman's CI.
