### PR TITLE
Add ptrace as a default seccomp allow to match Docker

### DIFF
--- a/pkg/seccomp/default_linux.go
+++ b/pkg/seccomp/default_linux.go
@@ -169,6 +169,7 @@ func DefaultProfile() *Seccomp {
 				"futex",
 				"futex_time64",
 				"futimesat",
+				"get_mempolicy",
 				"get_robust_list",
 				"get_thread_area",
 				"getcpu",
@@ -184,7 +185,6 @@ func DefaultProfile() *Seccomp {
 				"getgroups",
 				"getgroups32",
 				"getitimer",
-				"get_mempolicy",
 				"getpeername",
 				"getpgid",
 				"getpgrp",
@@ -274,9 +274,9 @@ func DefaultProfile() *Seccomp {
 				"nanosleep",
 				"newfstatat",
 				"open",
+				"open_tree",
 				"openat",
 				"openat2",
-				"open_tree",
 				"pause",
 				"pidfd_getfd",
 				"pidfd_open",
@@ -296,8 +296,11 @@ func DefaultProfile() *Seccomp {
 				"preadv2",
 				"prlimit64",
 				"process_mrelease",
+				"process_vm_readv",
+				"process_vm_writev",
 				"pselect6",
 				"pselect6_time64",
+				"ptrace",
 				"pwrite64",
 				"pwritev",
 				"pwritev2",
@@ -356,7 +359,6 @@ func DefaultProfile() *Seccomp {
 				"sendmmsg",
 				"sendmsg",
 				"sendto",
-				"setns",
 				"set_mempolicy",
 				"set_robust_list",
 				"set_thread_area",
@@ -370,6 +372,7 @@ func DefaultProfile() *Seccomp {
 				"setgroups",
 				"setgroups32",
 				"setitimer",
+				"setns",
 				"setpgid",
 				"setpriority",
 				"setregid",
@@ -527,10 +530,10 @@ func DefaultProfile() *Seccomp {
 			Names: []string{
 				"arm_fadvise64_64",
 				"arm_sync_file_range",
-				"sync_file_range2",
 				"breakpoint",
 				"cacheflush",
 				"set_tls",
+				"sync_file_range2",
 			},
 			Action: ActAllow,
 			Args:   []*Arg{},
@@ -653,8 +656,8 @@ func DefaultProfile() *Seccomp {
 		{
 			Names: []string{
 				"delete_module",
-				"init_module",
 				"finit_module",
+				"init_module",
 				"query_module",
 			},
 			Action: ActAllow,
@@ -666,8 +669,8 @@ func DefaultProfile() *Seccomp {
 		{
 			Names: []string{
 				"delete_module",
-				"init_module",
 				"finit_module",
+				"init_module",
 				"query_module",
 			},
 			Action:   ActErrno,
@@ -704,9 +707,6 @@ func DefaultProfile() *Seccomp {
 			Names: []string{
 				"kcmp",
 				"process_madvise",
-				"process_vm_readv",
-				"process_vm_writev",
-				"ptrace",
 			},
 			Action: ActAllow,
 			Args:   []*Arg{},
@@ -718,9 +718,6 @@ func DefaultProfile() *Seccomp {
 			Names: []string{
 				"kcmp",
 				"process_madvise",
-				"process_vm_readv",
-				"process_vm_writev",
-				"ptrace",
 			},
 			Action:   ActErrno,
 			Errno:    "EPERM",
@@ -732,8 +729,8 @@ func DefaultProfile() *Seccomp {
 		},
 		{
 			Names: []string{
-				"iopl",
 				"ioperm",
+				"iopl",
 			},
 			Action: ActAllow,
 			Args:   []*Arg{},
@@ -743,8 +740,8 @@ func DefaultProfile() *Seccomp {
 		},
 		{
 			Names: []string{
-				"iopl",
 				"ioperm",
+				"iopl",
 			},
 			Action:   ActErrno,
 			Errno:    "EPERM",
@@ -756,10 +753,10 @@ func DefaultProfile() *Seccomp {
 		},
 		{
 			Names: []string{
-				"settimeofday",
-				"stime",
 				"clock_settime",
 				"clock_settime64",
+				"settimeofday",
+				"stime",
 			},
 			Action: ActAllow,
 			Args:   []*Arg{},
@@ -769,10 +766,10 @@ func DefaultProfile() *Seccomp {
 		},
 		{
 			Names: []string{
-				"settimeofday",
-				"stime",
 				"clock_settime",
 				"clock_settime64",
+				"settimeofday",
+				"stime",
 			},
 			Action:   ActErrno,
 			Errno:    "EPERM",

--- a/pkg/seccomp/seccomp.json
+++ b/pkg/seccomp/seccomp.json
@@ -176,6 +176,7 @@
 				"futex",
 				"futex_time64",
 				"futimesat",
+				"get_mempolicy",
 				"get_robust_list",
 				"get_thread_area",
 				"getcpu",
@@ -191,7 +192,6 @@
 				"getgroups",
 				"getgroups32",
 				"getitimer",
-				"get_mempolicy",
 				"getpeername",
 				"getpgid",
 				"getpgrp",
@@ -281,9 +281,9 @@
 				"nanosleep",
 				"newfstatat",
 				"open",
+				"open_tree",
 				"openat",
 				"openat2",
-				"open_tree",
 				"pause",
 				"pidfd_getfd",
 				"pidfd_open",
@@ -303,8 +303,11 @@
 				"preadv2",
 				"prlimit64",
 				"process_mrelease",
+				"process_vm_readv",
+				"process_vm_writev",
 				"pselect6",
 				"pselect6_time64",
+				"ptrace",
 				"pwrite64",
 				"pwritev",
 				"pwritev2",
@@ -363,7 +366,6 @@
 				"sendmmsg",
 				"sendmsg",
 				"sendto",
-				"setns",
 				"set_mempolicy",
 				"set_robust_list",
 				"set_thread_area",
@@ -377,6 +379,7 @@
 				"setgroups",
 				"setgroups32",
 				"setitimer",
+				"setns",
 				"setpgid",
 				"setpriority",
 				"setregid",
@@ -571,10 +574,10 @@
 			"names": [
 				"arm_fadvise64_64",
 				"arm_sync_file_range",
-				"sync_file_range2",
 				"breakpoint",
 				"cacheflush",
-				"set_tls"
+				"set_tls",
+				"sync_file_range2"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [],
@@ -742,8 +745,8 @@
 		{
 			"names": [
 				"delete_module",
-				"init_module",
 				"finit_module",
+				"init_module",
 				"query_module"
 			],
 			"action": "SCMP_ACT_ALLOW",
@@ -759,8 +762,8 @@
 		{
 			"names": [
 				"delete_module",
-				"init_module",
 				"finit_module",
+				"init_module",
 				"query_module"
 			],
 			"action": "SCMP_ACT_ERRNO",
@@ -808,10 +811,7 @@
 		{
 			"names": [
 				"kcmp",
-				"process_madvise",
-				"process_vm_readv",
-				"process_vm_writev",
-				"ptrace"
+				"process_madvise"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [],
@@ -826,10 +826,7 @@
 		{
 			"names": [
 				"kcmp",
-				"process_madvise",
-				"process_vm_readv",
-				"process_vm_writev",
-				"ptrace"
+				"process_madvise"
 			],
 			"action": "SCMP_ACT_ERRNO",
 			"args": [],
@@ -845,8 +842,8 @@
 		},
 		{
 			"names": [
-				"iopl",
-				"ioperm"
+				"ioperm",
+				"iopl"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [],
@@ -860,8 +857,8 @@
 		},
 		{
 			"names": [
-				"iopl",
-				"ioperm"
+				"ioperm",
+				"iopl"
 			],
 			"action": "SCMP_ACT_ERRNO",
 			"args": [],
@@ -877,10 +874,10 @@
 		},
 		{
 			"names": [
-				"settimeofday",
-				"stime",
 				"clock_settime",
-				"clock_settime64"
+				"clock_settime64",
+				"settimeofday",
+				"stime"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [],
@@ -894,10 +891,10 @@
 		},
 		{
 			"names": [
-				"settimeofday",
-				"stime",
 				"clock_settime",
-				"clock_settime64"
+				"clock_settime64",
+				"settimeofday",
+				"stime"
 			],
 			"action": "SCMP_ACT_ERRNO",
 			"args": [],


### PR DESCRIPTION
Also sort all syscalls in alphabetic order.

Fixes: https://github.com/containers/buildah/issues/3833

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
