### PR TITLE
pkg/config: events_logfile_max_size add omitzero

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -251,7 +251,7 @@ type EngineConfig struct {
 
 	// EventsLogFileMaxSize sets the maximum size for the events log. When the limit is exceeded,
 	// the logfile is rotated and the old one is deleted.
-	EventsLogFileMaxSize uint64 `toml:"events_logfile_max_size,omitempty"`
+	EventsLogFileMaxSize uint64 `toml:"events_logfile_max_size,omitempty,omitzero"`
 
 	// EventsLogger determines where events should be logged.
 	EventsLogger string `toml:"events_logger,omitempty"`


### PR DESCRIPTION
Number types must use omitzero otherwise they are included in the toml
file when it is written and the value is 0, see commit 2f22f3dec91d.

