### PR TITLE
libimage: import should not ignore configured `variant` in `ImportOptions`

### DIFF
--- a/libimage/import.go
+++ b/libimage/import.go
@@ -58,6 +58,7 @@ func (r *Runtime) Import(ctx context.Context, path string, options *ImportOption
 		History:      hist,
 		OS:           options.OS,
 		Architecture: options.Arch,
+		Variant:      options.Variant,
 	}
 
 	u, err := url.ParseRequestURI(path)


### PR DESCRIPTION
[Image-spec](https://github.com/opencontainers/image-spec/blob/main/specs-go/v1/config.go#L93) already supports variant and if `ImportOptions` contains
any configured `Variant` it should be set on the imported image as well.

What does this fix:

Allows `podman import --variant <something> some.tar image-name` to
become functional from `no-op`

Ref: https://github.com/opencontainers/image-spec/blob/main/specs-go/v1/config.go#L93
