### PR TITLE
Add homedir option to passdriver

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,7 +51,6 @@ testing_task:
     NETAVARK_BINARY: "${NETAVARK_DIRPATH}/netavark"  # unit-tests sensitive to this
   setup_script:
     - mkdir "$GOLANGCI_LINT_CACHE"
-    - gpg --batch --passphrase '' --quick-gen-key tester@localhost default default never
     # TODO: Remove this when netavark is installed by RPM in VM images
     - curl --fail --location -o /tmp/netavark.zip "https://api.cirrus-ci.com/v1/artifact/github/containers/netavark/success/binary.zip?branch=${NETAVARK_BRANCH}"
     - mkdir -vp "${NETAVARK_DIRPATH}"

--- a/pkg/secrets/passdriver/passdriver.go
+++ b/pkg/secrets/passdriver/passdriver.go
@@ -30,6 +30,8 @@ type driverConfig struct {
 	Root string
 	// KeyID contains the key id that will be used for encryption (i.e. user@domain.tld)
 	KeyID string
+	// GPGHomedir is the homedir where the GPG keys are stored
+	GPGHomedir string
 }
 
 func (cfg *driverConfig) ParseOpts(opts map[string]string) {
@@ -39,6 +41,9 @@ func (cfg *driverConfig) ParseOpts(opts map[string]string) {
 	}
 	if val, ok := opts["key"]; ok {
 		cfg.KeyID = val
+	}
+	if val, ok := opts["gpghomedir"]; ok {
+		cfg.GPGHomedir = val
 	}
 }
 
@@ -156,6 +161,9 @@ func (d *Driver) Delete(id string) error {
 }
 
 func (d *Driver) gpg(ctx context.Context, in io.Reader, out io.Writer, args ...string) error {
+	if d.GPGHomedir != "" {
+		args = append([]string{"--homedir", d.GPGHomedir}, args...)
+	}
 	cmd := exec.CommandContext(ctx, "gpg", args...)
 	cmd.Env = os.Environ()
 	cmd.Stdin = in

--- a/pkg/secrets/passdriver/passdriver_test.go
+++ b/pkg/secrets/passdriver/passdriver_test.go
@@ -1,6 +1,7 @@
 package passdriver
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -9,17 +10,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const gpgTestID = "tester@localhost"
+const gpgTestID = "testing@passdriver"
 
 func setupDriver(t *testing.T) (driver *Driver, cleanup func()) {
 	base, err := ioutil.TempDir(os.TempDir(), "pass-test")
 	require.NoError(t, err)
+	gpghomedir, err := ioutil.TempDir(os.TempDir(), "gpg-dir")
+	require.NoError(t, err)
+
 	driver, err = NewDriver(map[string]string{
-		"root": base,
-		"key":  gpgTestID,
+		"root":       base,
+		"key":        gpgTestID,
+		"gpghomedir": gpghomedir,
 	})
 	require.NoError(t, err)
-	return driver, func() { os.RemoveAll(base) }
+
+	driver.gpg(context.TODO(), nil, nil, "--batch", "--passphrase", "--quick-generate-key", "testing@passdriver")
+	return driver, func() {
+		os.RemoveAll(base)
+		os.RemoveAll(gpghomedir)
+	}
 }
 
 func TestStoreAndLookup(t *testing.T) {


### PR DESCRIPTION
GPG has a homedir option that allows for placing the gpg keys in
different locations. This is especially useful for testing, where we can
create a GPG key in a tmp dir, without worrying about it affecting other
keys the user may have.

Fixes passdriver tests too.

Fixes: #750

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
