### PR TITLE
libnetwork: ipam driver none disable dns

### DIFF
--- a/libnetwork/cni/config.go
+++ b/libnetwork/cni/config.go
@@ -96,6 +96,9 @@ func (n *cniNetwork) networkCreate(newNetwork *types.Network, defaultNet bool) (
 	// generate the network ID
 	newNetwork.ID = getNetworkIDFromName(newNetwork.Name)
 
+	// when we do not have ipam we must disable dns
+	internalutil.IpamNoneDisableDns(newNetwork)
+
 	// FIXME: Should this be a hard error?
 	if newNetwork.DNSEnabled && newNetwork.Internal && hasDNSNamePlugin(n.cniPluginDirs) {
 		logrus.Warnf("dnsname and internal networks are incompatible. dnsname plugin not configured for network %s", newNetwork.Name)

--- a/libnetwork/cni/config_test.go
+++ b/libnetwork/cni/config_test.go
@@ -173,10 +173,12 @@ var _ = Describe("Config", func() {
 				IPAMOptions: map[string]string{
 					"driver": "none",
 				},
+				DNSEnabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network)
 			Expect(err).To(BeNil())
 			Expect(network1.Driver).To(Equal("bridge"))
+			Expect(network1.DNSEnabled).To(BeFalse())
 			Expect(network1.IPAMOptions).ToNot(BeEmpty())
 			Expect(network1.IPAMOptions).To(HaveKeyWithValue("driver", "none"))
 			Expect(network1.Subnets).To(HaveLen(0))

--- a/libnetwork/cni/run_test.go
+++ b/libnetwork/cni/run_test.go
@@ -837,6 +837,7 @@ var _ = Describe("run CNI", func() {
 					IPAMOptions: map[string]string{
 						types.Driver: types.NoneIPAMDriver,
 					},
+					DNSEnabled: true,
 				}
 				network1, err := libpodNet.NetworkCreate(network)
 				Expect(err).To(BeNil())

--- a/libnetwork/internal/util/create.go
+++ b/libnetwork/internal/util/create.go
@@ -3,6 +3,7 @@ package util
 import (
 	"github.com/containers/common/libnetwork/types"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 func CommonNetworkCreate(n NetUtil, network *types.Network) error {
@@ -38,4 +39,11 @@ func CommonNetworkCreate(n NetUtil, network *types.Network) error {
 		}
 	}
 	return nil
+}
+
+func IpamNoneDisableDns(network *types.Network) {
+	if network.IPAMOptions[types.Driver] == types.NoneIPAMDriver {
+		logrus.Debugf("dns disabled for network %q because ipam driver is set to none", network.Name)
+		network.DNSEnabled = false
+	}
 }

--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -121,6 +121,9 @@ func (n *netavarkNetwork) networkCreate(newNetwork *types.Network, defaultNet bo
 		return nil, errors.Wrapf(types.ErrInvalidArg, "unsupported driver %s", newNetwork.Driver)
 	}
 
+	// when we do not have ipam we must disable dns
+	internalutil.IpamNoneDisableDns(newNetwork)
+
 	// add gateway when not internal or dns enabled
 	addGateway := !newNetwork.Internal || newNetwork.DNSEnabled
 	err = internalutil.ValidateSubnets(newNetwork, addGateway, usedNetworks)

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -1003,10 +1003,12 @@ var _ = Describe("Config", func() {
 				IPAMOptions: map[string]string{
 					"driver": "none",
 				},
+				DNSEnabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network)
 			Expect(err).To(BeNil())
 			Expect(network1.Driver).To(Equal("macvlan"))
+			Expect(network1.DNSEnabled).To(BeFalse())
 			Expect(network1.IPAMOptions).ToNot(BeEmpty())
 			Expect(network1.IPAMOptions).To(HaveKeyWithValue("driver", "none"))
 			Expect(network1.Subnets).To(HaveLen(0))

--- a/libnetwork/netavark/run_test.go
+++ b/libnetwork/netavark/run_test.go
@@ -707,6 +707,7 @@ var _ = Describe("run netavark", func() {
 				IPAMOptions: map[string]string{
 					types.Driver: types.NoneIPAMDriver,
 				},
+				DNSEnabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network)
 			Expect(err).To(BeNil())


### PR DESCRIPTION
When we create a network with the ipam driver none we should disabled
dns automatically. Since we mange no ips we cannot provide name
resolution anyway.

This fixes a problem I spotted when adding test to the podman CI.


<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
