### PR TITLE
CI: add codespell job to GHA

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = ./vendor,./.git #,bin,vendor,.git,go.sum,changelog.txt,.cirrus.yml,"RELEASE_NOTES.md,*.xz,*.gz,*.tar,*.tgz,bin2img,*ico,*.png,*.1,*.5,copyimg,*.orig,apidoc.go"
+ignore-words-list = clos,creat
+

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,20 @@
+name: validate
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+      - v*
+  pull_request:
+
+jobs:
+  codespell:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: install deps
+      # Version of codespell bundled with Ubuntu is way old, so use pip.
+      run: pip install codespell
+    - name: run codespell
+      run: codespell

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ test-unit:
 
 .PHONY: codespell
 codespell:
-	codespell -S bin,vendor,.git,go.sum,changelog.txt,.cirrus.yml,"RELEASE_NOTES.md,*.xz,*.gz,*.tar,*.tgz,bin2img,*ico,*.png,*.1,*.5,copyimg,*.orig,apidoc.go" -L creat,uint,iff,od,seeked,splitted,marge,ERROR,hist,ether -w
+	codespell -w
 
 clean: ## Clean artifacts
 	$(MAKE) -C docs clean

--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -590,7 +590,7 @@ Number of seconds to wait for container to exit before sending kill signal.
 
 **exit_command_delay**=300
 
-Number of seconds to wait for the API process for the exec call before sending exit command mimicing the Docker behavior of 5 minutes (in seconds).
+Number of seconds to wait for the API process for the exec call before sending exit command mimicking the Docker behavior of 5 minutes (in seconds).
 
 **tmp_dir**="/run/libpod"
 

--- a/libimage/import.go
+++ b/libimage/import.go
@@ -49,13 +49,13 @@ func (r *Runtime) Import(ctx context.Context, path string, options *ImportOption
 		ic = config.ImageConfig
 	}
 
-	hist := []v1.History{
+	history := []v1.History{
 		{Comment: options.CommitMessage},
 	}
 
 	config := v1.Image{
 		Config:       ic,
-		History:      hist,
+		History:      history,
 		OS:           options.OS,
 		Architecture: options.Arch,
 		Variant:      options.Variant,

--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -121,7 +121,7 @@ func (n *netavarkNetwork) networkCreate(newNetwork *types.Network, defaultNet bo
 		return nil, errors.Wrapf(types.ErrInvalidArg, "unsupported driver %s", newNetwork.Driver)
 	}
 
-	// add gatway when not internal or dns enabled
+	// add gateway when not internal or dns enabled
 	addGateway := !newNetwork.Internal || newNetwork.DNSEnabled
 	err = internalutil.ValidateSubnets(newNetwork, addGateway, usedNetworks)
 	if err != nil {

--- a/libnetwork/netavark/network.go
+++ b/libnetwork/netavark/network.go
@@ -245,7 +245,7 @@ func parseNetwork(network *types.Network) error {
 		return errors.Errorf("invalid network ID %q", network.ID)
 	}
 
-	// add gatway when not internal or dns enabled
+	// add gateway when not internal or dns enabled
 	addGateway := !network.Internal || network.DNSEnabled
 	return util.ValidateSubnets(network, addGateway, nil)
 }

--- a/pkg/report/camelcase/README.md
+++ b/pkg/report/camelcase/README.md
@@ -27,9 +27,9 @@ go get github.com/fatih/camelcase
 ## Usage and examples
 
 ```go
-splitted := camelcase.Split("GolangPackage")
+split := camelcase.Split("GolangPackage")
 
-fmt.Println(splitted[0], splitted[1]) // prints: "Golang", "Package"
+fmt.Println(split[0], split[1]) // prints: "Golang", "Package"
 ```
 
 Both lower camel case and upper camel case are supported. For more info please


### PR DESCRIPTION
Apparently we do have codespell target in Makefile, but it is not used by any CI.

Fix all issues found by codespell, and create a small GHA CI job to run it for all PRs, branches and tags.