### PR TITLE
V0.48.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.47.4+dev"
+const Version = "0.48.0"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.48.0"
+const Version = "0.48.1+dev"


### PR DESCRIPTION
As the title says.  This release will be used with upstream
after RHEL 8.6/9.0.  This change is needed to get Buildah/Podman
on the same version of c/common in order to address a CVE.

[NO NEW TESTS NEEDED]
