### PR TITLE
Makefile: simplify for modern Go

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,7 @@ env:
 
 
 # Default, hard-coded max timeout is 2-hours.
-timeout_in: 30m  # no need to wait 2-hours before timing out
+timeout_in: 60m  # no need to wait 2-hours before timing out
 
 gcp_credentials: ENCRYPTED[dd6a042d1805167e38d8b79494f691b86637e68f072eba24220901435afd8d71c63f9006803142447326319102f68b7f]
 


### PR DESCRIPTION
Quite a few changes, mostly removing old stuff though.

1. "GO111MODULE=off" is no longer required to be set by default (and
   it used to be overridden below anyway).

2. "go build" no longer requires explicit "-mod=vendor", as this is the
   default since go 1.14.

3. GOPROXY is set to proxy.golang.org by default since go 1.13.

4. Always use default GOPATH (which is $HOME/go since Go 1.8; earlier
   releases needed to set it explicitly).

5. Drop the code that handles multiple comma-separated GOPATH elements
   (when using modules, GOPATH is no longer used for resolving imports,
   which basically means using multiple paths is useless).

6. Drop go-get macro (which is used to install md2man), use go install
       directly (supported since Go 1.16). While at it, do not check if
       go-md2man is available, install it unconditionally. This removes
       the need to have GOBIN make variable.


7. Remove GOPKGBASEDIR and GOPKGBASEDIR, defined by Makefile, were never
   used.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
