### PR TITLE
selinux: revert to v1.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/opencontainers/runc v1.1.0
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/opencontainers/runtime-tools v0.9.0
-	github.com/opencontainers/selinux v1.10.1
+	github.com/opencontainers/selinux v1.10.0
 	github.com/pkg/errors v0.9.1
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -851,9 +851,8 @@ github.com/opencontainers/runtime-tools v0.9.0/go.mod h1:r3f7wjNzSs2extwzU3Y+6pK
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
+github.com/opencontainers/selinux v1.10.0 h1:rAiKF8hTcgLI3w0DHm6i0ylVVcOrlgR1kK99DRLDhyU=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
-github.com/opencontainers/selinux v1.10.1 h1:09LIPVRP3uuZGQvgR+SgMSNBd1Eb3vlRbGqQpoHsF8w=
-github.com/opencontainers/selinux v1.10.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=

--- a/vendor/github.com/opencontainers/selinux/go-selinux/rchcon.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/rchcon.go
@@ -12,7 +12,7 @@ import (
 
 func rchcon(fpath, label string) error {
 	return pwalkdir.Walk(fpath, func(p string, _ fs.DirEntry, _ error) error {
-		e := lSetFileLabel(p, label)
+		e := setFileLabel(p, label)
 		// Walk a file tree can race with removal, so ignore ENOENT.
 		if errors.Is(e, os.ErrNotExist) {
 			return nil

--- a/vendor/github.com/opencontainers/selinux/go-selinux/rchcon_go115.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/rchcon_go115.go
@@ -11,7 +11,7 @@ import (
 
 func rchcon(fpath, label string) error {
 	return pwalk.Walk(fpath, func(p string, _ os.FileInfo, _ error) error {
-		e := lSetFileLabel(p, label)
+		e := setFileLabel(p, label)
 		// Walk a file tree can race with removal, so ignore ENOENT.
 		if errors.Is(e, os.ErrNotExist) {
 			return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -359,7 +359,7 @@ github.com/opencontainers/runtime-tools/generate
 github.com/opencontainers/runtime-tools/generate/seccomp
 github.com/opencontainers/runtime-tools/specerror
 github.com/opencontainers/runtime-tools/validate
-# github.com/opencontainers/selinux v1.10.1
+# github.com/opencontainers/selinux v1.10.0
 ## explicit
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label


### PR DESCRIPTION
Reverts https://github.com/containers/common/pull/987

I think new version of `selinux` is doing a blank replace of `setxattr` with `lsetxattr` where some of the context for `lsetxattr` throws `ENOTSUP` this is causing regression in https://github.com/containers/podman/pull/13726

Buildah and other parts must be instrumented to either ignore `ENOTSUP` or look for an alternative before bumping selinux.