### PR TITLE
golangci-lint spring cleaning and bump

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,8 @@ on:
       - main
       - v*
   pull_request:
+env:
+  LINT_VERSION: v1.45
 
 jobs:
   codespell:
@@ -18,3 +20,20 @@ jobs:
       run: pip install codespell
     - name: run codespell
       run: codespell
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version: 1.x # latest stable
+    - name: install deps
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get -qq install libseccomp-dev libdevmapper-dev
+    - name: lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: "${{ env.LINT_VERSION }}"
+    - name: validate seccomp
+      run: ./tools/validate_seccomp.sh ./pkg/seccomp

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
     - apparmor
     - seccomp
     - selinux
+    - systemd
     - exclude_graphdriver_btrfs
     - containers_image_openpgp
   concurrency: 6

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,5 @@
 ---
 run:
-  skip-dirs:
-    - libimage/manifests
-    - pkg/manifests
-    - pkg/supplemented
   build-tags:
     - apparmor
     - seccomp
@@ -13,107 +9,12 @@ run:
   concurrency: 6
   deadline: 5m
 linters:
-  enable-all: true
-  disable:
-    - asciicheck
-    - errcheck
-    - exhaustive
-    - funlen
-    - gochecknoglobals
-    - gochecknoinits
-    - gocognit
-    - goconst
-    - godot
-    - godox
-    - goerr113
-    - gofumpt
-    - golint
-    - gomnd
-    - gosec
-    - lll
-    - maligned
-    - nestif
-    - nlreturn
-    - prealloc
-    - stylecheck
-    - testpackage
-    - unconvert
-    - whitespace
-    - wsl
+  enable:
+    - dupl
+    - gocritic
 linters-settings:
   errcheck:
     check-type-assertions: true
-    check-blank: true
-  gocritic:
-    enabled-checks:
-      # Diagnostic
-      - appendAssign
-      - argOrder
-      - badCond
-      - caseOrder
-      - codegenComment
-      - commentedOutCode
-      - deprecatedComment
-      - dupArg
-      - dupBranchBody
-      - dupCase
-      - dupSubExpr
-      - exitAfterDefer
-      - flagDeref
-      - flagName
-      - nilValReturn
-      - offBy1
-      - sloppyReassign
-      - weakCond
-      - octalLiteral
-
-      # Performance
-      - appendCombine
-      - equalFold
-      - hugeParam
-      - indexAlloc
-      - rangeExprCopy
-      - rangeValCopy
-
-      # Style
-      - assignOp
-      - boolExprSimplify
-      - captLocal
-      - commentFormatting
-      - commentedOutImport
-      - defaultCaseOrder
-      - docStub
-      - elseif
-      - emptyFallthrough
-      - emptyStringTest
-      - hexLiteral
-      - ifElseChain
-      - methodExprCall
-      - regexpMust
-      - singleCaseSwitch
-      - sloppyLen
-      - stringXbytes
-      - switchTrue
-      - typeAssertChain
-      - typeSwitchVar
-      - underef
-      - unlabelStmt
-      - unlambda
-      - unslice
-      - valSwap
-      - wrapperFunc
-      - yodaStyleExpr
-
-      # Opinionated
-      - builtinShadow
-      - importShadow
-      - initClause
-      - nestingReduce
-      - paramTypeCombine
-      - ptrToRefParam
-      - typeUnparen
-      - unnamedResult
-      - unnecessaryBlock
   gocyclo:
     min-complexity: 35
 

--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,9 @@ vendor:
 .PHONY: install.tools
 install.tools: build/golangci-lint .install.md2man
 
+build/golangci-lint: VERSION=v1.45.2
 build/golangci-lint:
-	export \
-		VERSION=v1.30.0 \
-		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
-		BINDIR=build && \
-	curl -sfL $$URL/$$VERSION/install.sh | sh -s $$VERSION
-
+	curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/$(VERSION)/install.sh | sh -s -- -b ./build $(VERSION)
 
 .install.md2man:
 	$(GO) install github.com/cpuguy83/go-md2man/v2@latest

--- a/cmd/seccomp/generate.go
+++ b/cmd/seccomp/generate.go
@@ -27,7 +27,7 @@ func main() {
 		panic(err)
 	}
 
-	if err := ioutil.WriteFile(f, b, 0644); err != nil {
+	if err := ioutil.WriteFile(f, b, 0o644); err != nil {
 		panic(err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/common
 
-go 1.15
+go 1.16
 
 require (
 	github.com/BurntSushi/toml v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -338,7 +338,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=

--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -147,15 +147,13 @@ type copier struct {
 	destinationLookup LookupReferenceFunc
 }
 
-var (
-	// storageAllowedPolicyScopes overrides the policy for local storage
-	// to ensure that we can read images from it.
-	storageAllowedPolicyScopes = signature.PolicyTransportScopes{
-		"": []signature.PolicyRequirement{
-			signature.NewPRInsecureAcceptAnything(),
-		},
-	}
-)
+// storageAllowedPolicyScopes overrides the policy for local storage
+// to ensure that we can read images from it.
+var storageAllowedPolicyScopes = signature.PolicyTransportScopes{
+	"": []signature.PolicyRequirement{
+		signature.NewPRInsecureAcceptAnything(),
+	},
+}
 
 // getDockerAuthConfig extracts a docker auth config from the CopyOptions.  Returns
 // nil if no credentials are set.

--- a/libimage/corrupted_test.go
+++ b/libimage/corrupted_test.go
@@ -58,10 +58,11 @@ func TestCorruptedLayers(t *testing.T) {
 	// Now write back the layers without the first layer!
 	data, err = json.Marshal(layers[1:])
 	require.NoError(t, err, "unmarshaling layers.json")
-	err = ioutils.AtomicWriteFile(indexPath, data, 0600) // nolint
+	err = ioutils.AtomicWriteFile(indexPath, data, 0o600) // nolint
 	require.NoError(t, err, "writing back layers.json")
 
-	image.reload() // clear the cached data
+	err = image.reload() // clear the cached data
+	require.NoError(t, err)
 
 	// Now inspecting the image must fail!
 	_, err = image.Inspect(ctx, nil)

--- a/libimage/image_config.go
+++ b/libimage/image_config.go
@@ -95,9 +95,7 @@ func ImageConfigFromChanges(changes []string) (*ImageConfig, error) { // nolint:
 			// For now: we only support key=value
 			// We will attempt to strip quotation marks if present.
 
-			var (
-				key, val string
-			)
+			var key, val string
 
 			splitEnv := strings.SplitN(value, "=", 2)
 			key = splitEnv[0]

--- a/libimage/inspect.go
+++ b/libimage/inspect.go
@@ -213,7 +213,6 @@ func (i *Image) inspectInfo(ctx context.Context) (*types.ImageInspectInfo, error
 
 	ref, err := i.StorageReference()
 	if err != nil {
-
 		return nil, err
 	}
 

--- a/libimage/manifest_list_test.go
+++ b/libimage/manifest_list_test.go
@@ -42,7 +42,6 @@ func TestCreateManifestList(t *testing.T) {
 // Following test ensure that `Tag` tags the manifest list instead of resolved image.
 // Both the tags should point to same image id
 func TestCreateAndTagManifestList(t *testing.T) {
-
 	tagName := "testlisttagged"
 	listName := "testlist"
 	runtime, cleanup := testNewRuntime(t)
@@ -80,7 +79,6 @@ func TestCreateAndTagManifestList(t *testing.T) {
 // Test tags two manifestlist and deletes one of them and
 // confirms if other one is not deleted.
 func TestCreateAndRemoveManifestList(t *testing.T) {
-
 	tagName := "manifestlisttagged"
 	listName := "manifestlist"
 	runtime, cleanup := testNewRuntime(t)
@@ -113,5 +111,4 @@ func TestCreateAndRemoveManifestList(t *testing.T) {
 	// output should contain log of untagging the original manifestlist
 	require.True(t, rmReports[0].Removed)
 	require.Equal(t, []string{"localhost/manifestlist:latest"}, rmReports[0].Untagged)
-
 }

--- a/libimage/manifests/copy.go
+++ b/libimage/manifests/copy.go
@@ -4,12 +4,10 @@ import (
 	"github.com/containers/image/v5/signature"
 )
 
-var (
-	// storageAllowedPolicyScopes overrides the policy for local storage
-	// to ensure that we can read images from it.
-	storageAllowedPolicyScopes = signature.PolicyTransportScopes{
-		"": []signature.PolicyRequirement{
-			signature.NewPRInsecureAcceptAnything(),
-		},
-	}
-)
+// storageAllowedPolicyScopes overrides the policy for local storage
+// to ensure that we can read images from it.
+var storageAllowedPolicyScopes = signature.PolicyTransportScopes{
+	"": []signature.PolicyRequirement{
+		signature.NewPRInsecureAcceptAnything(),
+	},
+}

--- a/libimage/manifests/manifests.go
+++ b/libimage/manifests/manifests.go
@@ -384,10 +384,8 @@ func (l *list) Add(ctx context.Context, sys *types.SystemContext, ref types.Imag
 			}
 			instanceInfo.instanceDigest = &manifestDigest
 			instanceInfo.Size = int64(len(manifestBytes))
-		} else {
-			if manifestDigest == "" {
-				manifestDigest = *instanceInfo.instanceDigest
-			}
+		} else if manifestDigest == "" {
+			manifestDigest = *instanceInfo.instanceDigest
 		}
 		err = l.List.AddInstance(*instanceInfo.instanceDigest, instanceInfo.Size, manifestType, instanceInfo.OS, instanceInfo.Architecture, instanceInfo.OSVersion, instanceInfo.OSFeatures, instanceInfo.Variant, instanceInfo.Features, instanceInfo.Annotations)
 		if err != nil {

--- a/libimage/manifests/manifests.go
+++ b/libimage/manifests/manifests.go
@@ -405,9 +405,7 @@ func (l *list) Add(ctx context.Context, sys *types.SystemContext, ref types.Imag
 func (l *list) Remove(instanceDigest digest.Digest) error {
 	err := l.List.Remove(instanceDigest)
 	if err == nil {
-		if _, needToDelete := l.instances[instanceDigest]; needToDelete {
-			delete(l.instances, instanceDigest)
-		}
+		delete(l.instances, instanceDigest)
 	}
 	return err
 }

--- a/libimage/pull_test.go
+++ b/libimage/pull_test.go
@@ -185,7 +185,6 @@ func TestPullPolicy(t *testing.T) {
 	pulledImages, err = runtime.Pull(ctx, "alpine", config.PullPolicyNever, pullOptions)
 	require.NoError(t, err, "Never pull different arch alpine")
 	require.NotNil(t, pulledImages, "lookup alpine")
-
 }
 
 func TestShortNameAndIDconflict(t *testing.T) {

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -74,7 +74,7 @@ func (r *Runtime) SystemContext() *types.SystemContext {
 // Returns a copy of the runtime's system context.
 func (r *Runtime) systemContextCopy() *types.SystemContext {
 	var sys types.SystemContext
-	deepcopy.Copy(&sys, &r.systemContext)
+	_ = deepcopy.Copy(&sys, &r.systemContext)
 	return &sys
 }
 

--- a/libimage/runtime_test.go
+++ b/libimage/runtime_test.go
@@ -49,7 +49,7 @@ func testNewRuntime(t *testing.T, options ...testNewRuntimeOptions) (runtime *Ru
 	require.Equal(t, runtime.systemContext.BigFilesTemporaryDir, tmpdir())
 
 	cleanup = func() {
-		runtime.Shutdown(true)
+		_ = runtime.Shutdown(true)
 		_ = os.RemoveAll(workdir)
 	}
 

--- a/libimage/save.go
+++ b/libimage/save.go
@@ -68,7 +68,6 @@ func (r *Runtime) Save(ctx context.Context, names []string, format, path string,
 	}
 
 	return errors.Errorf("unsupported format %q for saving images", format)
-
 }
 
 // saveSingleImage saves the specified image name to the specified path.

--- a/libimage/save_test.go
+++ b/libimage/save_test.go
@@ -92,7 +92,7 @@ func TestSave(t *testing.T) {
 		_, rmErrors = runtime.RemoveImages(ctx, nil, nil)
 		require.Nil(t, rmErrors)
 
-		namesAndTags := append(test.names, test.tags...)
+		namesAndTags := append(test.names, test.tags...) //nolint:gocritic // ignore "appendAssign: append result not assigned to the same slice"
 		loadedImages, err := runtime.Load(ctx, tmp, loadOptions)
 		require.NoError(t, err)
 		require.Len(t, loadedImages, len(namesAndTags))

--- a/libnetwork/cni/cni_conversion.go
+++ b/libnetwork/cni/cni_conversion.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/containernetworking/cni/libcni"
@@ -21,6 +20,7 @@ import (
 	pkgutil "github.com/containers/common/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 func createNetworkFromCNIConfigList(conf *libcni.NetworkConfigList, confPath string) (*types.Network, error) {
@@ -45,12 +45,11 @@ func createNetworkFromCNIConfigList(conf *libcni.NetworkConfigList, confPath str
 		}
 	}
 
-	f, err := os.Stat(confPath)
+	t, err := fileTime(confPath)
 	if err != nil {
 		return nil, err
 	}
-	stat := f.Sys().(*syscall.Stat_t)
-	network.Created = time.Unix(int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec))
+	network.Created = t
 
 	firstPlugin := conf.Plugins[0]
 	network.Driver = firstPlugin.Network.Type
@@ -320,12 +319,11 @@ func (n *cniNetwork) createCNIConfigListFromNetwork(network *types.Network, writ
 		if err != nil {
 			return nil, "", err
 		}
-		f, err := os.Stat(cniPathName)
+		t, err := fileTime(cniPathName)
 		if err != nil {
 			return nil, "", err
 		}
-		stat := f.Sys().(*syscall.Stat_t)
-		network.Created = time.Unix(int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec))
+		network.Created = t
 	} else {
 		network.Created = time.Now()
 	}
@@ -423,4 +421,18 @@ func parseOptions(networkOptions map[string]string, networkDriver string) (*opti
 		}
 	}
 	return opt, nil
+}
+
+func fileTime(file string) (time.Time, error) {
+	var st unix.Stat_t
+	for {
+		err := unix.Stat(file, &st)
+		if err == nil {
+			break
+		}
+		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
+			return time.Time{}, &os.PathError{Path: file, Op: "stat", Err: err}
+		}
+	}
+	return time.Unix(int64(st.Ctim.Sec), int64(st.Ctim.Nsec)), nil //nolint:unconvert // On some platforms Sec and Nsec are int32.
 }

--- a/libnetwork/cni/cni_conversion.go
+++ b/libnetwork/cni/cni_conversion.go
@@ -316,7 +316,7 @@ func (n *cniNetwork) createCNIConfigListFromNetwork(network *types.Network, writ
 	cniPathName := ""
 	if writeToDisk {
 		cniPathName = filepath.Join(n.cniConfigDir, network.Name+".conflist")
-		err = ioutil.WriteFile(cniPathName, b, 0644)
+		err = ioutil.WriteFile(cniPathName, b, 0o644)
 		if err != nil {
 			return nil, "", err
 		}

--- a/libnetwork/cni/config.go
+++ b/libnetwork/cni/config.go
@@ -17,7 +17,6 @@ import (
 
 // NetworkCreate will take a partial filled Network and fill the
 // missing fields. It creates the Network and returns the full Network.
-// nolint:gocritic
 func (n *cniNetwork) NetworkCreate(net types.Network) (types.Network, error) {
 	n.lock.Lock()
 	defer n.lock.Unlock()

--- a/libnetwork/cni/config_test.go
+++ b/libnetwork/cni/config_test.go
@@ -31,7 +31,6 @@ var _ = Describe("Config", func() {
 		cniConfDir, err = ioutil.TempDir("", "podman_cni_test")
 		if err != nil {
 			Fail("Failed to create tmpdir")
-
 		}
 		logBuffer = bytes.Buffer{}
 		logrus.SetOutput(&logBuffer)
@@ -52,7 +51,6 @@ var _ = Describe("Config", func() {
 	})
 
 	Context("basic network config tests", func() {
-
 		It("check default network config exists", func() {
 			networks, err := libpodNet.NetworkList()
 			Expect(err).To(BeNil())
@@ -1167,7 +1165,6 @@ var _ = Describe("Config", func() {
 	})
 
 	Context("network load valid existing ones", func() {
-
 		numberOfConfigFiles := 0
 
 		BeforeEach(func() {
@@ -1182,7 +1179,7 @@ var _ = Describe("Config", func() {
 				if err != nil {
 					Fail("Failed to copy test files")
 				}
-				err = ioutil.WriteFile(filepath.Join(cniConfDir, filename), data, 0700)
+				err = ioutil.WriteFile(filepath.Join(cniConfDir, filename), data, 0o700)
 				if err != nil {
 					Fail("Failed to copy test files")
 				}
@@ -1516,7 +1513,6 @@ var _ = Describe("Config", func() {
 	})
 
 	Context("network load invalid existing ones", func() {
-
 		BeforeEach(func() {
 			dir := "testfiles/invalid"
 			files, err := ioutil.ReadDir(dir)
@@ -1529,7 +1525,7 @@ var _ = Describe("Config", func() {
 				if err != nil {
 					Fail("Failed to copy test files")
 				}
-				err = ioutil.WriteFile(filepath.Join(cniConfDir, filename), data, 0700)
+				err = ioutil.WriteFile(filepath.Join(cniConfDir, filename), data, 0o700)
 				if err != nil {
 					Fail("Failed to copy test files")
 				}
@@ -1548,9 +1544,7 @@ var _ = Describe("Config", func() {
 			Expect(logString).To(ContainSubstring("broken.conflist: error parsing configuration list"))
 			Expect(logString).To(ContainSubstring("invalid_gateway.conflist could not be converted to a libpod config, skipping: failed to parse gateway ip 10.89.8"))
 		})
-
 	})
-
 })
 
 func grepInFile(path, match string) {

--- a/libnetwork/internal/util/util.go
+++ b/libnetwork/internal/util/util.go
@@ -109,7 +109,6 @@ func GetFreeIPv4NetworkSubnet(usedNetworks []*net.IPNet, subnetPools []config.Su
 		return nil, err
 	}
 	return nil, errors.New("could not find free subnet from subnet pools")
-
 }
 
 // GetFreeIPv6NetworkSubnet returns a unused ipv6 subnet

--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -19,7 +19,6 @@ import (
 
 // NetworkCreate will take a partial filled Network and fill the
 // missing fields. It creates the Network and returns the full Network.
-// nolint:gocritic
 func (n *netavarkNetwork) NetworkCreate(net types.Network) (types.Network, error) {
 	n.lock.Lock()
 	defer n.lock.Unlock()

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -31,7 +31,6 @@ var _ = Describe("Config", func() {
 		networkConfDir, err = ioutil.TempDir("", "podman_netavark_test")
 		if err != nil {
 			Fail("Failed to create tmpdir")
-
 		}
 		logBuffer = bytes.Buffer{}
 		logrus.SetOutput(&logBuffer)
@@ -50,7 +49,6 @@ var _ = Describe("Config", func() {
 	})
 
 	Context("basic network config tests", func() {
-
 		It("check default network config exists", func() {
 			networks, err := libpodNet.NetworkList()
 			Expect(err).To(BeNil())
@@ -800,7 +798,8 @@ var _ = Describe("Config", func() {
 		It("create macvlan config with internal", func() {
 			subnet := "10.0.0.0/24"
 			n, _ := types.ParseCIDR(subnet)
-			network := types.Network{Driver: "macvlan",
+			network := types.Network{
+				Driver:   "macvlan",
 				Internal: true,
 				Subnets:  []types.Subnet{{Subnet: n}},
 			}
@@ -1021,11 +1020,9 @@ var _ = Describe("Config", func() {
 			Expect(err).To(BeNil())
 			EqualNetwork(network2, network1)
 		})
-
 	})
 
 	Context("network load valid existing ones", func() {
-
 		BeforeEach(func() {
 			dir := "testfiles/valid"
 			files, err := ioutil.ReadDir(dir)
@@ -1038,7 +1035,7 @@ var _ = Describe("Config", func() {
 				if err != nil {
 					Fail("Failed to copy test files")
 				}
-				err = ioutil.WriteFile(filepath.Join(networkConfDir, filename), data, 0700)
+				err = ioutil.WriteFile(filepath.Join(networkConfDir, filename), data, 0o700)
 				if err != nil {
 					Fail("Failed to copy test files")
 				}
@@ -1300,7 +1297,6 @@ var _ = Describe("Config", func() {
 	})
 
 	Context("network load invalid existing ones", func() {
-
 		BeforeEach(func() {
 			dir := "testfiles/invalid"
 			files, err := ioutil.ReadDir(dir)
@@ -1313,7 +1309,7 @@ var _ = Describe("Config", func() {
 				if err != nil {
 					Fail("Failed to copy test files")
 				}
-				err = ioutil.WriteFile(filepath.Join(networkConfDir, filename), data, 0700)
+				err = ioutil.WriteFile(filepath.Join(networkConfDir, filename), data, 0o700)
 				if err != nil {
 					Fail("Failed to copy test files")
 				}
@@ -1331,9 +1327,7 @@ var _ = Describe("Config", func() {
 			Expect(logString).To(ContainSubstring("Network config \\\"%s/wrongID.json\\\" could not be parsed, skipping: invalid network ID \\\"someID\\\"", networkConfDir))
 			Expect(logString).To(ContainSubstring("Network config \\\"%s/invalid_gateway.json\\\" could not be parsed, skipping: gateway 10.89.100.1 not in subnet 10.89.9.0/24", networkConfDir))
 		})
-
 	})
-
 })
 
 func grepInFile(path, match string) {

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -1344,7 +1344,6 @@ func HaveNetworkName(name string) gomegaTypes.GomegaMatcher {
 }
 
 // EqualNetwork must be used because comparing the time with deep equal does not work
-// nolint:gocritic
 func EqualNetwork(net1, net2 types.Network) {
 	ExpectWithOffset(1, net1.Created.Equal(net2.Created)).To(BeTrue(), "net1 created: %v is not equal net2 created: %v", net1.Created, net2.Created)
 	net1.Created = time.Time{}

--- a/libnetwork/netavark/ipam.go
+++ b/libnetwork/netavark/ipam.go
@@ -61,7 +61,7 @@ func newIPAMError(cause error, msg string, args ...interface{}) *ipamError {
 func (n *netavarkNetwork) openDB() (*bbolt.DB, error) {
 	// linter complains about the octal value
 	// nolint:gocritic
-	db, err := bbolt.Open(n.ipamDBPath, 0600, nil)
+	db, err := bbolt.Open(n.ipamDBPath, 0o600, nil)
 	if err != nil {
 		return nil, newIPAMError(err, "failed to open database %s", n.ipamDBPath)
 	}

--- a/libnetwork/netavark/ipam.go
+++ b/libnetwork/netavark/ipam.go
@@ -59,8 +59,6 @@ func newIPAMError(cause error, msg string, args ...interface{}) *ipamError {
 // openDB will open the ipam database
 // Note that the caller has to Close it.
 func (n *netavarkNetwork) openDB() (*bbolt.DB, error) {
-	// linter complains about the octal value
-	// nolint:gocritic
 	db, err := bbolt.Open(n.ipamDBPath, 0o600, nil)
 	if err != nil {
 		return nil, newIPAMError(err, "failed to open database %s", n.ipamDBPath)

--- a/libnetwork/netavark/ipam_test.go
+++ b/libnetwork/netavark/ipam_test.go
@@ -42,7 +42,7 @@ var _ = Describe("IPAM", func() {
 			Fail("Failed to create NewCNINetworkInterface")
 		}
 
-		networkInterface = libpodNet.(*netavarkNetwork)
+		networkInterface = libpodNet.(*netavarkNetwork) //nolint:errcheck // It is always *netavarkNetwork here.
 		// run network list to force a network load
 		_, err = networkInterface.NetworkList()
 		Expect(err).To(BeNil())

--- a/libnetwork/netavark/ipam_test.go
+++ b/libnetwork/netavark/ipam_test.go
@@ -28,7 +28,6 @@ var _ = Describe("IPAM", func() {
 		networkConfDir, err = ioutil.TempDir("", "podman_netavark_test")
 		if err != nil {
 			Fail("Failed to create tmpdir")
-
 		}
 		logBuffer = bytes.Buffer{}
 		logrus.SetOutput(&logBuffer)
@@ -45,7 +44,8 @@ var _ = Describe("IPAM", func() {
 
 		networkInterface = libpodNet.(*netavarkNetwork)
 		// run network list to force a network load
-		networkInterface.NetworkList()
+		_, err = networkInterface.NetworkList()
+		Expect(err).To(BeNil())
 	})
 
 	AfterEach(func() {
@@ -430,5 +430,4 @@ var _ = Describe("IPAM", func() {
 		err = networkInterface.deallocIPs(opts)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/libnetwork/netavark/network.go
+++ b/libnetwork/netavark/network.go
@@ -108,11 +108,11 @@ func NewNetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
 		return nil, errors.Wrap(err, "failed to parse default subnet")
 	}
 
-	if err := os.MkdirAll(conf.NetworkConfigDir, 0755); err != nil {
+	if err := os.MkdirAll(conf.NetworkConfigDir, 0o755); err != nil {
 		return nil, err
 	}
 
-	if err := os.MkdirAll(conf.NetworkRunDir, 0755); err != nil {
+	if err := os.MkdirAll(conf.NetworkRunDir, 0o755); err != nil {
 		return nil, err
 	}
 

--- a/libnetwork/network/interface.go
+++ b/libnetwork/network/interface.go
@@ -121,7 +121,6 @@ func defaultNetworkBackend(store storage.Store, conf *config.Config) (backend ty
 	defer func() {
 		// only write when there is no error
 		if err == nil {
-			// nolint:gocritic
 			if err := ioutils.AtomicWriteFile(file, []byte(backend), 0o644); err != nil {
 				logrus.Errorf("could not write network backend to file: %v", err)
 			}

--- a/libnetwork/network/interface.go
+++ b/libnetwork/network/interface.go
@@ -122,7 +122,7 @@ func defaultNetworkBackend(store storage.Store, conf *config.Config) (backend ty
 		// only write when there is no error
 		if err == nil {
 			// nolint:gocritic
-			if err := ioutils.AtomicWriteFile(file, []byte(backend), 0644); err != nil {
+			if err := ioutils.AtomicWriteFile(file, []byte(backend), 0o644); err != nil {
 				logrus.Errorf("could not write network backend to file: %v", err)
 			}
 		}

--- a/pkg/apparmor/apparmor_linux.go
+++ b/pkg/apparmor/apparmor_linux.go
@@ -233,7 +233,6 @@ func parseAAParserVersion(output string) (int, error) {
 	// major*10^5 + minor*10^3 + patch*10^0
 	numericVersion := majorVersion*1e5 + minorVersion*1e3 + patchLevel
 	return numericVersion, nil
-
 }
 
 // CheckProfileAndLoadDefault checks if the specified profile is loaded and

--- a/pkg/cgroups/blkio.go
+++ b/pkg/cgroups/blkio.go
@@ -12,8 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type blkioHandler struct {
-}
+type blkioHandler struct{}
 
 func getBlkioHandler() *blkioHandler {
 	return &blkioHandler{}

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -265,7 +265,7 @@ func createCgroupv2Path(path string) (deferredError error) {
 	for i, e := range elements[3:] {
 		current = filepath.Join(current, e)
 		if i > 0 {
-			if err := os.Mkdir(current, 0755); err != nil {
+			if err := os.Mkdir(current, 0o755); err != nil {
 				if !os.IsExist(err) {
 					return err
 				}
@@ -281,7 +281,7 @@ func createCgroupv2Path(path string) (deferredError error) {
 		// We enable the controllers for all the path components except the last one.  It is not allowed to add
 		// PIDs if there are already enabled controllers.
 		if i < len(elements[3:])-1 {
-			if err := ioutil.WriteFile(filepath.Join(current, "cgroup.subtree_control"), res, 0755); err != nil {
+			if err := ioutil.WriteFile(filepath.Join(current, "cgroup.subtree_control"), res, 0o755); err != nil {
 				return err
 			}
 		}
@@ -323,7 +323,7 @@ func (c *CgroupControl) initialize() (err error) {
 				continue
 			}
 			path := c.getCgroupv1Path(ctr.name)
-			if err := os.MkdirAll(path, 0755); err != nil {
+			if err := os.MkdirAll(path, 0o755); err != nil {
 				return errors.Wrapf(err, "error creating cgroup path for %s", ctr.name)
 			}
 		}
@@ -343,7 +343,7 @@ func (c *CgroupControl) createCgroupDirectory(controller string) (bool, error) {
 		return false, err
 	}
 
-	if err := os.MkdirAll(cPath, 0755); err != nil {
+	if err := os.MkdirAll(cPath, 0o755); err != nil {
 		return false, errors.Wrapf(err, "error creating cgroup for %s", controller)
 	}
 	return true, nil
@@ -589,7 +589,7 @@ func (c *CgroupControl) AddPid(pid int) error {
 
 	if c.cgroup2 {
 		p := filepath.Join(cgroupRoot, c.path, "cgroup.procs")
-		if err := ioutil.WriteFile(p, pidString, 0644); err != nil {
+		if err := ioutil.WriteFile(p, pidString, 0o644); err != nil {
 			return errors.Wrapf(err, "write %s", p)
 		}
 		return nil
@@ -612,7 +612,7 @@ func (c *CgroupControl) AddPid(pid int) error {
 			continue
 		}
 		p := filepath.Join(c.getCgroupv1Path(n), "tasks")
-		if err := ioutil.WriteFile(p, pidString, 0644); err != nil {
+		if err := ioutil.WriteFile(p, pidString, 0o644); err != nil {
 			return errors.Wrapf(err, "write %s", p)
 		}
 	}

--- a/pkg/cgroups/cpu.go
+++ b/pkg/cgroups/cpu.go
@@ -12,8 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type cpuHandler struct {
-}
+type cpuHandler struct{}
 
 func getCPUHandler() *cpuHandler {
 	return &cpuHandler{}

--- a/pkg/cgroups/cpuset.go
+++ b/pkg/cgroups/cpuset.go
@@ -10,8 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type cpusetHandler struct {
-}
+type cpusetHandler struct{}
 
 func cpusetCopyFileFromParent(dir, file string, cgroupv2 bool) ([]byte, error) {
 	if dir == cgroupRoot {
@@ -33,7 +32,7 @@ func cpusetCopyFileFromParent(dir, file string, cgroupv2 bool) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := ioutil.WriteFile(path, data, 0644); err != nil {
+	if err := ioutil.WriteFile(path, data, 0o644); err != nil {
 		return nil, errors.Wrapf(err, "write %s", path)
 	}
 	return data, nil

--- a/pkg/cgroups/pids.go
+++ b/pkg/cgroups/pids.go
@@ -8,8 +8,7 @@ import (
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-type pidHandler struct {
-}
+type pidHandler struct{}
 
 func getPidsHandler() *pidHandler {
 	return &pidHandler{}
@@ -29,7 +28,7 @@ func (c *pidHandler) Apply(ctr *CgroupControl, res *spec.LinuxResources) error {
 	}
 
 	p := filepath.Join(PIDRoot, "pids.max")
-	return ioutil.WriteFile(p, []byte(fmt.Sprintf("%d\n", res.Pids.Limit)), 0644)
+	return ioutil.WriteFile(p, []byte(fmt.Sprintf("%d\n", res.Pids.Limit)), 0o644)
 }
 
 // Create the cgroup

--- a/pkg/chown/chown_unix.go
+++ b/pkg/chown/chown_unix.go
@@ -41,7 +41,6 @@ func ChangeHostPathOwnership(path string, recursive bool, uid, gid int) error {
 
 			return nil
 		})
-
 		if err != nil {
 			return errors.Wrap(err, "failed to chown recursively host path")
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -579,7 +579,6 @@ type Destination struct {
 // with cgroupv2v2. Other OCI runtimes are not yet supporting cgroupv2v2. This
 // might change in the future.
 func NewConfig(userConfigPath string) (*Config, error) {
-
 	// Generate the default config for the system
 	config, err := DefaultConfig()
 	if err != nil {
@@ -763,7 +762,6 @@ func (c *Config) addCAPPrefix() {
 
 // Validate is the main entry point for library configuration validation.
 func (c *Config) Validate() error {
-
 	if err := c.Containers.Validate(); err != nil {
 		return errors.Wrap(err, "validating containers config")
 	}
@@ -820,7 +818,6 @@ func (c *EngineConfig) Validate() error {
 // It returns an `error` on validation failure, otherwise
 // `nil`.
 func (c *ContainersConfig) Validate() error {
-
 	if err := c.validateUlimits(); err != nil {
 		return err
 	}
@@ -952,7 +949,6 @@ func (c *Config) GetDefaultEnvEx(envHost, httpProxy bool) []string {
 // Capabilities returns the capabilities parses the Add and Drop capability
 // list from the default capabiltiies for the container
 func (c *Config) Capabilities(user string, addCapabilities, dropCapabilities []string) ([]string, error) {
-
 	userNotRoot := func(user string) bool {
 		if user == "" || user == "root" || user == "0" {
 			return false
@@ -1012,7 +1008,7 @@ func Device(device string) (src, dst, permissions string, err error) {
 // IsValidDeviceMode checks if the mode for device is valid or not.
 // IsValid mode is a composition of r (read), w (write), and m (mknod).
 func IsValidDeviceMode(mode string) bool {
-	var legalDeviceMode = map[rune]bool{
+	legalDeviceMode := map[rune]bool{
 		'r': true,
 		'w': true,
 		'm': true,
@@ -1063,7 +1059,6 @@ func rootlessConfigPath() (string, error) {
 }
 
 func stringsEq(a, b []string) bool {
-
 	if len(a) != len(b) {
 		return false
 	}
@@ -1148,10 +1143,10 @@ func (c *Config) Write() error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	configFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644)
+	configFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -132,7 +132,6 @@ var _ = Describe("Config Local", func() {
 				Size: 24,
 			}},
 		))
-
 	})
 
 	It("should fail during runtime", func() {
@@ -263,7 +262,6 @@ var _ = Describe("Config Local", func() {
 		gomega.Expect(config.Engine.Env).To(gomega.BeEquivalentTo(expectedEnv))
 		gomega.Expect(os.Getenv("super")).To(gomega.BeEquivalentTo("duper"))
 		gomega.Expect(os.Getenv("foo")).To(gomega.BeEquivalentTo("bar"))
-
 	})
 
 	It("Expect Remote to be False", func() {
@@ -316,7 +314,8 @@ var _ = Describe("Config Local", func() {
 		os.Setenv("CONTAINERS_CONF", tmpfile)
 		config, err := ReadCustomConfig()
 		gomega.Expect(err).To(gomega.BeNil())
-		config.Containers.Devices = []string{"/dev/null:/dev/null:rw",
+		config.Containers.Devices = []string{
+			"/dev/null:/dev/null:rw",
 			"/dev/sdc/",
 			"/dev/sdc:/dev/xvdc",
 			"/dev/sdc:rm",
@@ -470,5 +469,4 @@ var _ = Describe("Config Local", func() {
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config2.Machine.Memory).To(gomega.Equal(uint64(1024)))
 	})
-
 })

--- a/pkg/config/config_remote_test.go
+++ b/pkg/config/config_remote_test.go
@@ -139,5 +139,4 @@ var _ = Describe("Config Remote", func() {
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
 	})
-
 })

--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -16,9 +16,7 @@ const (
 	invalidPath = "/wrong"
 )
 
-var (
-	sut *Config
-)
+var sut *Config
 
 func beforeEach() {
 	sut = defaultConfig()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -39,7 +39,8 @@ var _ = Describe("Config", func() {
 
 		It("should succeed with devices", func() {
 			// Given
-			sut.Containers.Devices = []string{"/dev/null:/dev/null:rw",
+			sut.Containers.Devices = []string{
+				"/dev/null:/dev/null:rw",
 				"/dev/sdc/",
 				"/dev/sdc:/dev/xvdc",
 				"/dev/sdc:rm",
@@ -98,9 +99,7 @@ var _ = Describe("Config", func() {
 			defaultConfig, _ := NewConfig("")
 			// EnableLabeling should match whether or not SELinux is enabled on the host
 			gomega.Expect(defaultConfig.Containers.EnableLabeling).To(gomega.Equal(selinux.GetEnabled()))
-
 		})
-
 	})
 
 	Describe("ValidateNetworkConfig", func() {
@@ -155,7 +154,6 @@ image_copy_tmp_dir="storage"`
 
 			OCIRuntimeMap := map[string][]string{
 				"kata": {
-
 					"/usr/bin/kata-runtime",
 					"/usr/sbin/kata-runtime",
 					"/usr/local/bin/kata-runtime",
@@ -227,7 +225,6 @@ image_copy_tmp_dir="storage"`
 		})
 
 		It("test GetDefaultEnvEx", func() {
-
 			envs := []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 				"TERM=xterm",
@@ -351,7 +348,6 @@ image_copy_tmp_dir="storage"`
 			}
 			gomega.Expect(config.Engine.EventsLogFilePath).To(gomega.BeEquivalentTo(config.Engine.TmpDir + "/events/events.log"))
 			gomega.Expect(config.Engine.EventsLogFileMaxSize).To(gomega.Equal(uint64(0)))
-
 		})
 
 		It("should success with valid user file path", func() {
@@ -673,9 +669,9 @@ image_copy_tmp_dir="storage"`
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				conf := file.Name() + ".conf"
 
-				os.Rename(file.Name(), conf)
+				err = os.Rename(file.Name(), conf)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				return conf
-
 			}
 			configs := []string{
 				"test1",
@@ -794,6 +790,5 @@ env=["foo=bar"]`
 		// config should only contain empty stanzas
 		gomega.Expect(string(b)).To(gomega.
 			Equal("[containers]\n\n[engine]\n\n[machine]\n\n[network]\n\n[secrets]\n\n[configmaps]\n"))
-
 	})
 })

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -108,7 +108,6 @@ func parseSubnetPool(subnet string, size int) SubnetPool {
 		Base: &nettypes.IPNet{IPNet: *n},
 		Size: size,
 	}
-
 }
 
 const (
@@ -155,7 +154,6 @@ const (
 
 // DefaultConfig defines the default values from containers.conf
 func DefaultConfig() (*Config, error) {
-
 	defaultEngineConfig, err := defaultConfigFromMemory()
 	if err != nil {
 		return nil, err
@@ -397,10 +395,10 @@ func defaultTmpDir() (string, error) {
 	}
 	libpodRuntimeDir := filepath.Join(runtimeDir, "libpod")
 
-	if err := os.Mkdir(libpodRuntimeDir, 0700|os.ModeSticky); err != nil {
+	if err := os.Mkdir(libpodRuntimeDir, 0o700|os.ModeSticky); err != nil {
 		if !os.IsExist(err) {
 			return "", err
-		} else if err := os.Chmod(libpodRuntimeDir, 0700|os.ModeSticky); err != nil {
+		} else if err := os.Chmod(libpodRuntimeDir, 0o700|os.ModeSticky); err != nil {
 			// The directory already exist, just set the sticky bit
 			return "", errors.Wrap(err, "set sticky bit on")
 		}

--- a/pkg/config/default_test.go
+++ b/pkg/config/default_test.go
@@ -15,8 +15,12 @@ func prepareProbeBinary(t *testing.T, expectedOutput string) (path string) {
 	require.Nil(t, err)
 	defer func() { require.Nil(t, f.Close()) }()
 
-	f.Chmod(os.FileMode(0755))
-	f.WriteString(fmt.Sprintf("#!/usr/bin/env sh\necho %q", expectedOutput))
+	err = f.Chmod(os.FileMode(0o755))
+	require.Nil(t, err)
+
+	_, err = f.WriteString(fmt.Sprintf("#!/usr/bin/env sh\necho %q", expectedOutput))
+	require.Nil(t, err)
+
 	return f.Name()
 }
 

--- a/pkg/config/systemd.go
+++ b/pkg/config/systemd.go
@@ -58,7 +58,6 @@ func useSystemd() bool {
 			val := strings.TrimSuffix(string(dat), "\n")
 			usesSystemd = (val == "systemd")
 		}
-		return
 	})
 	return usesSystemd
 }
@@ -82,7 +81,6 @@ func useJournald() bool {
 				}
 			}
 		}
-		return
 	})
 	return usesJournald
 }

--- a/pkg/configmaps/configmaps.go
+++ b/pkg/configmaps/configmaps.go
@@ -99,7 +99,7 @@ func NewManager(rootPath string) (*ConfigMapManager, error) {
 		return nil, errors.Wrapf(errInvalidPath, "path must be absolute: %s", rootPath)
 	}
 	// the lockfile functions require that the rootPath dir is executable
-	if err := os.MkdirAll(rootPath, 0700); err != nil {
+	if err := os.MkdirAll(rootPath, 0o700); err != nil {
 		return nil, err
 	}
 
@@ -234,7 +234,6 @@ func (s *ConfigMapManager) List() ([]ConfigMap, error) {
 	var ls []ConfigMap
 	for _, v := range configMaps {
 		ls = append(ls, v)
-
 	}
 	return ls, nil
 }

--- a/pkg/configmaps/configmaps_test.go
+++ b/pkg/configmaps/configmaps_test.go
@@ -44,6 +44,7 @@ func TestAddSecretAndLookupData(t *testing.T) {
 		t.Errorf("error: configmap data not equal")
 	}
 }
+
 func TestAddConfigMapName(t *testing.T) {
 	manager, testpath, err := setup()
 	require.NoError(t, err)

--- a/pkg/configmaps/configmapsdb.go
+++ b/pkg/configmaps/configmapsdb.go
@@ -177,7 +177,7 @@ func (s *ConfigMapManager) store(entry *ConfigMap) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(s.configMapDBPath, marshalled, 0600)
+	err = ioutil.WriteFile(s.configMapDBPath, marshalled, 0o600)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func (s *ConfigMapManager) delete(nameOrID string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(s.configMapDBPath, marshalled, 0600)
+	err = ioutil.WriteFile(s.configMapDBPath, marshalled, 0o600)
 	if err != nil {
 		return err
 	}

--- a/pkg/configmaps/filedriver/filedriver.go
+++ b/pkg/configmaps/filedriver/filedriver.go
@@ -34,7 +34,7 @@ func NewDriver(rootPath string) (*Driver, error) {
 	fileDriver := new(Driver)
 	fileDriver.configMapsDataFilePath = filepath.Join(rootPath, configMapsDataFile)
 	// the lockfile functions require that the rootPath dir is executable
-	if err := os.MkdirAll(rootPath, 0700); err != nil {
+	if err := os.MkdirAll(rootPath, 0o700); err != nil {
 		return nil, err
 	}
 
@@ -95,7 +95,7 @@ func (d *Driver) Store(id string, data []byte) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(d.configMapsDataFilePath, marshalled, 0600)
+	err = ioutil.WriteFile(d.configMapsDataFilePath, marshalled, 0o600)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (d *Driver) Delete(id string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(d.configMapsDataFilePath, marshalled, 0600)
+	err = ioutil.WriteFile(d.configMapsDataFilePath, marshalled, 0o600)
 	if err != nil {
 		return err
 	}

--- a/pkg/formats/templates.go
+++ b/pkg/formats/templates.go
@@ -20,7 +20,7 @@ var basicFunctions = template.FuncMap{
 	},
 	"split":    strings.Split,
 	"join":     strings.Join,
-	"title":    strings.Title,
+	"title":    strings.Title, //nolint:staticcheck
 	"lower":    strings.ToLower,
 	"upper":    strings.ToUpper,
 	"pad":      padWithSpace,

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -442,38 +442,37 @@ func (l *list) preferOCI() bool {
 // Serialize encodes the list using the specified format, or by selecting one
 // which it thinks is appropriate.
 func (l *list) Serialize(mimeType string) ([]byte, error) {
-	var manifestBytes []byte
+	var (
+		res []byte
+		err error
+	)
 	switch mimeType {
 	case "":
 		if l.preferOCI() {
-			manifest, err := json.Marshal(&l.oci)
+			res, err = json.Marshal(&l.oci)
 			if err != nil {
 				return nil, errors.Wrapf(err, "error marshalling OCI image index")
 			}
-			manifestBytes = manifest
 		} else {
-			manifest, err := json.Marshal(&l.docker)
+			res, err = json.Marshal(&l.docker)
 			if err != nil {
 				return nil, errors.Wrapf(err, "error marshalling Docker manifest list")
 			}
-			manifestBytes = manifest
 		}
 	case v1.MediaTypeImageIndex:
-		manifest, err := json.Marshal(&l.oci)
+		res, err = json.Marshal(&l.oci)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error marshalling OCI image index")
 		}
-		manifestBytes = manifest
 	case manifest.DockerV2ListMediaType:
-		manifest, err := json.Marshal(&l.docker)
+		res, err = json.Marshal(&l.docker)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error marshalling Docker manifest list")
 		}
-		manifestBytes = manifest
 	default:
 		return nil, errors.Wrapf(ErrManifestTypeNotSupported, "serializing list to type %q not implemented", mimeType)
 	}
-	return manifestBytes, nil
+	return res, nil
 }
 
 // Instances returns the list of image instances mentioned in this list.

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -16,31 +16,22 @@ import (
 type List interface {
 	AddInstance(manifestDigest digest.Digest, manifestSize int64, manifestType, os, architecture, osVersion string, osFeatures []string, variant string, features []string, annotations []string) error
 	Remove(instanceDigest digest.Digest) error
-
 	SetURLs(instanceDigest digest.Digest, urls []string) error
 	URLs(instanceDigest digest.Digest) ([]string, error)
-
 	SetAnnotations(instanceDigest *digest.Digest, annotations map[string]string) error
 	Annotations(instanceDigest *digest.Digest) (map[string]string, error)
-
 	SetOS(instanceDigest digest.Digest, os string) error
 	OS(instanceDigest digest.Digest) (string, error)
-
 	SetArchitecture(instanceDigest digest.Digest, arch string) error
 	Architecture(instanceDigest digest.Digest) (string, error)
-
 	SetOSVersion(instanceDigest digest.Digest, osVersion string) error
 	OSVersion(instanceDigest digest.Digest) (string, error)
-
 	SetVariant(instanceDigest digest.Digest, variant string) error
 	Variant(instanceDigest digest.Digest) (string, error)
-
 	SetFeatures(instanceDigest digest.Digest, features []string) error
 	Features(instanceDigest digest.Digest) ([]string, error)
-
 	SetOSFeatures(instanceDigest digest.Digest, osFeatures []string) error
 	OSFeatures(instanceDigest digest.Digest) ([]string, error)
-
 	Serialize(mimeType string) ([]byte, error)
 	Instances() []digest.Digest
 	OCIv1() *v1.Index

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -72,7 +72,7 @@ func Create() List {
 
 // AddInstance adds an entry for the specified manifest digest, with assorted
 // additional information specified in parameters, to the list or index.
-func (l *list) AddInstance(manifestDigest digest.Digest, manifestSize int64, manifestType, osName, architecture, osVersion string, osFeatures []string, variant string, features []string, annotations []string) error {
+func (l *list) AddInstance(manifestDigest digest.Digest, manifestSize int64, manifestType, osName, architecture, osVersion string, osFeatures []string, variant string, features, annotations []string) error {
 	if err := l.Remove(manifestDigest); err != nil && !os.IsNotExist(errors.Cause(err)) {
 		return err
 	}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -18,9 +18,7 @@ const (
 	dockerFixture    = "testdata/fedora.list.json"
 )
 
-var (
-	_ List = &list{}
-)
+var _ List = &list{}
 
 func TestMain(m *testing.M) {
 	if reexec.Init() {

--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -71,7 +71,7 @@ func NewNSWithName(name string) (ns.NetNS, error) {
 	// Create the directory for mounting network namespaces
 	// This needs to be a shared mountpoint in case it is mounted in to
 	// other namespaces (containers)
-	err = os.MkdirAll(nsRunDir, 0755)
+	err = os.MkdirAll(nsRunDir, 0o755)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -141,7 +141,7 @@ func Device(device string) (src, dest, permissions string, err error) {
 // isValidDeviceMode checks if the mode for device is valid or not.
 // isValid mode is a composition of r (read), w (write), and m (mknod).
 func isValidDeviceMode(mode string) bool {
-	var legalDeviceMode = map[rune]bool{
+	legalDeviceMode := map[rune]bool{
 		'r': true,
 		'w': true,
 		'm': true,

--- a/pkg/report/formatter_test.go
+++ b/pkg/report/formatter_test.go
@@ -71,11 +71,15 @@ func TestFormatter_ParseTable(t *testing.T) {
 		{&tabwriter.Writer{}, OriginUser, "table {{ .ID}}\n", "Identity\nc061a0839e\nf10fc2e11057\n1eb6fab5aa8f4b5cbfd3e66aa35e9b2a\n"},
 		{&tabwriter.Writer{}, OriginUser, `table {{ .ID}}\n`, "Identity\nc061a0839e\nf10fc2e11057\n1eb6fab5aa8f4b5cbfd3e66aa35e9b2a\n"},
 		{&tabwriter.Writer{}, OriginUser, "table {{.ID}}", "Identity\nc061a0839e\nf10fc2e11057\n1eb6fab5aa8f4b5cbfd3e66aa35e9b2a\n"},
-		{&tabwriter.Writer{}, OriginUser, "table {{.ID}}\t{{.Value}}",
-			"Identity                          Value\nc061a0839e                        one\nf10fc2e11057                      two\n1eb6fab5aa8f4b5cbfd3e66aa35e9b2a  three\n"},
+		{
+			&tabwriter.Writer{}, OriginUser, "table {{.ID}}\t{{.Value}}",
+			"Identity                          Value\nc061a0839e                        one\nf10fc2e11057                      two\n1eb6fab5aa8f4b5cbfd3e66aa35e9b2a  three\n",
+		},
 		{&bytes.Buffer{}, OriginUser, "{{range .}}{{.ID}}\tID{{end}}", "c061a0839e\tIDf10fc2e11057\tID1eb6fab5aa8f4b5cbfd3e66aa35e9b2a\tID\n"},
-		{&tabwriter.Writer{}, OriginPodman, "Value\tIdent\n{{range .}}{{.ID}}\tID{{end}}",
-			"Value       Ident\nIdentity    ID\nValue       Ident\nc061a0839e  IDf10fc2e11057  ID1eb6fab5aa8f4b5cbfd3e66aa35e9b2a  ID\n"},
+		{
+			&tabwriter.Writer{}, OriginPodman, "Value\tIdent\n{{range .}}{{.ID}}\tID{{end}}",
+			"Value       Ident\nIdentity    ID\nValue       Ident\nc061a0839e  IDf10fc2e11057  ID1eb6fab5aa8f4b5cbfd3e66aa35e9b2a  ID\n",
+		},
 		{&bytes.Buffer{}, OriginUser, "{{range .}}{{.ID}}\tID\n{{end}}", "c061a0839e\tID\nf10fc2e11057\tID\n1eb6fab5aa8f4b5cbfd3e66aa35e9b2a\tID\n\n"},
 		{&bytes.Buffer{}, OriginUser, `{{range .}}{{.ID}}{{end -}}`, "c061a0839ef10fc2e110571eb6fab5aa8f4b5cbfd3e66aa35e9b2a"},
 	}
@@ -92,10 +96,11 @@ func TestFormatter_ParseTable(t *testing.T) {
 			assert.IsType(t, tc.Type, rpt.Writer())
 
 			if rpt.RenderHeaders {
-				rpt.Execute([]map[string]string{{
+				err = rpt.Execute([]map[string]string{{
 					"ID":    "Identity",
 					"Value": "Value",
 				}})
+				assert.NoError(t, err)
 			}
 			err = rpt.Execute([...]map[string]string{
 				{"ID": "c061a0839e", "Value": "one"},

--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -40,7 +40,7 @@ var DefaultFuncs = FuncMap{
 		buf := new(bytes.Buffer)
 		enc := json.NewEncoder(buf)
 		enc.SetEscapeHTML(false)
-		enc.Encode(v)
+		_ = enc.Encode(v)
 		// Remove the trailing new line added by the encoder
 		return strings.TrimSpace(buf.String())
 	},

--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -47,7 +47,7 @@ var DefaultFuncs = FuncMap{
 	"lower":    strings.ToLower,
 	"pad":      padWithSpace,
 	"split":    strings.Split,
-	"title":    strings.Title,
+	"title":    strings.Title, //nolint:staticcheck
 	"truncate": truncateWithLength,
 	"upper":    strings.ToUpper,
 }

--- a/pkg/report/template_test.go
+++ b/pkg/report/template_test.go
@@ -85,7 +85,6 @@ func TestTemplate_Parse(t *testing.T) {
 			}})
 			assert.NoError(t, err)
 			assert.Equal(t, "Ident\n", buf.String())
-
 		})
 		buf.Reset()
 	}

--- a/pkg/report/writer_test.go
+++ b/pkg/report/writer_test.go
@@ -23,7 +23,8 @@ func TestNewWriter(t *testing.T) {
 			w, err := NewWriter(&buf, 4, 8, 1, ':', 0)
 			assert.NoError(t, err)
 
-			w.Write([]byte(tc.input))
+			_, err = w.Write([]byte(tc.input))
+			assert.NoError(t, err)
 			w.Flush()
 			assert.Equal(t, tc.expected, buf.String())
 		})
@@ -35,7 +36,8 @@ func TestNewWriterDefault(t *testing.T) {
 	var buf bytes.Buffer
 	w, err := NewWriterDefault(&buf)
 	assert.NoError(t, err)
-	w.Write([]byte("a46001bfea3a4172b46c173101208244\tRandom\tuuid"))
+	_, err = w.Write([]byte("a46001bfea3a4172b46c173101208244\tRandom\tuuid"))
+	assert.NoError(t, err)
 	w.Flush()
 	assert.Equal(t, "a46001bfea3a4172b46c173101208244  Random      uuid", buf.String())
 }

--- a/pkg/seccomp/conversion_test.go
+++ b/pkg/seccomp/conversion_test.go
@@ -83,7 +83,6 @@ func TestSpecToSeccomp(t *testing.T) {
 		input    *specs.LinuxSeccomp
 		expected func(*Seccomp, error)
 	}{
-
 		{ // success
 			input: &specs.LinuxSeccomp{
 				DefaultAction: specs.ActKill,

--- a/pkg/seccomp/generate.go
+++ b/pkg/seccomp/generate.go
@@ -29,7 +29,7 @@ func main() {
 		panic(err)
 	}
 
-	if err := ioutil.WriteFile(f, b, 0644); err != nil {
+	if err := ioutil.WriteFile(f, b, 0o644); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/seccomp/seccomp_linux.go
+++ b/pkg/seccomp/seccomp_linux.go
@@ -112,7 +112,7 @@ func setupSeccomp(config *Seccomp, rs *specs.Spec) (*specs.LinuxSeccomp, error) 
 	newConfig := &specs.LinuxSeccomp{}
 
 	var arch string
-	var native, err = libseccomp.GetNativeArch()
+	native, err := libseccomp.GetNativeArch()
 	if err == nil {
 		arch = native.String()
 	}

--- a/pkg/secrets/filedriver/filedriver.go
+++ b/pkg/secrets/filedriver/filedriver.go
@@ -34,7 +34,7 @@ func NewDriver(rootPath string) (*Driver, error) {
 	fileDriver := new(Driver)
 	fileDriver.secretsDataFilePath = filepath.Join(rootPath, secretsDataFile)
 	// the lockfile functions require that the rootPath dir is executable
-	if err := os.MkdirAll(rootPath, 0700); err != nil {
+	if err := os.MkdirAll(rootPath, 0o700); err != nil {
 		return nil, err
 	}
 
@@ -95,7 +95,7 @@ func (d *Driver) Store(id string, data []byte) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(d.secretsDataFilePath, marshalled, 0600)
+	err = ioutil.WriteFile(d.secretsDataFilePath, marshalled, 0o600)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (d *Driver) Delete(id string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(d.secretsDataFilePath, marshalled, 0600)
+	err = ioutil.WriteFile(d.secretsDataFilePath, marshalled, 0o600)
 	if err != nil {
 		return err
 	}

--- a/pkg/secrets/passdriver/passdriver_test.go
+++ b/pkg/secrets/passdriver/passdriver_test.go
@@ -25,7 +25,9 @@ func setupDriver(t *testing.T) (driver *Driver, cleanup func()) {
 	})
 	require.NoError(t, err)
 
-	driver.gpg(context.TODO(), nil, nil, "--batch", "--passphrase", "--quick-generate-key", "testing@passdriver")
+	err = driver.gpg(context.TODO(), nil, nil, "--batch", "--passphrase", "--quick-generate-key", "testing@passdriver")
+	require.NoError(t, err)
+
 	return driver, func() {
 		os.RemoveAll(base)
 		os.RemoveAll(gpghomedir)
@@ -180,5 +182,4 @@ func TestDelete(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -102,7 +102,7 @@ func NewManager(rootPath string) (*SecretsManager, error) {
 		return nil, errors.Wrapf(errInvalidPath, "path must be absolute: %s", rootPath)
 	}
 	// the lockfile functions require that the rootPath dir is executable
-	if err := os.MkdirAll(rootPath, 0700); err != nil {
+	if err := os.MkdirAll(rootPath, 0o700); err != nil {
 		return nil, err
 	}
 
@@ -237,7 +237,6 @@ func (s *SecretsManager) List() ([]Secret, error) {
 	var ls []Secret
 	for _, v := range secrets {
 		ls = append(ls, v)
-
 	}
 	return ls, nil
 }

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -44,6 +44,7 @@ func TestAddSecretAndLookupData(t *testing.T) {
 		t.Errorf("error: secret data not equal")
 	}
 }
+
 func TestAddSecretName(t *testing.T) {
 	manager, testpath, err := setup()
 	require.NoError(t, err)

--- a/pkg/secrets/secretsdb.go
+++ b/pkg/secrets/secretsdb.go
@@ -177,7 +177,7 @@ func (s *SecretsManager) store(entry *Secret) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(s.secretsDBPath, marshalled, 0600)
+	err = ioutil.WriteFile(s.secretsDBPath, marshalled, 0o600)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func (s *SecretsManager) delete(nameOrID string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(s.secretsDBPath, marshalled, 0600)
+	err = ioutil.WriteFile(s.secretsDBPath, marshalled, 0o600)
 	if err != nil {
 		return err
 	}

--- a/pkg/secrets/shelldriver/shelldriver_test.go
+++ b/pkg/secrets/shelldriver/shelldriver_test.go
@@ -171,5 +171,4 @@ func TestDelete(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/subscriptions/subscriptions.go
+++ b/pkg/subscriptions/subscriptions.go
@@ -262,7 +262,6 @@ func addSubscriptionsFromMountsFile(filePath, mountLabel, containerRunDir string
 				data, err := readFileOrDir("", hostDirOrFile, mode.Perm())
 				if err != nil {
 					return nil, err
-
 				}
 				for _, s := range data {
 					if err := os.MkdirAll(filepath.Dir(ctrDirOrFileOnHost), s.dirMode); err != nil {
@@ -313,7 +312,7 @@ func addFIPSModeSubscription(mounts *[]rspec.Mount, containerRunDir, mountPoint,
 	subscriptionsDir := "/run/secrets"
 	ctrDirOnHost := filepath.Join(containerRunDir, subscriptionsDir)
 	if _, err := os.Stat(ctrDirOnHost); os.IsNotExist(err) {
-		if err = idtools.MkdirAllAs(ctrDirOnHost, 0755, uid, gid); err != nil { //nolint
+		if err = idtools.MkdirAllAs(ctrDirOnHost, 0o755, uid, gid); err != nil { //nolint
 			return err
 		}
 		if err = label.Relabel(ctrDirOnHost, mountLabel, false); err != nil {

--- a/pkg/supplemented/supplemented_test.go
+++ b/pkg/supplemented/supplemented_test.go
@@ -42,7 +42,7 @@ func makeLayer(t *testing.T) []byte {
 		Typeflag: tar.TypeReg,
 		Name:     "tmpfile",
 		Size:     int64(len),
-		Mode:     0644,
+		Mode:     0o644,
 		Uname:    "root",
 		Gname:    "root",
 		ModTime:  time.Now(),

--- a/pkg/sysinfo/sysinfo_linux_test.go
+++ b/pkg/sysinfo/sysinfo_linux_test.go
@@ -17,14 +17,14 @@ func TestReadProcBool(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	procFile := filepath.Join(tmpDir, "read-proc-bool")
-	err = ioutil.WriteFile(procFile, []byte("1"), 0644)
+	err = ioutil.WriteFile(procFile, []byte("1"), 0o644)
 	require.NoError(t, err)
 
 	if !readProcBool(procFile) {
 		t.Fatal("expected proc bool to be true, got false")
 	}
 
-	if err := ioutil.WriteFile(procFile, []byte("0"), 0644); err != nil {
+	if err := ioutil.WriteFile(procFile, []byte("0"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if readProcBool(procFile) {
@@ -34,7 +34,6 @@ func TestReadProcBool(t *testing.T) {
 	if readProcBool(path.Join(tmpDir, "no-exist")) {
 		t.Fatal("should be false for non-existent entry")
 	}
-
 }
 
 func TestCgroupEnabled(t *testing.T) {
@@ -46,7 +45,7 @@ func TestCgroupEnabled(t *testing.T) {
 		t.Fatal("cgroupEnabled should be false")
 	}
 
-	err = ioutil.WriteFile(path.Join(cgroupDir, "test"), []byte{}, 0644)
+	err = ioutil.WriteFile(path.Join(cgroupDir, "test"), []byte{}, 0o644)
 	require.NoError(t, err)
 
 	if !cgroupEnabled(cgroupDir, "test") {

--- a/pkg/sysinfo/sysinfo_solaris.go
+++ b/pkg/sysinfo/sysinfo_solaris.go
@@ -46,7 +46,7 @@ func IsCPUSharesAvailable() bool {
 
 // New returns a new SysInfo, using the filesystem to detect which features
 // the kernel supports.
-//NOTE Solaris: If we change the below capabilities be sure
+// NOTE Solaris: If we change the below capabilities be sure
 // to update verifyPlatformContainerSettings() in daemon_solaris.go
 func New(quiet bool) *SysInfo {
 	sysInfo := &SysInfo{}
@@ -64,7 +64,6 @@ func New(quiet bool) *SysInfo {
 
 // setCgroupMem reads the memory information for Solaris.
 func setCgroupMem(quiet bool) cgroupMemInfo {
-
 	return cgroupMemInfo{
 		MemoryLimit:       true,
 		SwapLimit:         true,
@@ -77,7 +76,6 @@ func setCgroupMem(quiet bool) cgroupMemInfo {
 
 // setCgroupCPU reads the cpu information for Solaris.
 func setCgroupCPU(quiet bool) cgroupCPUInfo {
-
 	return cgroupCPUInfo{
 		CPUShares:          true,
 		CPUCfsPeriod:       false,
@@ -89,7 +87,6 @@ func setCgroupCPU(quiet bool) cgroupCPUInfo {
 
 // blkio switches are not supported in Solaris.
 func setCgroupBlkioInfo(quiet bool) cgroupBlkioInfo {
-
 	return cgroupBlkioInfo{
 		BlkioWeight:       false,
 		BlkioWeightDevice: false,
@@ -98,7 +95,6 @@ func setCgroupBlkioInfo(quiet bool) cgroupBlkioInfo {
 
 // setCgroupCPUsetInfo reads the cpuset information for Solaris.
 func setCgroupCPUsetInfo(quiet bool) cgroupCpusetInfo {
-
 	return cgroupCpusetInfo{
 		Cpuset: true,
 		Cpus:   getCPUCount(),

--- a/pkg/timetype/timestamp.go
+++ b/pkg/timetype/timestamp.go
@@ -34,13 +34,14 @@ func GetTimestamp(value string, reference time.Time) (string, error) {
 	// if the string has a Z or a + or three dashes use parse otherwise use parseinlocation
 	parseInLocation := !(strings.ContainsAny(value, "zZ+") || strings.Count(value, "-") == 3)
 
-	if strings.Contains(value, ".") { // nolint:gocritic
+	switch {
+	case strings.Contains(value, "."):
 		if parseInLocation {
 			format = rFC3339NanoLocal
 		} else {
 			format = time.RFC3339Nano
 		}
-	} else if strings.Contains(value, "T") {
+	case strings.Contains(value, "T"):
 		// we want the number of colons in the T portion of the timestamp
 		tcolons := strings.Count(value, ":")
 		// if parseInLocation is off and we have a +/- zone offset (not Z) then
@@ -68,9 +69,9 @@ func GetTimestamp(value string, reference time.Time) (string, error) {
 				format = time.RFC3339
 			}
 		}
-	} else if parseInLocation {
+	case parseInLocation:
 		format = dateLocal
-	} else {
+	default:
 		format = dateWithZone
 	}
 
@@ -112,7 +113,7 @@ func ParseTimestamps(value string, def int64) (secs, nanoSecs int64, err error) 
 	return parseTimestamp(value)
 }
 
-func parseTimestamp(value string) (int64, int64, error) { // nolint:gocritic
+func parseTimestamp(value string) (int64, int64, error) {
 	sa := strings.SplitN(value, ".", 2)
 	s, err := strconv.ParseInt(sa[0], 10, 64)
 	if err != nil {

--- a/pkg/umask/umask_unix.go
+++ b/pkg/umask/umask_unix.go
@@ -10,8 +10,8 @@ import (
 )
 
 func Check() {
-	oldUmask := syscall.Umask(0022) //nolint
-	if (oldUmask & ^0022) != 0 {
+	oldUmask := syscall.Umask(0o022) //nolint
+	if (oldUmask & ^0o022) != 0 {
 		logrus.Debugf("umask value too restrictive.  Forcing it to 022")
 	}
 }

--- a/pkg/util/util_supported.go
+++ b/pkg/util/util_supported.go
@@ -23,7 +23,7 @@ var (
 // isWriteableOnlyByOwner checks that the specified permission mask allows write
 // access only to the owner.
 func isWriteableOnlyByOwner(perm os.FileMode) bool {
-	return (perm & 0722) == 0700
+	return (perm & 0o722) == 0o700
 }
 
 // GetRuntimeDir returns the runtime directory
@@ -46,7 +46,7 @@ func GetRuntimeDir() (string, error) {
 		uid := fmt.Sprintf("%d", unshare.GetRootlessUID())
 		if runtimeDir == "" {
 			tmpDir := filepath.Join("/run", "user", uid)
-			if err := os.MkdirAll(tmpDir, 0700); err != nil {
+			if err := os.MkdirAll(tmpDir, 0o700); err != nil {
 				logrus.Debugf("unable to make temp dir: %v", err)
 			}
 			st, err := os.Stat(tmpDir)
@@ -56,7 +56,7 @@ func GetRuntimeDir() (string, error) {
 		}
 		if runtimeDir == "" {
 			tmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("podman-run-%s", uid))
-			if err := os.MkdirAll(tmpDir, 0700); err != nil {
+			if err := os.MkdirAll(tmpDir, 0o700); err != nil {
 				logrus.Debugf("unable to make temp dir %v", err)
 			}
 			st, err := os.Stat(tmpDir)


### PR DESCRIPTION
This
 - fixes (or suppresses) some golangci-lint related warnings;
 - simplifies golangci-lint config for the sake of future maintainers;
 - bumps golangci-lint to v1.45.2.
 - adds a GHA CI job (a dup of one in cirrus-ci but separate, fast, and can annotate PRs).

TODO (not in this PR, just ideas)
 - maybe enable more linters;
 - maybe a separate lint job for new code (PRs) only and stricter rules (extra linters);
 
⚠️  **Please review commit by commit, and see commit messages for all the gory details.**