### PR TITLE
pkg/config: new value for events_logfile_max_size

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -405,10 +405,13 @@ if you want to set environment variables for the container.
 
 Define where event logs will be stored, when events_logger is "file".
 
-**events_logfile_max_size**=0
+**events_logfile_max_size**="1m"
 
-Sets the maximum size for events_logfile_path in bytes. When the limit is exceeded,
-the logfile will be rotated and the old one will be deleted.
+Sets the maximum size for events_logfile_path. 
+The unit can be b (bytes), k (kilobytes), m (megabytes) or g (gigabytes).
+The format for the size is `<number><unit>`, e.g., `1b` or `3g`.
+If no unit is included then the size will be in bytes.
+When the limit is exceeded, the logfile will be rotated and the old one will be deleted.
 If the maximumn size is set to 0, then no limit will be applied,
 and the logfile will not be rotated.
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -364,7 +364,7 @@ image_copy_tmp_dir="storage"`
 				gomega.Expect(config.Containers.LogDriver).To(gomega.BeEquivalentTo("k8s-file"))
 			}
 			gomega.Expect(config.Engine.EventsLogFilePath).To(gomega.BeEquivalentTo(config.Engine.TmpDir + "/events/events.log"))
-			gomega.Expect(config.Engine.EventsLogFileMaxSize).To(gomega.Equal(uint64(0)))
+			gomega.Expect(uint64(config.Engine.EventsLogFileMaxSize)).To(gomega.Equal(DefaultEventsLogSizeMax))
 		})
 
 		It("should success with valid user file path", func() {
@@ -402,7 +402,7 @@ image_copy_tmp_dir="storage"`
 			path, err := config.ImageCopyTmpDir()
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(path).To(gomega.BeEquivalentTo("/tmp/foobar"))
-			gomega.Expect(config.Engine.EventsLogFileMaxSize).To(gomega.BeEquivalentTo(uint64(500)))
+			gomega.Expect(uint64(config.Engine.EventsLogFileMaxSize)).To(gomega.Equal(uint64(500)))
 		})
 
 		It("should fail with invalid value", func() {

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -373,11 +373,14 @@ default_sysctls = [
 # Define where event logs will be stored, when events_logger is "file".
 #events_logfile_path=""
 
-# Sets the maximum size for events_logfile_path in bytes. When the limit is exceeded,
-# the logfile will be rotated and the old one will be deleted.
+# Sets the maximum size for events_logfile_path.
+# The size can be b (bytes), k (kilobytes), m (megabytes), or g (gigabytes).
+# The format for the size is `<number><unit>`, e.g., `1b` or `3g`.
+# If no unit is included then the size will be read in bytes.
+# When the limit is exceeded, the logfile will be rotated and the old one will be deleted.
 # If the maximum size is set to 0, then no limit will be applied,
 # and the logfile will not be rotated.
-#events_logfile_max_size = 0
+#events_logfile_max_size = "1m"
 
 # Selects which logging mechanism to use for container engine events.
 # Valid values are `journald`, `file` and `none`.
@@ -629,7 +632,7 @@ default_sysctls = [
 
 # Host directories to be mounted as volumes into the VM by default.
 # Environment variables like $HOME as well as complete paths are supported for
-# the source and destination. An optional third field `:ro` can be used to 
+# the source and destination. An optional third field `:ro` can be used to
 # tell the container engines to mount the volume readonly.
 #
 # volumes = [
@@ -641,3 +644,4 @@ default_sysctls = [
 # TOML does not provide a way to end a table other than a further table being
 # defined, so every key hereafter will be part of [machine] and not the
 # main config.
+

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -127,6 +127,9 @@ const (
 	// DefaultLogSizeMax is the default value for the maximum log size
 	// allowed for a container. Negative values mean that no limit is imposed.
 	DefaultLogSizeMax = -1
+	// DefaultEventsLogSize is the default value for the maximum events log size
+	// before rotation.
+	DefaultEventsLogSizeMax = uint64(1000000)
 	// DefaultPidsLimit is the default value for maximum number of processes
 	// allowed inside a container
 	DefaultPidsLimit = 2048
@@ -260,6 +263,8 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	c.TmpDir = tmp
 
 	c.EventsLogFilePath = filepath.Join(c.TmpDir, "events", "events.log")
+
+	c.EventsLogFileMaxSize = eventsLogMaxSize(DefaultEventsLogSizeMax)
 
 	c.CompatAPIEnforceDockerHub = true
 
@@ -462,6 +467,10 @@ func probeConmon(conmonBinary string) error {
 // NetNS returns the default network namespace
 func (c *Config) NetNS() string {
 	return c.Containers.NetNS
+}
+
+func (c EngineConfig) EventsLogMaxSize() uint64 {
+	return uint64(c.EventsLogFileMaxSize)
 }
 
 // SecurityOptions returns the default security options

--- a/pkg/config/testdata/containers_override.conf
+++ b/pkg/config/testdata/containers_override.conf
@@ -10,7 +10,7 @@ image_parallel_copies=10
 image_default_format="v2s2"
 image_copy_tmp_dir="/tmp/foobar"
 events_logfile_path = "/tmp/events.log"
-events_logfile_max_size=500
+events_logfile_max_size="500"
 
 [secrets]
 driver = "pass"


### PR DESCRIPTION
Changing the value for events_logfile_max_size from 0 to 1048576. This allows
up to 10,000 events to be written to the events log file before rotation occurs.
Also adding new values to default.go

Signed-off-by: Niall Crowe <nicrowe@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
