### PR TITLE
Add machine volumes to containers.conf

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -681,6 +681,13 @@ Memory in MB a machine is created with.
 Username to use and create on the podman machine OS for rootless container
 access. The default value is `user`. On Linux/Mac the default is`core`.
 
+**volumes**=["$HOME:$HOME"]
+
+Host directories to be mounted as volumes into the VM by default.
+Environment variables like $HOME as well as complete paths are supported for
+the source and destination. An optional third field `:ro` can be used to
+tell the container engines to mount the volume readonly.
+
 # FILES
 
 **containers.conf**

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -558,8 +558,10 @@ type MachineConfig struct {
 	Image string `toml:"image,omitempty"`
 	// Memory in MB a machine is created with.
 	Memory uint64 `toml:"memory,omitempty,omitzero"`
-	// Username to use for rootless podman when init-ing a podman machine VM
+	// User to use for rootless podman when init-ing a podman machine VM
 	User string `toml:"user,omitempty"`
+	// Volumes are host directories mounted into the VM by default.
+	Volumes []string `toml:"volumes"`
 }
 
 // Destination represents destination for remote service

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -203,6 +203,14 @@ image_copy_tmp_dir="storage"`
 				"TERM=xterm",
 			}
 
+			volumes := []string{
+				"$HOME:$HOME",
+			}
+
+			newVolumes := []string{
+				os.ExpandEnv("$HOME:$HOME"),
+			}
+
 			networkCmdOptions := []string{
 				"enable_ipv6=true",
 			}
@@ -224,6 +232,15 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(defaultConfig.Engine.HelperBinariesDir).To(gomega.Equal(helperDirs))
 			gomega.Expect(defaultConfig.Engine.ServiceTimeout).To(gomega.BeEquivalentTo(300))
 			gomega.Expect(defaultConfig.Engine.InfraImage).To(gomega.BeEquivalentTo("k8s.gcr.io/pause:3.4.1"))
+			gomega.Expect(defaultConfig.Machine.Volumes).To(gomega.BeEquivalentTo(volumes))
+			newV, err := defaultConfig.MachineVolumes()
+			if newVolumes[0] == ":" {
+				// $HOME is not set
+				gomega.Expect(err).To(gomega.HaveOccurred())
+			} else {
+				gomega.Expect(err).To(gomega.BeNil())
+				gomega.Expect(newV).To(gomega.BeEquivalentTo(newVolumes))
+			}
 		})
 
 		It("test GetDefaultEnvEx", func() {

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -627,6 +627,15 @@ default_sysctls = [
 #
 #user = "core"
 
+# Host directories to be mounted as volumes into the VM by default.
+# Environment variables like $HOME as well as complete paths are supported for
+# the source and destination. An optional third field `:ro` can be used to 
+# tell the container engines to mount the volume readonly.
+#
+# volumes = [
+#  "$HOME:$HOME",
+#]
+
 # The [machine] table MUST be the last entry in this file.
 # (Unless another table is added)
 # TOML does not provide a way to end a table other than a further table being

--- a/pkg/config/default_test.go
+++ b/pkg/config/default_test.go
@@ -63,3 +63,66 @@ func TestProbeConmon(t *testing.T) {
 		tc.assert(err, tc.msg)
 	}
 }
+
+func TestMachineVolumes(t *testing.T) {
+	t.Parallel()
+
+	os.Setenv("env1", "/test1")
+	os.Setenv("env2", "/test2")
+	for _, tc := range []struct {
+		msg     string
+		volumes []string
+		output  []string
+		assert  func(err error, in, out []string, msg string)
+	}{
+		{
+			volumes: []string{},
+			output:  []string{},
+			assert: func(err error, in, out []string, msg string) {
+				assert.Equal(t, in, out)
+				assert.Nil(t, err, msg)
+			},
+		},
+		{
+			volumes: []string{"/foobar:/foobar", "/foobar1:/foobardest:ro", "$env1:/env1", "$env1:$env1", "$env2:$env1"},
+			output:  []string{"/foobar:/foobar", "/foobar1:/foobardest:ro", "/test1:/env1", "/test1:/test1", "/test2:/test1"},
+			assert: func(err error, in, out []string, msg string) {
+				assert.Equal(t, in, out)
+				assert.Nil(t, err, msg)
+			},
+		},
+		{
+			volumes: []string{"/foobar:/foobar", "/foobar1:/foobardest:ro", "$env1:/env1", "$env1:$env1", "$env3:$env1"},
+			output:  []string{"/foobar:/foobar", "/foobar1:/foobardest:ro", "/test1:/env1", "/test1:/test1", "/test2:/test1"},
+			assert: func(err error, in, out []string, msg string) {
+				assert.EqualError(t, err, "invalid machine volume $env3:$env1, fields must container data", msg)
+			},
+		},
+		{
+			volumes: []string{"/foobar:/foobar", "/foobar1:/foobardest:ro", "$env1:/env1", "$env1:$env4", "$env1:$env1"},
+			output:  []string{"/foobar:/foobar", "/foobar1:/foobardest:ro", "/test1:/env1", "/test1:/test1", "/test2:/test1"},
+			assert: func(err error, in, out []string, msg string) {
+				assert.EqualError(t, err, "invalid machine volume $env1:$env4, fields must container data", msg)
+			},
+		},
+		{
+			msg:     "This is broken",
+			volumes: []string{"/foobar:/foobar:ro:badopt"},
+			output:  []string{"/foobar:/foobar:ro"},
+			assert: func(err error, in, out []string, msg string) {
+				assert.EqualError(t, err, "invalid machine volume /foobar:/foobar:ro:badopt, 2 or 3 fields required", msg)
+			},
+		},
+		{
+			msg:     "This is broken2",
+			volumes: []string{"/foobar"},
+			output:  []string{"/foobar:/foobar:ro"},
+			assert: func(err error, in, out []string, msg string) {
+				assert.EqualError(t, err, "invalid machine volume /foobar, 2 or 3 fields required", msg)
+			},
+		},
+	} {
+		output, err := machineVolumes(tc.volumes)
+		tc.assert(err, tc.output, output, tc.msg)
+	}
+}


### PR DESCRIPTION
This will allow users to specify which volumes they want podman machine
to automatically mount into the machine. These volumes can later be used
to volume mount into containers.

Environment variables like $HOME can be used and are translated at the
time of machine start.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
