### PR TITLE
pkg/config: fix docs for network_cmd_options

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -407,7 +407,7 @@ Define where event logs will be stored, when events_logger is "file".
 
 **events_logfile_max_size**="1m"
 
-Sets the maximum size for events_logfile_path. 
+Sets the maximum size for events_logfile_path.
 The unit can be b (bytes), k (kilobytes), m (megabytes) or g (gigabytes).
 The format for the size is `<number><unit>`, e.g., `1b` or `3g`.
 If no unit is included then the size will be in bytes.
@@ -509,16 +509,16 @@ and pods are visible.
 
 Path to the slirp4netns binary.
 
-**network_cmd_options**=["enable_ipv6=true",]
+**network_cmd_options**=[]
 
 Default options to pass to the slirp4netns binary.
 
 Valid options values are:
 
-  - **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`, which is added to `/etc/hosts` as `host.containers.internal` for your convenience). Default is false.
+  - **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`). Default is false.
   - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).
   - **cidr=CIDR**: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
-  - **enable_ipv6=true|false**: Enable IPv6. Default is false. (Required for `outbound_addr6`).
+  - **enable_ipv6=true|false**: Enable IPv6. Default is true. (Required for `outbound_addr6`).
   - **outbound_addr=INTERFACE**: Specify the outbound interface slirp should bind to (ipv4 traffic only).
   - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp should bind to.
   - **outbound_addr6=INTERFACE**: Specify the outbound interface slirp should bind to (ipv6 traffic only).

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -209,10 +209,6 @@ image_copy_tmp_dir="storage"`
 				os.ExpandEnv("$HOME:$HOME"),
 			}
 
-			networkCmdOptions := []string{
-				"enable_ipv6=true",
-			}
-
 			helperDirs := []string{
 				"/somepath",
 			}
@@ -226,7 +222,7 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(defaultConfig.Engine.NumLocks).To(gomega.BeEquivalentTo(2048))
 			gomega.Expect(defaultConfig.Engine.OCIRuntimes).To(gomega.Equal(OCIRuntimeMap))
 			gomega.Expect(defaultConfig.Containers.HTTPProxy).To(gomega.Equal(false))
-			gomega.Expect(defaultConfig.Engine.NetworkCmdOptions).To(gomega.BeEquivalentTo(networkCmdOptions))
+			gomega.Expect(defaultConfig.Engine.NetworkCmdOptions).To(gomega.BeNil())
 			gomega.Expect(defaultConfig.Engine.HelperBinariesDir).To(gomega.Equal(helperDirs))
 			gomega.Expect(defaultConfig.Engine.ServiceTimeout).To(gomega.BeEquivalentTo(300))
 			gomega.Expect(defaultConfig.Engine.InfraImage).To(gomega.BeEquivalentTo("k8s.gcr.io/pause:3.4.1"))

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -464,9 +464,26 @@ default_sysctls = [
 #network_cmd_path = ""
 
 # Default options to pass to the slirp4netns binary.
-# For example "allow_host_loopback=true"
+# Valid options values are:
 #
-#network_cmd_options = ["enable_ipv6=true",]
+# - allow_host_loopback=true|false: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`).
+#   Default is false.
+# - mtu=MTU: Specify the MTU to use for this network. (Default is `65520`).
+# - cidr=CIDR: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
+# - enable_ipv6=true|false: Enable IPv6. Default is true. (Required for `outbound_addr6`).
+# - outbound_addr=INTERFACE: Specify the outbound interface slirp should bind to (ipv4 traffic only).
+# - outbound_addr=IPv4: Specify the outbound ipv4 address slirp should bind to.
+# - outbound_addr6=INTERFACE: Specify the outbound interface slirp should bind to (ipv6 traffic only).
+# - outbound_addr6=IPv6: Specify the outbound ipv6 address slirp should bind to.
+# - port_handler=rootlesskit: Use rootlesskit for port forwarding. Default.
+#   Note: Rootlesskit changes the source IP address of incoming packets to a IP address in the container
+#   network namespace, usually `10.0.2.100`. If your application requires the real source IP address,
+#   e.g. web server logs, use the slirp4netns port handler. The rootlesskit port handler is also used for
+#   rootless containers when connected to user-defined networks.
+# - port_handler=slirp4netns: Use the slirp4netns port forwarding, it is slower than rootlesskit but
+#   preserves the correct source IP address. This port handler cannot be used for user-defined networks.
+#
+#network_cmd_options = []
 
 # Whether to use chroot instead of pivot_root in the runtime
 #
@@ -644,4 +661,3 @@ default_sysctls = [
 # TOML does not provide a way to end a table other than a further table being
 # defined, so every key hereafter will be part of [machine] and not the
 # main config.
-

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -299,9 +299,6 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	c.ServiceTimeout = uint(5)
 	c.StopTimeout = uint(10)
 	c.ExitCommandDelay = uint(5 * 60)
-	c.NetworkCmdOptions = []string{
-		"enable_ipv6=true",
-	}
 	c.Remote = isRemote()
 	c.OCIRuntimes = map[string][]string{
 		"crun": {


### PR DESCRIPTION
Slirp4netns options were changed to always default to ipv6 so it does
not need the extra setting. Update the documentation to reflect this.

see https://github.com/containers/podman/pull/13929

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
