### PR TITLE
Define default loggers in man page

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -434,8 +434,15 @@ and the logfile will not be rotated.
 
 **events_logger**="journald"
 
-Default method to use when logging events.
-Valid values: `file`, `journald`, and `none`.
+The default method to use when logging events.  
+
+The default method is different based on the platform that
+Podman is being run upon.  To determine the current value,
+use this command:
+
+`podman info --format {{.Host.EventLogger}`
+
+Valid values are: `file`, `journald`, and `none`.
 
 **helper_binaries_dir**=["/usr/libexec/podman", ...]
 


### PR DESCRIPTION
We have received two Bugzilla's about the upstream
documentation being incorrect about the default value of the
events_logger field in containers.conf.  The are:

https://bugzilla.redhat.com/show_bug.cgi?id=2076664
https://bugzilla.redhat.com/show_bug.cgi?id=2076665

From what I can see, we use `file` in RHEL and the podman machine,
in all other distributions were' using journald.  I've
attempted to change the man page to reflect that.

Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
