### PR TITLE
libimage should be using containers.conf for tmpdir

### DIFF
--- a/libimage/testdata/containers.conf
+++ b/libimage/testdata/containers.conf
@@ -1,0 +1,5 @@
+[engine]
+# Default location for storing temporary container image content. Can be overridden with the TMPDIR environment
+# variable. If you specify "storage", then the location of the
+# container/storage tmp directory will be used.
+image_copy_tmp_dir="/tmp/from/containers.conf"


### PR DESCRIPTION
if image_copy_tmp_dir is set in containers.conf it needs to be used in
the systemcontext for BigFilesTemporaryDir value.

Fixes: https://github.com/containers/podman/issues/14091

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
