### PR TITLE
Only attempt CGO_ENABLED builds on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,15 @@ define go-build
 	GOOS=$(1) GOARCH=$(2) $(GO) build -tags "$(3)" ./...
 endef
 
+ifeq ($(shell uname -s),Linux)
 define go-build-c
 	CGO_ENABLED=1 \
 	GOOS=$(1) GOARCH=$(2) $(GO) build -tags "$(3)" ./...
 endef
+else
+define go-build-c
+endef
+endif
 
 .PHONY:
 build-cross:


### PR DESCRIPTION
The cgo-enabled builds require Linux include files and libraries.
This change makes it possible to build the non-cgo versions on
non-Linux platforms.

Signed-off-by: Doug Rabson <dfr@rabson.org>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
