### PR TITLE
libnetwork: add new resolvconf package

### DIFF
--- a/libnetwork/resolvconf/resolv.go
+++ b/libnetwork/resolvconf/resolv.go
@@ -1,0 +1,178 @@
+package resolvconf
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containers/common/pkg/util"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	localhost         = "127.0.0.1"
+	systemdResolvedIP = "127.0.0.53"
+)
+
+// Params for the New() function.
+type Params struct {
+	// Path is the path to new resolv.conf file which should be created.
+	Path string
+	// Namespaces is the list of container namespaces.
+	// This is required to fist check for a resolv.conf under /etc/netns,
+	// created by "ip netns". Also used to check if the container has a
+	// netns in which case localhost nameserver must be filtered.
+	Namespaces []specs.LinuxNamespace
+	// IPv6Enabled will filter ipv6 nameservers when not set to true.
+	IPv6Enabled bool
+	// Nameservers is a list of nameservers the container should use,
+	// instead of the default ones from the host.
+	Nameservers []string
+	// Searches is a list of dns search domains the container should use,
+	// instead of the default ones from the host.
+	Searches []string
+	// Options is a list of dns options the container should use,
+	// instead of the default ones from the host.
+	Options []string
+
+	// resolvConfPath is the path which should be used as base to get the dns
+	// options. This should only be used for testing purposes. For all other
+	// callers this defaults to /etc/resolv.conf.
+	resolvConfPath string
+}
+
+func getDefaultResolvConf(params *Params) ([]byte, bool, error) {
+	resolveConf := DefaultResolvConf
+	// this is only used by testing
+	if params.resolvConfPath != "" {
+		resolveConf = params.resolvConfPath
+	}
+	hostNS := true
+	for _, ns := range params.Namespaces {
+		if ns.Type == specs.NetworkNamespace {
+			hostNS = false
+			if ns.Path != "" && !strings.HasPrefix(ns.Path, "/proc/") {
+				// check for netns created by "ip netns"
+				path := filepath.Join("/etc/netns", filepath.Base(ns.Path), "resolv.conf")
+				_, err := os.Stat(path)
+				if err == nil {
+					resolveConf = path
+				}
+			}
+			break
+		}
+	}
+
+	contents, err := os.ReadFile(resolveConf)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, false, err
+	}
+	if hostNS {
+		return contents, hostNS, nil
+	}
+
+	ns := getNameservers(contents)
+	// Check for local only resolver, in this case we want to get the real nameservers
+	// since localhost is not reachable from the netns.
+	if len(ns) == 1 {
+		var path string
+		switch ns[0] {
+		case systemdResolvedIP:
+			// used by systemd-resolved
+			path = "/run/systemd/resolve/resolv.conf"
+		case localhost:
+			// used by NetworkManager https://github.com/containers/podman/issues/13599
+			path = "/run/NetworkManager/no-stub-resolv.conf"
+		}
+		if path != "" {
+			// read the actual resolv.conf file for
+			resolvedContents, err := os.ReadFile(path)
+			if err != nil {
+				// do not error when the file does not exists, the detection logic is not perfect
+				if !errors.Is(err, os.ErrNotExist) {
+					return nil, false, fmt.Errorf("local resolver detected, but could not read real resolv.conf at %q: %w", path, err)
+				}
+			} else {
+				logrus.Debugf("found local resolver, using %q to get the nameservers", path)
+				contents = resolvedContents
+			}
+		}
+	}
+
+	return contents, hostNS, nil
+}
+
+// unsetSearchDomainsIfNeeded removes the search domain when they contain a single dot as element.
+func unsetSearchDomainsIfNeeded(searches []string) []string {
+	if util.StringInSlice(".", searches) {
+		return nil
+	}
+	return searches
+}
+
+// New creates a new resolv.conf file with the given params.
+func New(params *Params) error {
+	// short path, if everything is given there is no need to actually read the hosts /etc/resolv.conf
+	if len(params.Nameservers) > 0 && len(params.Options) > 0 && len(params.Searches) > 0 {
+		return build(params.Path, params.Nameservers, unsetSearchDomainsIfNeeded(params.Searches), params.Options)
+	}
+
+	content, hostNS, err := getDefaultResolvConf(params)
+	if err != nil {
+		return fmt.Errorf("failed to get the default /etc/resolv.conf content: %w", err)
+	}
+
+	content = filterResolvDNS(content, params.IPv6Enabled, !hostNS)
+
+	nameservers := params.Nameservers
+	if len(nameservers) == 0 {
+		nameservers = getNameservers(content)
+	}
+
+	searches := params.Searches
+	if len(searches) == 0 {
+		searches = getSearchDomains(content)
+	} else {
+		searches = unsetSearchDomainsIfNeeded(searches)
+	}
+
+	options := params.Options
+	if len(options) == 0 {
+		options = getOptions(content)
+	}
+
+	return build(params.Path, nameservers, searches, options)
+}
+
+// Add will add the given nameservers to the given resolv.conf file.
+// It will add the nameserver in front of the existing ones.
+func Add(path string, nameservers []string) error {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	nameservers = append(nameservers, getNameservers(contents)...)
+	return build(path, nameservers, getSearchDomains(contents), getOptions(contents))
+}
+
+// Remove the given nameserver from the given resolv.conf file.
+func Remove(path string, nameservers []string) error {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	oldNameservers := getNameservers(contents)
+	newNameserver := make([]string, 0, len(oldNameservers))
+	for _, ns := range oldNameservers {
+		if !util.StringInSlice(ns, nameservers) {
+			newNameserver = append(newNameserver, ns)
+		}
+	}
+
+	return build(path, newNameserver, getSearchDomains(contents), getOptions(contents))
+}

--- a/libnetwork/resolvconf/resolv_test.go
+++ b/libnetwork/resolvconf/resolv_test.go
@@ -1,0 +1,217 @@
+package resolvconf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+)
+
+const resolv1 = `nameserver 1.1.1.1
+`
+
+const resolv2 = `search example.com
+nameserver 1.1.1.1
+options edns0
+`
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name        string
+		baseContent string
+		nameservers []string
+		options     []string
+		searches    []string
+		ipv6        bool
+		hostns      bool
+		want        string
+	}{
+		{
+			name:        "simple resolv.conf",
+			baseContent: resolv1,
+			want:        resolv1,
+		},
+		{
+			name:        "simple resolv.conf with search and options",
+			baseContent: resolv2,
+			want:        resolv2,
+		},
+		{
+			name:        "simple resolv.conf with comments",
+			baseContent: "#some comment\n" + resolv2,
+			want:        resolv2,
+		},
+		{
+			name:        "overwrite default nameservers",
+			baseContent: resolv2,
+			nameservers: []string{"1.2.3.4", "5.6.7.8"},
+			want:        "search example.com\nnameserver 1.2.3.4\nnameserver 5.6.7.8\noptions edns0\n",
+		},
+		{
+			name:        "overwrite default options",
+			baseContent: resolv2,
+			options:     []string{"ndots:2"},
+			want:        "search example.com\nnameserver 1.1.1.1\noptions ndots:2\n",
+		},
+		{
+			name:        "overwrite default searches",
+			baseContent: resolv2,
+			searches:    []string{"test.com"},
+			want:        "search test.com\nnameserver 1.1.1.1\noptions edns0\n",
+		},
+		{
+			name:        "dot in searches should unset all search domains",
+			baseContent: resolv2,
+			searches:    []string{"."},
+			want:        "nameserver 1.1.1.1\noptions edns0\n",
+		},
+		{
+			name:        "overwrite all",
+			baseContent: resolv2,
+			nameservers: []string{"1.2.3.4", "5.6.7.8"},
+			options:     []string{"ndots:2"},
+			searches:    []string{"test.com"},
+			want:        "search test.com\nnameserver 1.2.3.4\nnameserver 5.6.7.8\noptions ndots:2\n",
+		},
+		{
+			name:        "localhost nameservers should be filtered and use defaults instead",
+			baseContent: "nameserver 127.0.0.1\nnameserver ::1\n",
+			want:        "nameserver 8.8.8.8\nnameserver 8.8.4.4\n",
+		},
+		{
+			name:        "localhost nameservers should not be filtered with hostns",
+			baseContent: "nameserver 127.0.0.1\nnameserver ::1\n",
+			hostns:      true,
+			want:        "nameserver 127.0.0.1\nnameserver ::1\n",
+		},
+		{
+			name:        "ipv6 nameservers should be filtered when ipv6 is not set",
+			baseContent: "nameserver 1.1.1.1\nnameserver fd::1\n",
+			want:        "nameserver 1.1.1.1\n",
+		},
+		{
+			name:        "ipv6 nameservers should not be filtered when ipv6 is set",
+			baseContent: "nameserver 1.1.1.1\nnameserver fd::1\n",
+			ipv6:        true,
+			want:        "nameserver 1.1.1.1\nnameserver fd::1\n",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			base := filepath.Join(t.TempDir(), "resolv.conf")
+			target := filepath.Join(t.TempDir(), "new-resolv.conf")
+			err := os.WriteFile(base, []byte(tt.baseContent), 0o644)
+			assert.NoError(t, err, "write tmp resolv.conf")
+			var namespaces []specs.LinuxNamespace
+			if !tt.hostns {
+				namespaces = []specs.LinuxNamespace{
+					{Type: specs.NetworkNamespace},
+				}
+			}
+			err = New(&Params{
+				Path:           target,
+				Nameservers:    tt.nameservers,
+				Searches:       tt.searches,
+				Options:        tt.options,
+				IPv6Enabled:    tt.ipv6,
+				Namespaces:     namespaces,
+				resolvConfPath: base,
+			})
+			assert.NoError(t, err, "New()")
+			content, err := os.ReadFile(target)
+			assert.NoError(t, err, "read tmp resolv.conf)")
+			assert.Equal(t, tt.want, string(content), "expected resolv.conf does not match")
+		})
+	}
+}
+
+func TestAdd(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		nameservers []string
+		want        string
+	}{
+		{
+			name:        "add single nameserver",
+			content:     resolv1,
+			nameservers: []string{"1.2.3.4"},
+			want:        "nameserver 1.2.3.4\n" + resolv1,
+		},
+		{
+			name:        "add single nameserver with search and options",
+			content:     resolv2,
+			nameservers: []string{"1.2.3.4"},
+			want: `search example.com
+nameserver 1.2.3.4
+nameserver 1.1.1.1
+options edns0
+`,
+		},
+		{
+			name:        "add three nameservers",
+			content:     resolv1,
+			nameservers: []string{"1.2.3.4", "2.3.4.5", "3.4.5.6"},
+			want:        "nameserver 1.2.3.4\nnameserver 2.3.4.5\nnameserver 3.4.5.6\n" + resolv1,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			resolvPath := filepath.Join(t.TempDir(), "resolv.conf")
+			err := os.WriteFile(resolvPath, []byte(tt.content), 0o644)
+			assert.NoError(t, err, "write tmp resolv.conf")
+			err = Add(resolvPath, tt.nameservers)
+			assert.NoError(t, err, "Add()")
+			content, err := os.ReadFile(resolvPath)
+			assert.NoError(t, err, "read tmp resolv.conf)")
+			assert.Equal(t, tt.want, string(content), "expected resolv.conf does not match")
+		})
+	}
+}
+
+func TestRemove(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		nameservers []string
+		want        string
+	}{
+		{
+			name:        "remove single nameserver",
+			content:     resolv1,
+			nameservers: []string{"1.1.1.1"},
+			want:        "",
+		},
+		{
+			name:        "remove single nameserver with search and options",
+			content:     resolv2,
+			nameservers: []string{"1.1.1.1"},
+			want: `search example.com
+options edns0
+`,
+		},
+		{
+			name:        "remove three nameservers",
+			content:     "nameserver 1.2.3.4\nnameserver 2.3.4.5\nnameserver 3.4.5.6\n" + resolv1,
+			nameservers: []string{"1.2.3.4", "2.3.4.5", "3.4.5.6"},
+			want:        resolv1,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			resolvPath := filepath.Join(t.TempDir(), "resolv.conf")
+			err := os.WriteFile(resolvPath, []byte(tt.content), 0o644)
+			assert.NoError(t, err, "write tmp resolv.conf")
+			err = Remove(resolvPath, tt.nameservers)
+			assert.NoError(t, err, "Remove()")
+			content, err := os.ReadFile(resolvPath)
+			assert.NoError(t, err, "read tmp resolv.conf)")
+			assert.Equal(t, tt.want, string(content), "expected resolv.conf does not match")
+		})
+	}
+}

--- a/libnetwork/resolvconf/resolvconf.go
+++ b/libnetwork/resolvconf/resolvconf.go
@@ -1,0 +1,156 @@
+// Package resolvconf provides utility code to query and update DNS configuration in /etc/resolv.conf.
+// Originally from github.com/docker/libnetwork/resolvconf but heavily modified to better work with podman.
+package resolvconf
+
+import (
+	"bytes"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// DefaultResolvConf points to the default file used for dns configuration on a linux machine.
+	DefaultResolvConf = "/etc/resolv.conf"
+)
+
+var (
+	// Note: the default IPv4 & IPv6 resolvers are set to Google's Public DNS.
+	defaultIPv4Dns = []string{"nameserver 8.8.8.8", "nameserver 8.8.4.4"}
+	defaultIPv6Dns = []string{"nameserver 2001:4860:4860::8888", "nameserver 2001:4860:4860::8844"}
+	ipv4NumBlock   = `(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)`
+	ipv4Address    = `(` + ipv4NumBlock + `\.){3}` + ipv4NumBlock
+	// This is not an IPv6 address verifier as it will accept a super-set of IPv6, and also
+	// will *not match* IPv4-Embedded IPv6 Addresses (RFC6052), but that and other variants
+	// -- e.g. other link-local types -- either won't work in containers or are unnecessary.
+	// For readability and sufficiency for Docker purposes this seemed more reasonable than a
+	// 1000+ character regexp with exact and complete IPv6 validation.
+	ipv6Address = `([0-9A-Fa-f]{0,4}:){2,7}([0-9A-Fa-f]{0,4})(%\w+)?`
+
+	// ipLocalhost is a regex pattern for IPv4 or IPv6 loopback range.
+	ipLocalhost = `((127\.([0-9]{1,3}\.){2}[0-9]{1,3})|(::1)$)`
+
+	localhostNSRegexp = regexp.MustCompile(`(?m)^nameserver\s+` + ipLocalhost + `\s*\n*`)
+	nsIPv6Regexp      = regexp.MustCompile(`(?m)^nameserver\s+` + ipv6Address + `\s*\n*`)
+	nsRegexp          = regexp.MustCompile(`^\s*nameserver\s*((` + ipv4Address + `)|(` + ipv6Address + `))\s*$`)
+	searchRegexp      = regexp.MustCompile(`^\s*search\s*(([^\s]+\s*)*)$`)
+	optionsRegexp     = regexp.MustCompile(`^\s*options\s*(([^\s]+\s*)*)$`)
+)
+
+// filterResolvDNS cleans up the config in resolvConf.  It has two main jobs:
+// 1. If a netns is enabled, it looks for localhost (127.*|::1) entries in the provided
+//    resolv.conf, removing local nameserver entries, and, if the resulting
+//    cleaned config has no defined nameservers left, adds default DNS entries
+// 2. Given the caller provides the enable/disable state of IPv6, the filter
+//    code will remove all IPv6 nameservers if it is not enabled for containers
+//
+func filterResolvDNS(resolvConf []byte, ipv6Enabled bool, netnsEnabled bool) []byte {
+	// If we're using the host netns, we have nothing to do besides hash the file.
+	if !netnsEnabled {
+		return resolvConf
+	}
+	cleanedResolvConf := localhostNSRegexp.ReplaceAll(resolvConf, []byte{})
+	// if IPv6 is not enabled, also clean out any IPv6 address nameserver
+	if !ipv6Enabled {
+		cleanedResolvConf = nsIPv6Regexp.ReplaceAll(cleanedResolvConf, []byte{})
+	}
+	// if the resulting resolvConf has no more nameservers defined, add appropriate
+	// default DNS servers for IPv4 and (optionally) IPv6
+	if len(getNameservers(cleanedResolvConf)) == 0 {
+		logrus.Infof("No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: %v", defaultIPv4Dns)
+		dns := defaultIPv4Dns
+		if ipv6Enabled {
+			logrus.Infof("IPv6 enabled; Adding default IPv6 external servers: %v", defaultIPv6Dns)
+			dns = append(dns, defaultIPv6Dns...)
+		}
+		cleanedResolvConf = append(cleanedResolvConf, []byte("\n"+strings.Join(dns, "\n"))...)
+	}
+	return cleanedResolvConf
+}
+
+// getLines parses input into lines and strips away comments.
+func getLines(input []byte) [][]byte {
+	lines := bytes.Split(input, []byte("\n"))
+	var output [][]byte
+	for _, currentLine := range lines {
+		commentIndex := bytes.Index(currentLine, []byte("#"))
+		if commentIndex == -1 {
+			output = append(output, currentLine)
+		} else {
+			output = append(output, currentLine[:commentIndex])
+		}
+	}
+	return output
+}
+
+// getNameservers returns nameservers (if any) listed in /etc/resolv.conf.
+func getNameservers(resolvConf []byte) []string {
+	nameservers := []string{}
+	for _, line := range getLines(resolvConf) {
+		ns := nsRegexp.FindSubmatch(line)
+		if len(ns) > 0 {
+			nameservers = append(nameservers, string(ns[1]))
+		}
+	}
+	return nameservers
+}
+
+// getSearchDomains returns search domains (if any) listed in /etc/resolv.conf
+// If more than one search line is encountered, only the contents of the last
+// one is returned.
+func getSearchDomains(resolvConf []byte) []string {
+	domains := []string{}
+	for _, line := range getLines(resolvConf) {
+		match := searchRegexp.FindSubmatch(line)
+		if match == nil {
+			continue
+		}
+		domains = strings.Fields(string(match[1]))
+	}
+	return domains
+}
+
+// getOptions returns options (if any) listed in /etc/resolv.conf
+// If more than one options line is encountered, only the contents of the last
+// one is returned.
+func getOptions(resolvConf []byte) []string {
+	options := []string{}
+	for _, line := range getLines(resolvConf) {
+		match := optionsRegexp.FindSubmatch(line)
+		if match == nil {
+			continue
+		}
+		options = strings.Fields(string(match[1]))
+	}
+	return options
+}
+
+// build writes a configuration file to path containing a "nameserver" entry
+// for every element in dns, a "search" entry for every element in
+// dnsSearch, and an "options" entry for every element in dnsOptions.
+func build(path string, dns, dnsSearch, dnsOptions []string) error {
+	content := new(bytes.Buffer)
+	if len(dnsSearch) > 0 {
+		if searchString := strings.Join(dnsSearch, " "); strings.Trim(searchString, " ") != "." {
+			if _, err := content.WriteString("search " + searchString + "\n"); err != nil {
+				return err
+			}
+		}
+	}
+	for _, dns := range dns {
+		if _, err := content.WriteString("nameserver " + dns + "\n"); err != nil {
+			return err
+		}
+	}
+	if len(dnsOptions) > 0 {
+		if optsString := strings.Join(dnsOptions, " "); strings.Trim(optsString, " ") != "" {
+			if _, err := content.WriteString("options " + optsString + "\n"); err != nil {
+				return err
+			}
+		}
+	}
+
+	return os.WriteFile(path, content.Bytes(), 0o644)
+}


### PR DESCRIPTION
both buildah and podman currently use a slightly different resolvconf lib,
to prevent duplication and having to fix bugs twice they should both use
this new package instead.

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
