### PR TITLE
CI: enable extra linters for new code

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
     - uses: actions/setup-go@v3
       with:
         go-version: 1.x # latest stable
@@ -35,5 +37,11 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: "${{ env.LINT_VERSION }}"
+    # Extra linters, only checking new code from a pull request.
+    - name: lint-extra
+      if: github.event_name == 'pull_request'
+      run: |
+        golangci-lint run --config .golangci-extra.yml --new-from-rev=HEAD~1 --out-format=github-actions
+
     - name: validate seccomp
       run: ./tools/validate_seccomp.sh ./pkg/seccomp

--- a/.golangci-extra.yml
+++ b/.golangci-extra.yml
@@ -1,0 +1,23 @@
+# This is golangci-lint config file which is used to check new code in
+# github PRs only (see lint-extra in .github/workflows/validate.yml).
+#
+# For the default linter config, see .golangci.yml. This config should
+# only enable additional linters not enabled in the default config.
+# The idea is to impose additional rules for newly added code only
+# (rules we can not realistically satisfy for existing code).
+
+run:
+  build-tags:
+    - apparmor
+    - seccomp
+    - selinux
+    - systemd
+    - exclude_graphdriver_btrfs
+    - containers_image_openpgp
+  concurrency: 6
+  deadline: 5m
+
+linters:
+  disable-all: true
+  enable:
+    - godot


### PR DESCRIPTION
The idea here is to run some more picky linters only on new code,
so we can keep the existing code as is, but impose some additional
requirements to any new code.

Currently, this enables godot linter which wants all comments to have a
period at the end of the sentence. This makes sense because otherwise
some comments might be read as unfinished.

Obviously, no one wants to fix all the existing comments to have
periods, but this will impose such requirement onto any new code
(which also includes the code that is moved around).

Hope that makes sense.
