### PR TITLE
cirrus-ci: rm make validate

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -65,8 +65,6 @@ testing_task:
     - make vendor
     - make build
     - make build-cross
-    - make install.tools
-    - make validate
     - make test
 
 


### PR DESCRIPTION
This is now performed by github actions (see commit
05a2076120acd2c8c0, PR #997), so there's no need to perform this twice.