### PR TITLE
libimage: load: close reader

### DIFF
--- a/libimage/load.go
+++ b/libimage/load.go
@@ -114,6 +114,11 @@ func (r *Runtime) loadMultiImageDockerArchive(ctx context.Context, ref types.Ima
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err := reader.Close(); err != nil {
+			logrus.Errorf("Closing reader of docker archive: %v", err)
+		}
+	}()
 
 	refLists, err := reader.List()
 	if err != nil {

--- a/libimage/load_test.go
+++ b/libimage/load_test.go
@@ -2,6 +2,7 @@ package libimage
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -9,6 +10,17 @@ import (
 )
 
 func TestLoad(t *testing.T) {
+	// Make sure that loading images does not leave any artifacts in TMPDIR
+	// behind (containers/podman/issues/14287).
+	tmpdir := t.TempDir()
+	os.Setenv("TMPDIR", tmpdir)
+	defer func() {
+		dir, err := ioutil.ReadDir(tmpdir)
+		require.NoError(t, err)
+		require.Len(t, dir, 0)
+		os.Unsetenv("TMPDIR")
+	}()
+
 	runtime, cleanup := testNewRuntime(t)
 	defer cleanup()
 	ctx := context.Background()

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -315,6 +315,11 @@ func (r *Runtime) copyFromDockerArchive(ctx context.Context, ref types.ImageRefe
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err := reader.Close(); err != nil {
+			logrus.Errorf("Closing reader of docker archive: %v", err)
+		}
+	}()
 
 	return r.copyFromDockerArchiveReaderReference(ctx, reader, readerRef, options)
 }


### PR DESCRIPTION
Close the reader of an Docker archive to make sure that artifacts in
TMPDIR are removed.

Closes: github.com/containers/podman/issues/14287
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
