### PR TITLE
libimage/define: add search filters

### DIFF
--- a/libimage/define/search.go
+++ b/libimage/define/search.go
@@ -1,0 +1,13 @@
+package define
+
+const (
+	// SearchFilterAutomated is the key for filtering images by their automated attribute.
+	SearchFilterAutomated = "is-automated"
+	// SearchFilterOfficial is the key for filtering images by their official attribute.
+	SearchFilterOfficial = "is-official"
+	// SearchFilterStars is the key for filtering images by stars.
+	SearchFilterStars = "stars"
+)
+
+// SearchFilters includes all supported search filters.
+var SearchFilters = []string{SearchFilterAutomated, SearchFilterOfficial, SearchFilterStars}

--- a/libimage/search.go
+++ b/libimage/search.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/containers/common/libimage/define"
 	registryTransport "github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/image/v5/transports/alltransports"
@@ -81,22 +82,22 @@ func ParseSearchFilter(filter []string) (*SearchFilter, error) {
 	for _, f := range filter {
 		arr := strings.SplitN(f, "=", 2)
 		switch arr[0] {
-		case "stars":
+		case define.SearchFilterStars:
 			if len(arr) < 2 {
-				return nil, errors.Errorf("invalid `stars` filter %q, should be stars=<value>", filter)
+				return nil, errors.Errorf("invalid filter %q, should be stars=<value>", filter)
 			}
 			stars, err := strconv.Atoi(arr[1])
 			if err != nil {
 				return nil, errors.Wrapf(err, "incorrect value type for stars filter")
 			}
 			sFilter.Stars = stars
-		case "is-automated":
+		case define.SearchFilterAutomated:
 			if len(arr) == 2 && arr[1] == "false" {
 				sFilter.IsAutomated = types.OptionalBoolFalse
 			} else {
 				sFilter.IsAutomated = types.OptionalBoolTrue
 			}
-		case "is-official":
+		case define.SearchFilterOfficial:
 			if len(arr) == 2 && arr[1] == "false" {
 				sFilter.IsOfficial = types.OptionalBoolFalse
 			} else {


### PR DESCRIPTION
To have tools using libimage be able to auto-complete the search filters
on the CLI, move the consts and vars to a new `libimage/define` package.
The new package prevents pulling in all the low-levels libraries.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
