### PR TITLE
secret handling for kube compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 retract (

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -32,7 +32,7 @@ func TestAddSecretAndLookupData(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(testpath)
 
-	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, opts)
+	_, err = manager.Store("mysecret", []byte("mydata"), false, drivertype, opts)
 	require.NoError(t, err)
 
 	_, err = manager.lookupSecret("mysecret")
@@ -51,28 +51,28 @@ func TestAddSecretName(t *testing.T) {
 	defer cleanup(testpath)
 
 	// test one char secret name
-	_, err = manager.Store("a", []byte("mydata"), drivertype, opts)
+	_, err = manager.Store("a", []byte("mydata"), false, drivertype, opts)
 	require.NoError(t, err)
 
 	_, err = manager.lookupSecret("a")
 	require.NoError(t, err)
 
 	// name too short
-	_, err = manager.Store("", []byte("mydata"), drivertype, opts)
+	_, err = manager.Store("", []byte("mydata"), false, drivertype, opts)
 	require.Error(t, err)
 	// name too long
-	_, err = manager.Store("uatqsbssrapurkuqoapubpifvsrissslzjehalxcesbhpxcvhsozlptrmngrivaiz", []byte("mydata"), drivertype, opts)
+	_, err = manager.Store("uatqsbssrapurkuqoapubpifvsrissslzjehalxcesbhpxcvhsozlptrmngrivaiz", []byte("mydata"), false, drivertype, opts)
 	require.Error(t, err)
 	// invalid chars
-	_, err = manager.Store("??", []byte("mydata"), drivertype, opts)
+	_, err = manager.Store("??", []byte("mydata"), false, drivertype, opts)
 	require.Error(t, err)
-	_, err = manager.Store("-a", []byte("mydata"), drivertype, opts)
+	_, err = manager.Store("-a", []byte("mydata"), false, drivertype, opts)
 	require.Error(t, err)
-	_, err = manager.Store("a-", []byte("mydata"), drivertype, opts)
+	_, err = manager.Store("a-", []byte("mydata"), false, drivertype, opts)
 	require.Error(t, err)
-	_, err = manager.Store(".a", []byte("mydata"), drivertype, opts)
+	_, err = manager.Store(".a", []byte("mydata"), false, drivertype, opts)
 	require.Error(t, err)
-	_, err = manager.Store("a.", []byte("mydata"), drivertype, opts)
+	_, err = manager.Store("a.", []byte("mydata"), false, drivertype, opts)
 	require.Error(t, err)
 }
 
@@ -81,10 +81,10 @@ func TestAddMultipleSecrets(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(testpath)
 
-	id, err := manager.Store("mysecret", []byte("mydata"), drivertype, opts)
+	id, err := manager.Store("mysecret", []byte("mydata"), false, drivertype, opts)
 	require.NoError(t, err)
 
-	id2, err := manager.Store("mysecret2", []byte("mydata2"), drivertype, opts)
+	id2, err := manager.Store("mysecret2", []byte("mydata2"), false, drivertype, opts)
 	require.NoError(t, err)
 
 	secrets, err := manager.List()
@@ -115,10 +115,10 @@ func TestAddSecretDupName(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(testpath)
 
-	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, opts)
+	_, err = manager.Store("mysecret", []byte("mydata"), false, drivertype, opts)
 	require.NoError(t, err)
 
-	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, opts)
+	_, err = manager.Store("mysecret", []byte("mydata"), false, drivertype, opts)
 	require.Error(t, err)
 }
 
@@ -129,10 +129,10 @@ func TestAddSecretPrefix(t *testing.T) {
 
 	// If the randomly generated secret id is something like "abcdeiuoergnadufigh"
 	// we should still allow someone to store a secret with the name "abcd" or "a"
-	secretID, err := manager.Store("mysecret", []byte("mydata"), drivertype, opts)
+	secretID, err := manager.Store("mysecret", []byte("mydata"), false, drivertype, opts)
 	require.NoError(t, err)
 
-	_, err = manager.Store(secretID[0:5], []byte("mydata"), drivertype, opts)
+	_, err = manager.Store(secretID[0:5], []byte("mydata"), false, drivertype, opts)
 	require.NoError(t, err)
 }
 
@@ -141,7 +141,7 @@ func TestRemoveSecret(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(testpath)
 
-	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, opts)
+	_, err = manager.Store("mysecret", []byte("mydata"), false, drivertype, opts)
 	require.NoError(t, err)
 
 	_, err = manager.lookupSecret("mysecret")
@@ -171,7 +171,7 @@ func TestLookupAllSecrets(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(testpath)
 
-	id, err := manager.Store("mysecret", []byte("mydata"), drivertype, opts)
+	id, err := manager.Store("mysecret", []byte("mydata"), false, drivertype, opts)
 	require.NoError(t, err)
 
 	// inspect using secret name
@@ -185,7 +185,7 @@ func TestInspectSecretId(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(testpath)
 
-	id, err := manager.Store("mysecret", []byte("mydata"), drivertype, opts)
+	id, err := manager.Store("mysecret", []byte("mydata"), false, drivertype, opts)
 	require.NoError(t, err)
 
 	_, err = manager.lookupSecret("mysecret")
@@ -217,12 +217,44 @@ func TestSecretList(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(testpath)
 
-	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, opts)
+	_, err = manager.Store("mysecret", []byte("mydata"), false, drivertype, opts)
 	require.NoError(t, err)
-	_, err = manager.Store("mysecret2", []byte("mydata2"), drivertype, opts)
+	_, err = manager.Store("mysecret2", []byte("mydata2"), false, drivertype, opts)
 	require.NoError(t, err)
 
 	allSecrets, err := manager.List()
 	require.NoError(t, err)
 	require.Len(t, allSecrets, 2)
+}
+
+func TestSecretKubeFormat(t *testing.T) {
+	manager, testpath, err := setup()
+	require.NoError(t, err)
+	defer cleanup(testpath)
+
+	secret := `
+    apiVersion: v1
+    data:
+      mydata1: 1234
+      mydata2: 5678
+    kind: Secret
+    metadata:
+      name: mysecret
+    type: Opaque`
+
+	_, err = manager.Store("mysecret", []byte(secret), true, drivertype, opts)
+	require.NoError(t, err)
+
+	_, err = manager.lookupSecret("mysecret")
+	require.NoError(t, err)
+
+	_, data, err := manager.LookupKubeSecretData("mysecret", []string{"mydata1"})
+	require.NoError(t, err)
+
+	val, ok := data["mydata1"]
+	require.True(t, ok)
+
+	if !bytes.Equal(val, []byte("1234")) {
+		t.Errorf("error: secret data not equal")
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -595,6 +595,7 @@ gopkg.in/square/go-jose.v2
 gopkg.in/square/go-jose.v2/cipher
 gopkg.in/square/go-jose.v2/json
 # gopkg.in/yaml.v2 v2.4.0
+## explicit
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 gopkg.in/yaml.v3


### PR DESCRIPTION
implement a new secret design that allows for a single secret to have multiple
data tags, similar to how kube secrets are implemented so that podman can natively
convert its own secrets to kube secrets when running `podman play kube` and `podman generate kube`

Signed-off-by: cdoern <cbdoer23@g.holycross.edu>
