### PR TITLE
[CI:DOCS] Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,5 @@
 name: validate
+
 on:
   push:
     tags:
@@ -7,6 +8,9 @@ on:
       - main
       - v*
   pull_request:
+
+permissions: read-all
+
 env:
   LINT_VERSION: v1.45
 
@@ -14,7 +18,7 @@ jobs:
   codespell:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3
     - name: install deps
       # Version of codespell bundled with Ubuntu is way old, so use pip.
       run: pip install codespell
@@ -23,10 +27,10 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3
       with:
         fetch-depth: 2
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v3
       with:
         go-version: 1.x # latest stable
     - name: install deps
@@ -34,7 +38,7 @@ jobs:
         sudo apt-get -qq update
         sudo apt-get -qq install libseccomp-dev libdevmapper-dev
     - name: lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc # v3
       with:
         version: "${{ env.LINT_VERSION }}"
     # Extra linters, only checking new code from a pull request.


### PR DESCRIPTION
This corresponds to similar changes made in Buildah, Podman, and Skopeo: https://github.com/containers/podman/pull/13564 https://github.com/containers/buildah/pull/3872 https://github.com/containers/skopeo/pull/1652

+ Pin actions to a full length commit SHA is currently the only way
  to use an action as an immutable release. Pinning to a particular SHA
  helps mitigate the risk of a bad actor adding a backdoor to the action's
  repository, as they would need to generate a SHA-1 collision for a valid
  Git object payload. Ref:
  https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

+ Explicitly set permissions for actions to minimum required.  The
  defaults are (unfortunately) overly permissive: Ref:
  https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
