### PR TITLE
libnetwork: add a dummy network backend

### DIFF
--- a/libnetwork/dummy/dummy.go
+++ b/libnetwork/dummy/dummy.go
@@ -1,0 +1,59 @@
+package dummy
+
+import (
+	"github.com/containers/common/libnetwork/types"
+	"github.com/pkg/errors"
+)
+
+type dummyNetwork struct{}
+
+// NetworkCreate will take a partial filled Network and fill the
+// missing fields. It creates the Network and returns the full Network.
+func (n *dummyNetwork) NetworkCreate(net types.Network) (types.Network, error) {
+	return types.Network{}, errors.New("function not supported by the dummy network backend")
+}
+
+// NetworkRemove will remove the Network with the given name or ID.
+// It does not ensure that the network is unused.
+func (n *dummyNetwork) NetworkRemove(nameOrID string) error {
+	return errors.New("function not supported by the dummy network backend")
+}
+
+// NetworkList will return all known Networks. Optionally you can
+// supply a list of filter functions. Only if a network matches all
+// functions it is returned.
+func (n *dummyNetwork) NetworkList(filters ...types.FilterFunc) ([]types.Network, error) {
+	return nil, errors.New("function not supported by the dummy network backend")
+}
+
+// NetworkInspect will return the Network with the given name or ID.
+func (n *dummyNetwork) NetworkInspect(nameOrID string) (types.Network, error) {
+	return types.Network{}, errors.New("function not supported by the dummy network backend")
+}
+
+// Setup will setup the container network namespace. It returns
+// a map of StatusBlocks, the key is the network name.
+func (n *dummyNetwork) Setup(namespacePath string, options types.SetupOptions) (map[string]types.StatusBlock, error) {
+	return nil, errors.New("function not supported by the dummy network backend")
+}
+
+// Teardown will teardown the container network namespace.
+func (n *dummyNetwork) Teardown(namespacePath string, options types.TeardownOptions) error {
+	return errors.New("function not supported by the dummy network backend")
+}
+
+// Drivers will return the list of supported network drivers
+// for this interface.
+func (n *dummyNetwork) Drivers() []string {
+	return []string{}
+}
+
+// DefaultNetworkName will return the default cni network name.
+func (n *dummyNetwork) DefaultNetworkName() string {
+	return "dummy"
+}
+
+// NewNetworkInterface creates the ContainerNetwork interface for the dummy backend.
+func NewDummyNetworkInterface() types.ContainerNetwork {
+	return &dummyNetwork{}
+}

--- a/libnetwork/network/interface_unsupported.go
+++ b/libnetwork/network/interface_unsupported.go
@@ -1,0 +1,37 @@
+//go:build !linux && !freebsd
+// +build !linux,!freebsd
+
+package network
+
+import (
+	"fmt"
+
+	"github.com/containers/common/libnetwork/dummy"
+	"github.com/containers/common/libnetwork/types"
+	"github.com/containers/common/pkg/config"
+	"github.com/containers/storage"
+)
+
+func NetworkBackend(store storage.Store, conf *config.Config, syslog bool) (types.NetworkBackend, types.ContainerNetwork, error) {
+	backend := types.NetworkBackend(conf.Network.NetworkBackend)
+	if backend == "" {
+		var err error
+		backend, err = defaultNetworkBackend(store, conf)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to get default network backend: %w", err)
+		}
+	}
+
+	switch backend {
+	case types.Dummy:
+		netInt := dummy.NewDummyNetworkInterface()
+		return types.Dummy, netInt, nil
+
+	default:
+		return "", nil, fmt.Errorf("unsupported network backend %q, check network_backend in containers.conf", backend)
+	}
+}
+
+func defaultNetworkBackend(store storage.Store, conf *config.Config) (backend types.NetworkBackend, err error) {
+	return types.Dummy, nil
+}

--- a/libnetwork/types/const.go
+++ b/libnetwork/types/const.go
@@ -41,6 +41,7 @@ type NetworkBackend string
 const (
 	CNI      NetworkBackend = "cni"
 	Netavark NetworkBackend = "netavark"
+	Dummy    NetworkBackend = "dummy"
 )
 
 // ValidMacVLANModes is the list of valid mode options for the macvlan driver


### PR DESCRIPTION
Add a dummy network backend that fails on every operation requested to
it.

This allows consumers of this package to obtain and carry around (as
long it's not really used) a types.ContainerNetwork object even on
targets where no network backend is supported, which is convenient to
avoid having to gate a significant amount of code behind run-time
and/or build-time conditionals.

Signed-off-by: Sergio Lopez <slp@redhat.com>
