### PR TITLE
libimage: tweak platform checks

### DIFF
--- a/libimage/platform.go
+++ b/libimage/platform.go
@@ -6,6 +6,16 @@ import (
 	"runtime"
 )
 
+// PlatformPolicy controls the behavior of image-platform matching.
+type PlatformPolicy int
+
+const (
+	// Only debug log if an image does not match the expected platform.
+	PlatformPolicyDefault PlatformPolicy = iota
+	// Warn if an image does not match the expected platform.
+	PlatformPolicyWarn
+)
+
 func toPlatformString(architecture, os, variant string) string {
 	if variant == "" {
 		return fmt.Sprintf("%s/%s", os, architecture)


### PR DESCRIPTION
Do not check the platform of an image when it was looked up by it's ID.
In that case we must assume that the user/tool knows what they are
doing.

Further make the warnings configurable via a new `PlatformPolicy` field
in the `ImageLookupOptions`.  By default, the error will only be printed
on the debug logs.  User can opt-in to display the error on the warning
level.  Not all code paths should warn.  For instance, when inspecting
an image.  This way, consumers of libimage can opt-in.  The policy can
later on be extended to error out instead of logging.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
