### PR TITLE
pkg/config: CONTAINERS_CONF must be absolute

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -709,6 +709,13 @@ func systemConfigs() ([]string, error) {
 	configs := []string{}
 	path := os.Getenv("CONTAINERS_CONF")
 	if path != "" {
+		// Podman cleanup process may not fire if the path isn't
+		// absolute.
+		path, err = filepath.Abs(path)
+		if err != nil {
+			return nil, err
+		}
+		os.Setenv("CONTAINERS_CONF", path)
 		if _, err := os.Stat(path); err != nil {
 			return nil, fmt.Errorf("CONTAINERS_CONF file: %w", err)
 		}


### PR DESCRIPTION
Otherwise Podman's cleanup process does not start. I do not know why but
tests turn green in containers/podman/pull/14559 with it.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
