### PR TITLE
improve NewSystemd's capability for setting resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/opencontainers/runtime-tools v0.9.0
 	github.com/opencontainers/selinux v1.10.1
 	github.com/pkg/errors v0.9.1
-	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646
+	github.com/seccomp/libseccomp-golang v0.10.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
@@ -115,4 +115,4 @@ retract (
 	v1.0.0 // We reverted to v0.… version numbers; the v1.0.0 tag was actually deleted.
 )
 
-replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.1-0.20220607072441-a7a45d7d2721
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc

--- a/go.sum
+++ b/go.sum
@@ -747,8 +747,8 @@ github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.3-0.20211202193544-a5463b7f9c84 h1:g47eG1u/gw0JB7mZ88TcHKCmsy7sWUNZD8ZS9Jhi0O8=
 github.com/opencontainers/image-spec v1.0.3-0.20211202193544-a5463b7f9c84/go.mod h1:Qnt1q4cjDNQI9bT832ziho5Iw2BhK8o1KwLOwW56VP4=
-github.com/opencontainers/runc v1.1.1-0.20220607072441-a7a45d7d2721 h1:geG4wjkUPHyg+Ya/BBb8YlX1z4INWpVMdoUnmBxttqc=
-github.com/opencontainers/runc v1.1.1-0.20220607072441-a7a45d7d2721/go.mod h1:QvA0UNe48mC1JxcXq0sENIR38+/LdJMLNxuAvtFBhxA=
+github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc h1:qjkUzmFsOFbQyjObybk40mRida83j5IHRaKzLGdBbEU=
+github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc/go.mod h1:wUOQGsiKae6VzA/UvlCK3cO+pHk8F2VQHlIoITEfMM8=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2-0.20190207185410-29686dbc5559/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
@@ -841,8 +841,8 @@ github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=
 github.com/sebdah/goldie/v2 v2.5.3/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
-github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646 h1:RpforrEYXWkmGwJHIGnLZ3tTWStkjVVstwzNGqxX2Ds=
-github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
+github.com/seccomp/libseccomp-golang v0.10.0 h1:aA4bp+/Zzi0BnWZ2F1wgNBs5gTpm+na2rWM6M9YjLpY=
+github.com/seccomp/libseccomp-golang v0.10.0/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/pkg/cgroups/blkio_linux.go
+++ b/pkg/cgroups/blkio_linux.go
@@ -41,6 +41,9 @@ func (c *linuxBlkioHandler) Apply(ctr *CgroupControl, res *configs.Resources) er
 
 // Create the cgroup
 func (c *linuxBlkioHandler) Create(ctr *CgroupControl) (bool, error) {
+	if ctr.cgroup2 {
+		return false, nil
+	}
 	return ctr.createCgroupDirectory(Blkio)
 }
 

--- a/pkg/cgroups/cgroups_linux_test.go
+++ b/pkg/cgroups/cgroups_linux_test.go
@@ -25,7 +25,7 @@ func TestCreated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cgr, err = NewSystemd("machine.slice")
+	cgr, err = NewSystemd("machine.slice", &resources)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,5 +57,10 @@ func TestResources(t *testing.T) {
 	}
 	if cgr.config.CpuPeriod != 100000 || cgr.config.CpuQuota != 100000 {
 		t.Fatal("Got the wrong value, set cpu.cfs_period_us failed.")
+	}
+
+	_, err = NewSystemd("machine2.slice", &resources)
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/cgroups/cpu_linux.go
+++ b/pkg/cgroups/cpu_linux.go
@@ -38,6 +38,9 @@ func (c *linuxCPUHandler) Apply(ctr *CgroupControl, res *configs.Resources) erro
 
 // Create the cgroup
 func (c *linuxCPUHandler) Create(ctr *CgroupControl) (bool, error) {
+	if ctr.cgroup2 {
+		return false, nil
+	}
 	return ctr.createCgroupDirectory(CPU)
 }
 

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/blkio_device.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/blkio_device.go
@@ -2,8 +2,8 @@ package configs
 
 import "fmt"
 
-// blockIODevice holds major:minor format supported in blkio cgroup
-type blockIODevice struct {
+// BlockIODevice holds major:minor format supported in blkio cgroup.
+type BlockIODevice struct {
 	// Major is the device's major number
 	Major int64 `json:"major"`
 	// Minor is the device's minor number
@@ -12,7 +12,7 @@ type blockIODevice struct {
 
 // WeightDevice struct holds a `major:minor weight`|`major:minor leaf_weight` pair
 type WeightDevice struct {
-	blockIODevice
+	BlockIODevice
 	// Weight is the bandwidth rate for the device, range is from 10 to 1000
 	Weight uint16 `json:"weight"`
 	// LeafWeight is the bandwidth rate for the device while competing with the cgroup's child cgroups, range is from 10 to 1000, cfq scheduler only
@@ -41,7 +41,7 @@ func (wd *WeightDevice) LeafWeightString() string {
 
 // ThrottleDevice struct holds a `major:minor rate_per_second` pair
 type ThrottleDevice struct {
-	blockIODevice
+	BlockIODevice
 	// Rate is the IO rate limit per cgroup per device
 	Rate uint64 `json:"rate"`
 }

--- a/vendor/github.com/seccomp/libseccomp-golang/CHANGELOG
+++ b/vendor/github.com/seccomp/libseccomp-golang/CHANGELOG
@@ -2,6 +2,31 @@ libseccomp-golang: Releases
 ===============================================================================
 https://github.com/seccomp/libseccomp-golang
 
+* Version 0.10.0 - June 9, 2022
+- Minimum supported version of libseccomp bumped to v2.3.1
+- Add seccomp userspace notification API (ActNotify, filter.*Notif*)
+- Add filter.{Get,Set}SSB (to support SCMP_FLTATR_CTL_SSB)
+- Add filter.{Get,Set}Optimize (to support SCMP_FLTATR_CTL_OPTIMIZE)
+- Add filter.{Get,Set}RawRC (to support SCMP_FLTATR_API_SYSRAWRC)
+- Add ArchPARISC, ArchPARISC64, ArchRISCV64
+- Add ActKillProcess and ActKillThread; deprecate ActKill
+- Add go module support
+- Return ErrSyscallDoesNotExist when unable to resolve a syscall
+- Fix some functions to check for both kernel level API and libseccomp version
+- Fix MakeCondition to use sanitizeCompareOp
+- Fix AddRule to handle EACCES (from libseccomp >= 2.5.0)
+- Updated the main docs and converted to README.md
+- Added CONTRIBUTING.md, SECURITY.md, and administrative docs under doc/admin
+- Add GitHub action CI, enable more linters
+- test: test against various libseccomp versions
+- test: fix and simplify execInSubprocess
+- test: fix APILevelIsSupported
+- Refactor the Errno(-1 * retCode) pattern
+- Refactor/unify libseccomp version / API level checks
+- Code cleanups (linter, formatting, spelling fixes)
+- Cleanup: use errors.New instead of fmt.Errorf where appropriate
+- Cleanup: remove duplicated cgo stuff, redundant linux build tag
+
 * Version 0.9.1 - May 21, 2019
 - Minimum supported version of libseccomp bumped to v2.2.0
 - Use Libseccomp's `seccomp_version` API to retrieve library version

--- a/vendor/github.com/seccomp/libseccomp-golang/README.md
+++ b/vendor/github.com/seccomp/libseccomp-golang/README.md
@@ -22,19 +22,37 @@ The library source repository currently lives on GitHub at the following URLs:
 * https://github.com/seccomp/libseccomp-golang
 * https://github.com/seccomp/libseccomp
 
-The project mailing list is currently hosted on Google Groups at the URL below,
-please note that a Google account is not required to subscribe to the mailing
-list.
-
-* https://groups.google.com/d/forum/libseccomp
-
 Documentation for this package is also available at:
 
 * https://pkg.go.dev/github.com/seccomp/libseccomp-golang
 
+## Verifying Releases
+
+Starting with libseccomp-golang v0.10.0, the git tag corresponding to each
+release should be signed by one of the libseccomp-golang maintainers.  It is
+recommended that before use you verify the release tags using the following
+command:
+
+	% git tag -v <tag>
+
+At present, only the following keys, specified via the fingerprints below, are
+authorized to sign official libseccomp-golang release tags:
+
+	Paul Moore <paul@paul-moore.com>
+	7100 AADF AE6E 6E94 0D2E  0AD6 55E4 5A5A E8CA 7C8A
+
+	Tom Hromatka <tom.hromatka@oracle.com>
+	47A6 8FCE 37C7 D702 4FD6  5E11 356C E62C 2B52 4099
+
+	Kir Kolyshkin <kolyshkin@gmail.com>
+	C242 8CD7 5720 FACD CF76  B6EA 17DE 5ECB 75A1 100E
+
+More information on GnuPG and git tag verification can be found at their
+respective websites: https://git-scm.com/docs/git and https://gnupg.org.
+
 ## Installing the package
 
-	# go get github.com/seccomp/libseccomp-golang
+	% go get github.com/seccomp/libseccomp-golang
 
 ## Contributing
 

--- a/vendor/github.com/seccomp/libseccomp-golang/SECURITY.md
+++ b/vendor/github.com/seccomp/libseccomp-golang/SECURITY.md
@@ -22,6 +22,7 @@ window.
 
 * Paul Moore, paul@paul-moore.com
 * Tom Hromatka, tom.hromatka@oracle.com
+* Kir Kolyshkin, kolyshkin@gmail.com
 
 ### Resolving Sensitive Security Issues
 

--- a/vendor/github.com/seccomp/libseccomp-golang/seccomp_internal.go
+++ b/vendor/github.com/seccomp/libseccomp-golang/seccomp_internal.go
@@ -340,7 +340,7 @@ func ensureSupportedVersion() error {
 func getAPI() (uint, error) {
 	api := C.seccomp_api_get()
 	if api == 0 {
-		return 0, fmt.Errorf("API level operations are not supported")
+		return 0, errors.New("API level operations are not supported")
 	}
 
 	return uint(api), nil
@@ -349,11 +349,12 @@ func getAPI() (uint, error) {
 // Set the API level
 func setAPI(api uint) error {
 	if retCode := C.seccomp_api_set(C.uint(api)); retCode != 0 {
-		if errRc(retCode) == syscall.EOPNOTSUPP {
-			return fmt.Errorf("API level operations are not supported")
+		e := errRc(retCode)
+		if e == syscall.EOPNOTSUPP {
+			return errors.New("API level operations are not supported")
 		}
 
-		return fmt.Errorf("could not set API level: %v", retCode)
+		return fmt.Errorf("could not set API level: %w", e)
 	}
 
 	return nil
@@ -411,7 +412,7 @@ func (f *ScmpFilter) setFilterAttr(attr scmpFilterAttr, value C.uint32_t) error 
 // Wrapper for seccomp_rule_add_... functions
 func (f *ScmpFilter) addRuleWrapper(call ScmpSyscall, action ScmpAction, exact bool, length C.uint, cond C.scmp_cast_t) error {
 	if length != 0 && cond == nil {
-		return fmt.Errorf("null conditions list, but length is nonzero")
+		return errors.New("null conditions list, but length is nonzero")
 	}
 
 	var retCode C.int
@@ -430,7 +431,7 @@ func (f *ScmpFilter) addRuleWrapper(call ScmpSyscall, action ScmpAction, exact b
 		case syscall.EPERM, syscall.EACCES:
 			return errDefAction
 		case syscall.EINVAL:
-			return fmt.Errorf("two checks on same syscall argument")
+			return errors.New("two checks on same syscall argument")
 		default:
 			return e
 		}
@@ -455,7 +456,7 @@ func (f *ScmpFilter) addRuleGeneric(call ScmpSyscall, action ScmpAction, exact b
 	} else {
 		argsArr := C.make_arg_cmp_array(C.uint(len(conds)))
 		if argsArr == nil {
-			return fmt.Errorf("error allocating memory for conditions")
+			return errors.New("error allocating memory for conditions")
 		}
 		defer C.free(argsArr)
 
@@ -495,7 +496,7 @@ func sanitizeAction(in ScmpAction) error {
 	}
 
 	if inTmp != ActTrace && inTmp != ActErrno && (in&0xFFFF0000) != 0 {
-		return fmt.Errorf("highest 16 bits must be zeroed except for Trace and Errno")
+		return errors.New("highest 16 bits must be zeroed except for Trace and Errno")
 	}
 
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -376,7 +376,7 @@ github.com/opencontainers/go-digest
 ## explicit; go 1.11
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/opencontainers/runc v1.1.3 => github.com/opencontainers/runc v1.1.1-0.20220607072441-a7a45d7d2721
+# github.com/opencontainers/runc v1.1.3 => github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc
 ## explicit; go 1.17
 github.com/opencontainers/runc/libcontainer/apparmor
 github.com/opencontainers/runc/libcontainer/cgroups
@@ -439,7 +439,7 @@ github.com/prometheus/procfs/internal/util
 # github.com/rivo/uniseg v0.2.0
 ## explicit; go 1.12
 github.com/rivo/uniseg
-# github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646
+# github.com/seccomp/libseccomp-golang v0.10.0
 ## explicit; go 1.14
 github.com/seccomp/libseccomp-golang
 # github.com/sirupsen/logrus v1.8.1
@@ -668,4 +668,4 @@ gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
-# github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.1-0.20220607072441-a7a45d7d2721
+# github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc


### PR DESCRIPTION
in the first PR for improving cgroup creation, systemd was not included. This change is as simple as including a resource parameter in the `NewSystemd` function and leaving the creation
in podman to do the rest. Also, a new function has been added to convert spec.Linux limits into systemd properties

Signed-off-by: cdoern <cdoern@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
