### PR TITLE
cpu quota patch

### DIFF
--- a/pkg/cgroups/cgroups_linux_test.go
+++ b/pkg/cgroups/cgroups_linux_test.go
@@ -4,6 +4,7 @@
 package cgroups
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/containers/storage/pkg/unshare"
@@ -62,5 +63,16 @@ func TestResources(t *testing.T) {
 	_, err = NewSystemd("machine2.slice", &resources)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// test CPU Quota adjustment.
+	u, _, _, _ := resourcesToProps(&resources)
+
+	val, ok := u["CPUQuotaPerSecUSec"]
+	if !ok {
+		t.Fatal("CPU Quota not parsed.")
+	}
+	if val != 1000000 {
+		t.Fatal("CPU Quota incorrect value expected 1000000 got " + strconv.FormatUint(val, 10))
 	}
 }

--- a/pkg/cgroups/systemd_linux.go
+++ b/pkg/cgroups/systemd_linux.go
@@ -129,7 +129,15 @@ func resourcesToProps(res *configs.Resources) (map[string]uint64, map[string]str
 		uMap["CPUQuotaPeriodUSec"] = res.CpuPeriod
 	}
 	if res.CpuQuota != 0 {
-		uMap["CPUQuotaPerSecUSec"] = uint64(res.CpuQuota)
+		period := res.CpuPeriod
+		if period == 0 {
+			period = uint64(100000)
+		}
+		cpuQuotaPerSecUSec := uint64(res.CpuQuota*1000000) / period
+		if cpuQuotaPerSecUSec%10000 != 0 {
+			cpuQuotaPerSecUSec = ((cpuQuotaPerSecUSec / 10000) + 1) * 10000
+		}
+		uMap["CPUQuotaPerSecUSec"] = cpuQuotaPerSecUSec
 	}
 
 	// CPUSet


### PR DESCRIPTION
systemd truncates the given cpu quota value from us / cpu second to s / cpu second meaning
we need to mimic runc's logic here and change our value based on this internal truncation.

Signed-off-by: Charlie Doern <cdoern@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
