### PR TITLE
type conversion for systemd memory limits and additonal tests

### DIFF
--- a/pkg/cgroups/cgroups_linux_test.go
+++ b/pkg/cgroups/cgroups_linux_test.go
@@ -4,6 +4,7 @@
 package cgroups
 
 import (
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -44,6 +45,9 @@ func TestResources(t *testing.T) {
 	var resources configs.Resources
 	resources.CpuPeriod = 100000
 	resources.CpuQuota = 100000
+	resources.Memory = 900
+	resources.MemorySwap = 1000
+	resources.BlkioWeight = 300
 
 	cgr, err := New("machine.slice", &resources)
 	if err != nil {
@@ -60,7 +64,11 @@ func TestResources(t *testing.T) {
 		t.Fatal("Got the wrong value, set cpu.cfs_period_us failed.")
 	}
 
-	_, err = NewSystemd("machine2.slice", &resources)
+	if err := cgr.Delete(); err != nil {
+		t.Fatal(err)
+	}
+
+	cgr2, err := NewSystemd("machine2.slice", &resources)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,5 +82,15 @@ func TestResources(t *testing.T) {
 	}
 	if val != 1000000 {
 		t.Fatal("CPU Quota incorrect value expected 1000000 got " + strconv.FormatUint(val, 10))
+	}
+
+	// machine.slice = parent, libpod_pod_ID = path
+	err = cgr2.CreateSystemdUnit(fmt.Sprintf("%s/%s-%s%s", "machine2.slice", "machine2", "libpod_pod_1234", ".slice"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cgr2.Delete(); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/cgroups/systemd_linux.go
+++ b/pkg/cgroups/systemd_linux.go
@@ -152,10 +152,10 @@ func resourcesToProps(res *configs.Resources) (map[string]uint64, map[string]str
 
 	// Mem
 	if res.Memory != 0 {
-		iMap["MemoryMax"] = res.Memory
+		uMap["MemoryMax"] = uint64(res.Memory)
 	}
 	if res.MemorySwap != 0 {
-		iMap["MemorySwapMax"] = res.MemorySwap
+		uMap["MemorySwapMax"] = uint64(res.MemorySwap)
 	}
 
 	// Blkio


### PR DESCRIPTION
upon trying to implement --memory for podman pod create, I realized that all memory limits in bytes
need to be uint64 not int64. Switched the type and added a test for ALL "implemented" fields to check that they work

Signed-off-by: Charlie Doern <cdoern@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
