### PR TITLE
add netavark dns port option

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -359,6 +359,13 @@ and "$HOME/.config/cni/net.d" as rootless.
 For the netavark backend "/etc/containers/networks" is used as root
 and "$graphroot/networks" as rootless.
 
+**dns_bind_port**=53
+
+Port to use for dns forwarding daemon with netavark in rootful bridge
+mode and dns enabled.
+Using an alternate port might be useful if other dns services should
+run on the machine.
+
 ## ENGINE TABLE
 The `engine` table contains configuration options used to set up container engines such as Podman and Buildah.
 

--- a/libnetwork/netavark/exec.go
+++ b/libnetwork/netavark/exec.go
@@ -119,6 +119,9 @@ func (n *netavarkNetwork) execNetavark(args []string, stdin, result interface{})
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		cmd.Env = append(cmd.Env, "RUST_BACKTRACE=1")
 	}
+	if n.dnsBindPort != 0 {
+		cmd.Env = append(cmd.Env, "NETAVARK_DNS_PORT="+strconv.Itoa(int(n.dnsBindPort)))
+	}
 
 	err = cmd.Start()
 	if err != nil {

--- a/libnetwork/netavark/network.go
+++ b/libnetwork/netavark/network.go
@@ -43,6 +43,9 @@ type netavarkNetwork struct {
 	// defaultsubnetPools contains the subnets which must be used to allocate a free subnet by network create
 	defaultsubnetPools []config.SubnetPool
 
+	// dnsBindPort is set the the port to pass to netavark for aardvark
+	dnsBindPort uint16
+
 	// ipamDBPath is the path to the ip allocation bolt db
 	ipamDBPath string
 
@@ -79,6 +82,9 @@ type InitConfig struct {
 
 	// DefaultsubnetPools contains the subnets which must be used to allocate a free subnet by network create
 	DefaultsubnetPools []config.SubnetPool
+
+	// DNSBindPort is set the the port to pass to netavark for aardvark
+	DNSBindPort uint16
 
 	// Syslog describes whenever the netavark debbug output should be log to the syslog as well.
 	// This will use logrus to do so, make sure logrus is set up to log to the syslog.
@@ -131,6 +137,7 @@ func NewNetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
 		defaultNetwork:     defaultNetworkName,
 		defaultSubnet:      defaultNet,
 		defaultsubnetPools: defaultSubnetPools,
+		dnsBindPort:        conf.DNSBindPort,
 		lock:               lock,
 		syslog:             conf.Syslog,
 	}

--- a/libnetwork/network/interface.go
+++ b/libnetwork/network/interface.go
@@ -84,6 +84,7 @@ func NetworkBackend(store storage.Store, conf *config.Config, syslog bool) (type
 			DefaultNetwork:     conf.Network.DefaultNetwork,
 			DefaultSubnet:      conf.Network.DefaultSubnet,
 			DefaultsubnetPools: conf.Network.DefaultSubnetPools,
+			DNSBindPort:        conf.Network.DNSBindPort,
 			Syslog:             syslog,
 		})
 		return types.Netavark, netInt, err

--- a/libnetwork/network/interface.go
+++ b/libnetwork/network/interface.go
@@ -160,7 +160,7 @@ func getCniInterface(conf *config.Config) (types.ContainerNetwork, error) {
 	confDir := conf.Network.NetworkConfigDir
 	if confDir == "" {
 		var err error
-		confDir, err = getDefultCNIConfigDir()
+		confDir, err = getDefaultCNIConfigDir()
 		if err != nil {
 			return nil, err
 		}
@@ -175,7 +175,7 @@ func getCniInterface(conf *config.Config) (types.ContainerNetwork, error) {
 	})
 }
 
-func getDefultCNIConfigDir() (string, error) {
+func getDefaultCNIConfigDir() (string, error) {
 	if !unshare.IsRootless() {
 		return cniConfigDir, nil
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -532,6 +532,11 @@ type NetworkConfig struct {
 
 	// NetworkConfigDir is where network configuration files are stored.
 	NetworkConfigDir string `toml:"network_config_dir,omitempty"`
+
+	// DNSBindPort is the port that should be used by dns forwarding daemon
+	// for netavark rootful bridges with dns enabled. This can be necessary
+	// when other dns forwarders run on the machine. 53 is used if unset.
+	DNSBindPort uint16 `toml:"dns_bind_port,omitempty,omitzero"`
 }
 
 type SubnetPool struct {

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -134,6 +134,18 @@ var _ = Describe("Config Local", func() {
 		))
 	})
 
+	It("parse dns port", func() {
+		// Given
+		config, err := NewConfig("")
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config.Network.DNSBindPort).To(gomega.Equal(uint16(0)))
+		// When
+		config2, err := NewConfig("testdata/containers_default.conf")
+		// Then
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config2.Network.DNSBindPort).To(gomega.Equal(uint16(1153)))
+	})
+
 	It("should fail during runtime", func() {
 		validDirPath, err := ioutil.TempDir("", "config-empty")
 		if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -198,7 +198,7 @@ image_copy_tmp_dir="storage"`
 
 			pluginDirs := []string{
 				"/usr/libexec/cni",
-				"/usr/libexec/foo",
+				"/tmp",
 			}
 
 			envs := []string{

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -325,6 +325,13 @@ default_sysctls = [
 #
 #network_config_dir = "/etc/cni/net.d/"
 
+# Port to use for dns forwarding daemon with netavark in rootful bridge
+# mode and dns enabled.
+# Using an alternate port might be useful if other dns services should
+# run on the machine.
+#
+#dns_bind_port = 53
+
 [engine]
 # Index to the active service
 #

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -230,6 +230,7 @@ func DefaultConfig() (*Config, error) {
 			DefaultNetwork:     "podman",
 			DefaultSubnet:      DefaultSubnet,
 			DefaultSubnetPools: DefaultSubnetPools,
+			DNSBindPort:        0,
 			CNIPluginDirs:      DefaultCNIPluginDirs,
 		},
 		Engine:  *defaultEngineConfig,

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -101,7 +101,7 @@ netns="bridge"
 # Path to directory where CNI plugin binaries are located.
 cni_plugin_dirs = [
   "/usr/libexec/cni",
-  "/usr/libexec/foo",
+  "/tmp",
 ]
 
 # Path to the directory where CNI configuration files are located.

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -109,6 +109,9 @@ network_config_dir = "/etc/cni/net.d/"
 
 default_subnet_pools = [{"base" = "10.89.0.0/16", "size" = 24}, {"base" = "10.90.0.0/15", "size" = 24}]
 
+# dns port for netavark/aardvark
+dns_bind_port = 1153
+
 [engine]
 
 # Cgroup management implementation used for the runtime.


### PR DESCRIPTION
companion PR for containers/netavark#323 

I've:
 - added `dns_bind_port` setting to structs, example config and manual page
Note the default in go is 0, which means do not set the env var. Someone setting it to 53 explicitly in the config would set the variable if we ever change the default.
 - added a test to validate we parse it; I've tested manually that invalid config value errors out but we don't have any value by value invalid parsing check (setting the value to an int < 0 or > 65535 would fail on Validate(), sure, but I don't see the point and it doesn't allow validating things like `dns_bind_port = yes` or other nonsensical value)
 - I've taken the liberty to fix a typo where Default was spelled Defult
 - likewise, tests didn't pass on my machine because /usr/libexec/foo doesn't exist. The tests only care that such a directory exist so I've just renamed it to /tmp on both sides (config and test) as that'll help more people than just creating the dir -- this is in a separate commit so if you don't want it I'll just drop it.


If we agree on the approach merge order probably doesn't matter, but I've tested this with the PR branch and it works ok for me.

cc @Luap99 