### PR TITLE
cgroup v2 support for IOWeight

### DIFF
--- a/pkg/cgroups/systemd_linux.go
+++ b/pkg/cgroups/systemd_linux.go
@@ -201,7 +201,11 @@ func resourcesToProps(res *configs.Resources, v2 bool) (map[string]uint64, map[s
 
 	// Blkio
 	if res.BlkioWeight > 0 {
-		uMap["BlockIOWeight"] = uint64(res.BlkioWeight)
+		if v2 {
+			uMap["IOWeight"] = uint64(res.BlkioWeight)
+		} else {
+			uMap["BlockIOWeight"] = uint64(res.BlkioWeight)
+		}
 	}
 
 	// systemd requires the paths to be in the form /dev/{block, char}/major:minor


### PR DESCRIPTION
I only included the v1 name for a cgroup wide IO weight in my previous PR, this fixes the --blkio-weight
flag in containers/podman#14876

Signed-off-by: Charlie Doern <cdoern@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
