### PR TITLE
[wip] Add option to push all tags

### DIFF
--- a/libimage/push.go
+++ b/libimage/push.go
@@ -3,12 +3,11 @@ package libimage
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
-	dockerTransport "github.com/containers/image/v5/docker"
 	dockerArchiveTransport "github.com/containers/image/v5/docker/archive"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/sirupsen/logrus"
 )
@@ -33,60 +32,79 @@ func (r *Runtime) Push(ctx context.Context, source, destination string, options 
 		options = &PushOptions{}
 	}
 
-	// Look up the local image.  Note that we need to ignore the platform
-	// and push what the user specified (containers/podman/issues/10344).
-	image, resolvedSource, err := r.LookupImage(source, nil)
-	if err != nil {
-		return nil, err
-	}
+	// Push the single image
+	if !options.AllTags {
 
-	// Make sure we have a proper destination, and parse it into an image
-	// reference for copying.
-	if destination == "" {
-		// Doing an ID check here is tempting but false positives (due
-		// to a short partial IDs) are more painful than false
-		// negatives.
-		destination = resolvedSource
-	}
-
-	// If specified to push --all-tags, look them up and iterate.
-	if options.AllTags {
-
-		// Do not allow : for tags, other than specifying transport
-		d := strings.TrimPrefix(destination, "docker://")
-		if strings.ContainsAny(d, ":") {
-			return nil, fmt.Errorf("tag can't be used with --all-tags/-a")
-		}
-
-		namedRepoTags, err := image.NamedTaggedRepoTags()
+		// Look up the local image.  Note that we need to ignore the platform
+		// and push what the user specified (containers/podman/issues/10344).
+		image, resolvedSource, err := r.LookupImage(source, nil)
 		if err != nil {
 			return nil, err
 		}
 
-		logrus.Debugf("Flag --all-tags true, found: %s", namedRepoTags)
-
-		for _, tag := range namedRepoTags {
-			fullNamedTag := fmt.Sprintf("%s:%s", destination, tag.Tag())
-			_, err = pushImage(ctx, fullNamedTag, options, image, r)
-			if err != nil {
-				return nil, err
-			}
+		// Make sure we have a proper destination, and parse it into an image
+		// reference for copying.
+		if destination == "" {
+			// Doing an ID check here is tempting but false positives (due
+			// to a short partial IDs) are more painful than false
+			// negatives.
+			destination = resolvedSource
 		}
-	} else {
-		// No --all-tags, so just push just the single image.
-		return pushImage(ctx, destination, options, image, r)
+
+		return pushImage(ctx, image, destination, options, resolvedSource, r)
 	}
 
-	return nil, nil
+	// Below handles the AllTags option, for which we have to build a list of
+	// all the local images that match the provided repository and then push them.
+	//
+	// Start by making sure a destination was not specified, since we'll get that from the source
+	if len(destination) != 0 {
+		return nil, fmt.Errorf("`destination` should not be specified if using AllTags")
+	}
+
+	// Make sure the source repository does not have a tag
+	srcNamed, err := reference.ParseNormalizedNamed(source)
+	if err != nil {
+		return nil, err
+	}
+	if _, hasTag := srcNamed.(reference.NamedTagged); hasTag {
+		return nil, fmt.Errorf("can't push with AllTags if source tag is specified")
+	}
+
+	// Now list every image of that source repository
+	listOptions := &ListImagesOptions{}
+	listOptions.Filters = []string{fmt.Sprintf("reference=%s:*", source)}
+	logrus.Debugf("Finding all images for source %s", source)
+	srcImages, _ := r.ListImages(ctx, nil, listOptions)
+
+	// Push each tag for every image in the list
+	var byteManifest []byte
+	for _, img := range srcImages {
+		namedTagged, err := img.NamedTaggedRepoTags()
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range namedTagged {
+			destWithTag := fmt.Sprintf("%s:%s", source, n.Tag())
+			b, err := pushImage(ctx, img, destWithTag, options, "", r)
+			if err != nil {
+				return byteManifest, err
+			}
+			byteManifest = append(byteManifest, b...)
+		}
+	}
+
+	return byteManifest, nil
 }
 
-func pushImage(ctx context.Context, destination string, options *PushOptions, image *Image, r *Runtime) ([]byte, error) {
+// pushImage sends a single image to be copied to the destination
+func pushImage(ctx context.Context, image *Image, destination string, options *PushOptions, resolvedSource string, r *Runtime) ([]byte, error) {
 	srcRef, err := image.StorageReference()
 	if err != nil {
 		return nil, err
 	}
 
-	logrus.Debugf("Pushing image %s to %s", srcRef, destination)
+	logrus.Debugf("Pushing image %s to %s", transports.ImageName(srcRef), destination)
 
 	destRef, err := alltransports.ParseImageName(destination)
 	if err != nil {
@@ -99,11 +117,6 @@ func pushImage(ctx context.Context, destination string, options *PushOptions, im
 		destRef = dockerRef
 	}
 
-	// If using --all-tags, must push to registry
-	if destRef.Transport().Name() != dockerTransport.Transport.Name() && options.AllTags {
-		return nil, fmt.Errorf("--all-tags can only be used with docker transport")
-	}
-
 	if r.eventChannel != nil {
 		defer r.writeEvent(&Event{ID: image.ID(), Name: destination, Time: time.Now(), Type: EventTypeImagePush})
 	}
@@ -111,7 +124,7 @@ func pushImage(ctx context.Context, destination string, options *PushOptions, im
 	// Buildah compat: Make sure to tag the destination image if it's a
 	// Docker archive. This way, we preserve the image name.
 	if destRef.Transport().Name() == dockerArchiveTransport.Transport.Name() {
-		if named, err := reference.ParseNamed(destination); err == nil {
+		if named, err := reference.ParseNamed(resolvedSource); err == nil {
 			tagged, isTagged := named.(reference.NamedTagged)
 			if isTagged {
 				options.dockerArchiveAdditionalTags = []reference.NamedTagged{tagged}


### PR DESCRIPTION
If the `libimage.PushOptions` `AllTags=true` then `libimage.Push()` will search the local image storage for all images matching the source repository name. It will then push each tag for each of  those images to the matching repository.

This seeks to mirror behavior behind `docker push --all-tags IMAGE`.

If `AllTags=true`:
- the user must provide the name of the image only; providing a tag will crash
- `libimage.Push()` will always return `nil` for the manifest byte array
- only the docker transport is supported due to how tags are appended to names with other transports.

Requirement for https://github.com/containers/podman/pull/14949
@rhatdan 

Signed-off-by: Brian Yarbrough <bcynmelk+git@gmail.com>


<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
