### PR TITLE
RFC: tag v0.49.1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.49.1"
+const Version = "0.49.2-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.49.1-dev"
+const Version = "0.49.1"


### PR DESCRIPTION
@vrothberg @rhatdan @TomSweeneyRedHat RFC. @flouthoc FYI

For https://github.com/containers/podman/pull/15108 to land in Podman 4.2 (if that is an option at all), we need #1106 .

That, in turn, probably means making another c/common release (and vendoring it in Buildah first; and making another Skopeo release).

Do we want to do that?

---

If we do want to do it, should the new release be v0.50.0? There have been new APIs added since 0.49.0. Or is the branching driven primarily by Podman releases?