### PR TITLE
Podman rmi --no-prune flag

### DIFF
--- a/libimage/image.go
+++ b/libimage/image.go
@@ -478,6 +478,11 @@ func (i *Image) removeRecursive(ctx context.Context, rmMap map[string]*RemoveIma
 		report.Removed = true
 	}
 
+	// Do not delete any parents if NoPrune is true
+	if options.NoPrune {
+		return processedIDs, nil
+	}
+
 	// Check if can remove the parent image.
 	if parent == nil {
 		return processedIDs, nil
@@ -495,7 +500,6 @@ func (i *Image) removeRecursive(ctx context.Context, rmMap map[string]*RemoveIma
 	if !danglingParent {
 		return processedIDs, nil
 	}
-
 	// Recurse into removing the parent.
 	return parent.removeRecursive(ctx, rmMap, processedIDs, "", options)
 }

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -608,6 +608,8 @@ type RemoveImagesOptions struct {
 	// much space was freed. However, computing the size of an image is
 	// comparatively expensive, so it is made optional.
 	WithSize bool
+	// NoPrune will not remove dangling images
+	NoPrune bool
 }
 
 // RemoveImages removes images specified by names.  If no names are specified,
@@ -653,7 +655,6 @@ func (r *Runtime) RemoveImages(ctx context.Context, names []string, options *Rem
 	toDelete := []string{}
 	// Look up images in the local containers storage and fill out
 	// toDelete and the deleteMap.
-
 	switch {
 	case len(names) > 0:
 		// prepare lookupOptions


### PR DESCRIPTION
containers/common changes for podman rmi --no-prune flag.
--no-prune does not delete dangling parent images.
For compatibility with Docker

Signed-off-by: Karthik Elango <kelango@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
