### PR TITLE
libimage: image removal: add hint to external containers

### DIFF
--- a/libimage/image.go
+++ b/libimage/image.go
@@ -470,6 +470,9 @@ func (i *Image) removeRecursive(ctx context.Context, rmMap map[string]*RemoveIma
 	}
 
 	if _, err := i.runtime.store.DeleteImage(i.ID(), true); handleError(err) != nil {
+		if errors.Is(err, storage.ErrImageUsedByContainer) {
+			err = fmt.Errorf("%w: consider listing external containers and force-removing image", err)
+		}
 		return processedIDs, err
 	}
 	report.Untagged = append(report.Untagged, i.Names()...)


### PR DESCRIPTION
Trying to remove an image that is in use by containers is a confusing
experience for users who may not be aware of "external" containers which
are not displayed in `podman ps` by default (see containers/podman/issues/15006).

Add some context to the error from containers/storage to guide the user
into listing external containers and force-removing the image.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
