### PR TITLE
cirrus: bump cpus and ram

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,8 +33,8 @@ gcp_credentials: ENCRYPTED[dd6a042d1805167e38d8b79494f691b86637e68f072eba2422090
 gce_instance:
     image_project: libpod-218412
     zone: "us-central1-a"
-    cpu: 2
-    memory: "4Gb"
+    cpu: 8
+    memory: "16Gb"
     # Required to be 200gig, do not modify - has i/o performance impact
     # according to gcloud CLI tool warning messages.
     disk: 200


### PR DESCRIPTION
Getting CI to pass got frustratingly slow (>40 minutes).
A first step to make it faster is to bump the number of
CPUs and increase RAM to the same Podman CI is using.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
