### PR TITLE
default: look up init binary in helper_binaries_dir

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -824,6 +824,20 @@ func (c *EngineConfig) findRuntime() string {
 	return ""
 }
 
+func (c *EngineConfig) findInit() string {
+	if _, err := os.Stat(DefaultInitPath); err == nil {
+		return DefaultInitPath
+	}
+	for _, dir := range c.HelperBinariesDir {
+		path := filepath.Join(dir, DefaultInitBinaryName)
+		if _, err := os.Stat(path); err == nil {
+			logrus.Debugf("Found init binary %s in helper binary directory %s", DefaultInitBinaryName, dir)
+			return path
+		}
+	}
+	return ""
+}
+
 // Validate is the main entry point for Engine configuration validation
 // It returns an `error` on validation failure, otherwise
 // `nil`.

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -49,6 +49,9 @@ const (
 )
 
 var (
+	// DefaultInitBinaryName is the default name of the container-init binary.
+	// TODO: Expose this?
+	DefaultInitBinaryName = "catatonit"
 	// DefaultInitPath is the default path to the container-init binary.
 	DefaultInitPath = "/usr/libexec/podman/catatonit"
 	// DefaultInfraImage is the default image to run as infrastructure containers in pods.
@@ -381,7 +384,8 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	}
 	c.RuntimeSupportsNoCgroups = []string{"crun", "krun"}
 	c.RuntimeSupportsKVM = []string{"kata", "kata-runtime", "kata-qemu", "kata-fc", "krun"}
-	c.InitPath = DefaultInitPath
+	c.InitPath = c.findInit()
+
 	c.NoPivotRoot = false
 
 	c.InfraImage = DefaultInfraImage


### PR DESCRIPTION
Some Linux distributions does not install files into `/usr/libexec` and
would fail to lookup the init binary.

This change first checks if the file exists in the default location,
else we look for the binary in helper_binaries_dir as they should
encompass all the possible installation directories.

Fixes https://github.com/containers/common/issues/1110

Signed-off-by: Morten Linderud <morten@linderud.pw>