### PR TITLE
Eliminate segfault when image does not have config

### DIFF
--- a/libimage/inspect.go
+++ b/libimage/inspect.go
@@ -190,7 +190,7 @@ func (i *Image) Inspect(ctx context.Context, options *InspectOptions) (*ImageDat
 		// NOTE: Health checks may be listed in the container config or
 		// the config.
 		data.HealthCheck = dockerManifest.ContainerConfig.Healthcheck
-		if data.HealthCheck == nil {
+		if data.HealthCheck == nil && dockerManifest.Config != nil {
 			data.HealthCheck = dockerManifest.Config.Healthcheck
 		}
 	}


### PR DESCRIPTION
[NO NEW TEST NEEDED]

Fixes: https://github.com/containers/podman/issues/15265

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
