### PR TITLE
Add support for returning image path with ARCH and OS Substitutions

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -441,7 +441,7 @@ and the logfile will not be rotated.
 
 **events_logger**="journald"
 
-The default method to use when logging events.  
+The default method to use when logging events.
 
 The default method is different based on the platform that
 Podman is being run upon.  To determine the current value,
@@ -711,11 +711,13 @@ The size of the disk in GB created when init-ing a podman-machine VM
 
 **image**=""
 
-Default image used when creating a new VM using `podman machine init`.
+Default image URI when creating a new VM using `podman machine init`.
 Options: On Linux/Mac, `testing`, `stable`, `next`. On Windows, the major
-version of the OS (e.g `35`). For all platforms you can alternatively specify
-a custom path or download URL to an image. The default is `testing` on
-Linux/Mac, and `35` on Windows.
+version of the OS (e.g `36`) for Fedora 36. For all platforms you can
+alternatively specify a custom download URL to an image. Container engines
+translate URIs $OS and $ARCH to the native OS and ARCH. URI "https://example.com/$OS/$ARCH/foobar.ami" would become "https://example.com/linux/amd64/foobar.ami" on a Linux AMD machine.
+The default value
+is `testing` on Linux/Mac, and on Windows.
 
 **memory**=2048
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -813,6 +814,18 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// URI returns the URI Path to the machine image
+func (m *MachineConfig) URI() string {
+	uri := m.Image
+	for _, val := range []string{"$ARCH", "$arch"} {
+		uri = strings.Replace(uri, val, runtime.GOARCH, 1)
+	}
+	for _, val := range []string{"$OS", "$os"} {
+		uri = strings.Replace(uri, val, runtime.GOOS, 1)
+	}
+	return uri
 }
 
 func (c *EngineConfig) findRuntime() string {

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -4,9 +4,11 @@
 package config
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
+	"runtime"
 	"strings"
 
 	"github.com/containers/common/libnetwork/types"
@@ -433,7 +435,10 @@ var _ = Describe("Config Local", func() {
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config2.Machine.Image).To(gomega.Equal("stable"))
+		path := "https://example.com/$OS/$ARCH/foobar.ami"
+		gomega.Expect(config2.Machine.Image).To(gomega.Equal(path))
+		val := fmt.Sprintf("https://example.com/%s/%s/foobar.ami", runtime.GOOS, runtime.GOARCH)
+		gomega.Expect(config2.Machine.URI()).To(gomega.BeEquivalentTo(val))
 	})
 
 	It("CompatAPIEnforceDockerHub", func() {

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -665,9 +665,16 @@ default_sysctls = [
 #
 #disk_size=10
 
-# The image used when creating a podman-machine VM.
+# Default image URI when creating a new VM using `podman machine init`.
+# Options: On Linux/Mac, `testing`, `stable`, `next`. On Windows, the major
+# version of the OS (e.g `36`) for Fedora 36. For all platforms you can
+# alternatively specify a custom download URL to an image. Container engines
+# translate URIs $OS and $ARCH to the native OS and ARCH. URI
+# "https://example.com/$OS/$ARCH/foobar.ami" becomes
+# "https://example.com/linux/amd64/foobar.ami" on a Linux AMD machine.
+# The default value is `testing`.
 #
-#image = "testing"
+# image = "testing"
 
 # Memory in MB a machine is created with.
 #

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -267,7 +267,8 @@ cpus=2
 disk_size = 20
 
 # The image used when creating a podman-machine VM.
-image = "stable"
+image = "https://example.com/$OS/$ARCH/foobar.ami"
+
 # Memory in MB a machine is created with.
 
 memory=1024

--- a/pkg/config/testdata/containers_override.conf
+++ b/pkg/config/testdata/containers_override.conf
@@ -13,6 +13,10 @@ events_logfile_path = "/tmp/events.log"
 events_logfile_max_size="500"
 pod_exit_policy="stop"
 
+[machine]
+# The image used when creating a podman-machine VM.
+image = "https://example.com/$OS/$ARCH/foobar.ami"
+
 [secrets]
 driver = "pass"
 


### PR DESCRIPTION
Allow distributions to specify the location of the podman image VM
images in the form of URIs with $ARCH and $OS specified.  This would
allow a distribution to pull the image based on the current OS and Arch.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
