### PR TITLE
Use an alternative CNI lock for read-only config dirs

### DIFF
--- a/libnetwork/network/interface.go
+++ b/libnetwork/network/interface.go
@@ -169,6 +169,7 @@ func getCniInterface(conf *config.Config) (types.ContainerNetwork, error) {
 	return cni.NewCNINetworkInterface(&cni.InitConfig{
 		CNIConfigDir:       confDir,
 		CNIPluginDirs:      conf.Network.CNIPluginDirs,
+		RunDir:             conf.Engine.TmpDir,
 		DefaultNetwork:     conf.Network.DefaultNetwork,
 		DefaultSubnet:      conf.Network.DefaultSubnet,
 		DefaultsubnetPools: conf.Network.DefaultSubnetPools,


### PR DESCRIPTION
When the configuration directory is on a read-only filesystem, there's no risk of concurrency issues as there's no possibility of changing anything. As such, while it prevents the use of our default lock location, it also removes any need for a lock at all.

Making the lock entirely optional is a lot of code, so instead of doing that let's just put it in our temporary files directory, where it can't hurt anything.
