### PR TITLE
Adjust default volumes for windows compatibility

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -264,7 +264,7 @@ func defaultMachineConfig() MachineConfig {
 		Image:    getDefaultMachineImage(),
 		Memory:   2048,
 		User:     getDefaultMachineUser(),
-		Volumes:  []string{"$HOME:$HOME"},
+		Volumes:  getDefaultMachineVolumes(),
 	}
 }
 

--- a/pkg/config/default_darwin.go
+++ b/pkg/config/default_darwin.go
@@ -11,3 +11,8 @@ func getDefaultLockType() string {
 func getLibpodTmpDir() string {
 	return "/run/libpod"
 }
+
+// getDefaultMachineVolumes returns default mounted volumes (possibly with env vars, which will be expanded)
+func getDefaultMachineVolumes() []string {
+	return []string{"$HOME:$HOME"}
+}

--- a/pkg/config/default_freebsd.go
+++ b/pkg/config/default_freebsd.go
@@ -18,3 +18,8 @@ func getDefaultLockType() string {
 func getLibpodTmpDir() string {
 	return "/var/run/libpod"
 }
+
+// getDefaultMachineVolumes returns default mounted volumes (possibly with env vars, which will be expanded)
+func getDefaultMachineVolumes() []string {
+	return []string{"$HOME:$HOME"}
+}

--- a/pkg/config/default_linux.go
+++ b/pkg/config/default_linux.go
@@ -70,3 +70,8 @@ func getDefaultLockType() string {
 func getLibpodTmpDir() string {
 	return "/run/libpod"
 }
+
+// getDefaultMachineVolumes returns default mounted volumes (possibly with env vars, which will be expanded)
+func getDefaultMachineVolumes() []string {
+	return []string{"$HOME:$HOME"}
+}

--- a/pkg/config/default_windows.go
+++ b/pkg/config/default_windows.go
@@ -44,3 +44,8 @@ func getDefaultLockType() string {
 func getLibpodTmpDir() string {
 	return "/run/libpod"
 }
+
+// getDefaultMachineVolumes returns default mounted volumes (possibly with env vars, which will be expanded)
+func getDefaultMachineVolumes() []string {
+	return []string{}
+}


### PR DESCRIPTION
Signed-off-by: Arthur Sengileyev <arthur.sengileyev@gmail.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

Fixes #1124 

Windows path values are unsafe to use with unix like environments, so, just replace with empty safe default.