### PR TITLE
Add v0.49.1 commits to the v0.49 branch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -67,7 +67,7 @@ meta_task:
     container:
         cpu: 2
         memory: 2
-        image: quay.io/libpod/imgts:$IMAGE_SUFFIX
+        image: quay.io/libpod/imgts:latest
     env:
         # Space-separated list of images used by this repository state
         IMGNAMES: >-

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/BurntSushi/toml v1.2.0
 	github.com/containerd/containerd v1.6.6
-	github.com/containernetworking/cni v1.1.1
+	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.1.1
 	github.com/containers/image/v5 v5.22.0
 	github.com/containers/ocicrypt v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -366,8 +366,9 @@ github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ
 github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/cni v1.0.1/go.mod h1:AKuhXbN5EzmD4yTNtfSsX3tPcmtrBI6QcRV0NiNt15Y=
-github.com/containernetworking/cni v1.1.1 h1:ky20T7c0MvKvbMOwS/FrlbNwjEoqJEUUYfsL4b0mc4k=
 github.com/containernetworking/cni v1.1.1/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
+github.com/containernetworking/cni v1.1.2 h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl31EQbXALQ=
+github.com/containernetworking/cni v1.1.2/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
 github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHVlzhJpcY6TQxn/fUyDDM=
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
 github.com/containernetworking/plugins v1.0.1/go.mod h1:QHCfGpaTwYTbbH+nZXKVTxNBDZcxSOplJT5ico8/FLE=

--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -102,6 +102,13 @@ type CopyOptions struct {
 	// If non-empty, asks for a signature to be added during the copy, and
 	// specifies a key ID.
 	SignBy string
+	// If non-empty, passphrase to use when signing with the key ID from SignBy.
+	SignPassphrase string
+	// If non-empty, asks for a signature to be added during the copy, using
+	// a sigstore private key file at the provided path.
+	SignBySigstorePrivateKeyFile string
+	// Passphrase to use when signing with SignBySigstorePrivateKeyFile.
+	SignSigstorePrivateKeyPassphrase []byte
 	// Remove any pre-existing signatures. SignBy will still add a new
 	// signature.
 	RemoveSignatures bool
@@ -293,6 +300,9 @@ func (r *Runtime) newCopier(options *CopyOptions) (*copier, error) {
 	c.imageCopyOptions.OciDecryptConfig = options.OciDecryptConfig
 	c.imageCopyOptions.RemoveSignatures = options.RemoveSignatures
 	c.imageCopyOptions.SignBy = options.SignBy
+	c.imageCopyOptions.SignPassphrase = options.SignPassphrase
+	c.imageCopyOptions.SignBySigstorePrivateKeyFile = options.SignBySigstorePrivateKeyFile
+	c.imageCopyOptions.SignSigstorePrivateKeyPassphrase = options.SignSigstorePrivateKeyPassphrase
 	c.imageCopyOptions.ReportWriter = options.Writer
 
 	defaultContainerConfig, err := config.Default()

--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
+	structcopier "github.com/jinzhu/copier"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -37,6 +38,28 @@ type ManifestList struct {
 
 	// The underlying manifest list.
 	list manifests.List
+}
+
+// ManifestListDescriptor references a platform-specific manifest.
+// Contains exclusive field like `annotations` which is only present in
+// OCI spec and not in docker image spec.
+type ManifestListDescriptor struct {
+	manifest.Schema2Descriptor
+	Platform manifest.Schema2PlatformSpec `json:"platform"`
+	// Annotations contains arbitrary metadata for the image index.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// ManifestListData is a list of platform-specific manifests, specifically used to
+// generate output struct for `podman manifest inspect`. Reason for maintaining and
+// having this type is to ensure we can have a common type which contains exclusive
+// fields from both Docker manifest format and OCI manifest format.
+type ManifestListData struct {
+	SchemaVersion int                      `json:"schemaVersion"`
+	MediaType     string                   `json:"mediaType"`
+	Manifests     []ManifestListDescriptor `json:"manifests"`
+	// Annotations contains arbitrary metadata for the image index.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // ID returns the ID of the manifest list.
@@ -210,8 +233,21 @@ func (i *Image) IsManifestList(ctx context.Context) (bool, error) {
 }
 
 // Inspect returns a dockerized version of the manifest list.
-func (m *ManifestList) Inspect() (*manifest.Schema2List, error) {
-	return m.list.Docker(), nil
+func (m *ManifestList) Inspect() (*ManifestListData, error) {
+	inspectList := ManifestListData{}
+	dockerFormat := m.list.Docker()
+	err := structcopier.Copy(&inspectList, &dockerFormat)
+	if err != nil {
+		return &inspectList, err
+	}
+	// Get missing annotation field from OCIv1 Spec
+	// and populate inspect data.
+	ociFormat := m.list.OCIv1()
+	inspectList.Annotations = ociFormat.Annotations
+	for i, manifest := range ociFormat.Manifests {
+		inspectList.Manifests[i].Annotations = manifest.Annotations
+	}
+	return &inspectList, nil
 }
 
 // Options for adding a manifest list.

--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -411,14 +411,17 @@ func (m *ManifestList) Push(ctx context.Context, destination string, options *Ma
 	defer copier.close()
 
 	pushOptions := manifests.PushOptions{
-		Store:              m.image.runtime.store,
-		SystemContext:      copier.systemContext,
-		ImageListSelection: options.ImageListSelection,
-		Instances:          options.Instances,
-		ReportWriter:       options.Writer,
-		SignBy:             options.SignBy,
-		RemoveSignatures:   options.RemoveSignatures,
-		ManifestType:       options.ManifestMIMEType,
+		Store:                            m.image.runtime.store,
+		SystemContext:                    copier.systemContext,
+		ImageListSelection:               options.ImageListSelection,
+		Instances:                        options.Instances,
+		ReportWriter:                     options.Writer,
+		SignBy:                           options.SignBy,
+		SignPassphrase:                   options.SignPassphrase,
+		SignBySigstorePrivateKeyFile:     options.SignBySigstorePrivateKeyFile,
+		SignSigstorePrivateKeyPassphrase: options.SignSigstorePrivateKeyPassphrase,
+		RemoveSignatures:                 options.RemoveSignatures,
+		ManifestType:                     options.ManifestMIMEType,
 	}
 
 	_, d, err := m.list.Push(ctx, dest, pushOptions)

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/exec.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/exec.go
@@ -50,6 +50,12 @@ func fixupResultVersion(netconf, result []byte) (string, []byte, error) {
 		return "", nil, fmt.Errorf("failed to unmarshal raw result: %w", err)
 	}
 
+	// plugin output of "null" is successfully unmarshalled, but results in a nil
+	// map which causes a panic when the confVersion is assigned below.
+	if rawResult == nil {
+		rawResult = make(map[string]interface{})
+	}
+
 	// Manually decode Result version; we need to know whether its cniVersion
 	// is empty, while built-in decoders (correctly) substitute 0.1.0 for an
 	// empty version per the CNI spec.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -63,7 +63,7 @@ github.com/containerd/containerd/platforms
 ## explicit; go 1.16
 github.com/containerd/stargz-snapshotter/estargz
 github.com/containerd/stargz-snapshotter/estargz/errorutil
-# github.com/containernetworking/cni v1.1.1
+# github.com/containernetworking/cni v1.1.2
 ## explicit; go 1.14
 github.com/containernetworking/cni/libcni
 github.com/containernetworking/cni/pkg/invoke


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

I created a "v0.49" branch that was based off the v0.49.0 release as we had not done so, and we will need one for long-term support of RHEL 8.7/9.1.  This PR cherry-picks the 4 commits that are part of the v0.49.1 release.  Once this completes, we can then cherry-pick #1122 "Use an alternative CNI lock for read-only config dirs" and then create c/common v0.49.2 from this branch for final inclusion in RHEL 8.7 and 9.1.  #1122 is a high-priority request from Veritas.