### PR TITLE
Add volume plugin timeout to containers.conf

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -454,6 +454,13 @@ type EngineConfig struct {
 	// may not be by other drivers.
 	VolumePath string `toml:"volume_path,omitempty"`
 
+	// VolumePluginTimeout sets the default timeout, in seconds, for
+	// operations that must contact a volume plugin. Plugins are external
+	// programs accessed via REST API; this sets a timeout for requests to
+	// that API.
+	// A value of 0 is treated as no timeout.
+	VolumePluginTimeout uint `toml:"volume_plugin_timeout,omitempty,omitzero"`
+
 	// VolumePlugins is a set of plugins that can be used as the backend for
 	// Podman named volumes. Each volume is specified as a name (what Podman
 	// will refer to the plugin as) mapped to a path, which must point to a

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -605,6 +605,12 @@ default_sysctls = [
 #
 #volume_path = "/var/lib/containers/storage/volumes"
 
+# Default timeout (in seconds) for volume plugin operations.
+# Plugins are external programs accessed via a REST API; this sets a timeout
+# for requests to that API.
+# A value of 0 is treated as no timeout.
+#volume_plugin_timeout = 5
+
 # Paths to look for a valid OCI runtime (crun, runc, kata, runsc, krun, etc)
 [engine.runtimes]
 #crun = [

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -168,6 +168,8 @@ const (
 	SeccompOverridePath = _etcDir + "/containers/seccomp.json"
 	// SeccompDefaultPath defines the default seccomp path.
 	SeccompDefaultPath = _installPrefix + "/share/containers/seccomp.json"
+	// DefaultVolumePluginTimeout is the default volume plugin timeout, in seconds
+	DefaultVolumePluginTimeout = 5
 )
 
 // DefaultConfig defines the default values from containers.conf.
@@ -303,6 +305,8 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	c.ImageCopyTmpDir = getDefaultTmpDir()
 	c.StaticDir = filepath.Join(storeOpts.GraphRoot, "libpod")
 	c.VolumePath = filepath.Join(storeOpts.GraphRoot, "volumes")
+
+	c.VolumePluginTimeout = DefaultVolumePluginTimeout
 
 	c.HelperBinariesDir = defaultHelperBinariesDir
 	if additionalHelperBinariesDir != "" {


### PR DESCRIPTION
Add a new config knob for setting a default timeout for volume plugins. Just adds a field to containers.conf, real work will be in Libpod to wire it in.