### PR TITLE
libimage: untag events on image removal

### DIFF
--- a/libimage/image.go
+++ b/libimage/image.go
@@ -475,7 +475,11 @@ func (i *Image) removeRecursive(ctx context.Context, rmMap map[string]*RemoveIma
 		}
 		return processedIDs, err
 	}
+
 	report.Untagged = append(report.Untagged, i.Names()...)
+	for _, name := range i.Names() {
+		i.runtime.writeEvent(&Event{ID: i.ID(), Name: name, Time: time.Now(), Type: EventTypeImageUntag})
+	}
 
 	if !hasChildren {
 		report.Removed = true


### PR DESCRIPTION
As reported in containers/podman/issues/15485, Docker sends untag events
prior to removing the image.  Follow that example for compatibility
reasons.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
