### PR TITLE
cgroup: do not fail with missing cpuset file

### DIFF
--- a/pkg/cgroups/utils.go
+++ b/pkg/cgroups/utils.go
@@ -92,6 +92,11 @@ func cpusetCopyFileFromParent(dir, file string, cgroupv2 bool) ([]byte, error) {
 	}
 	data, err := ioutil.ReadFile(parentPath)
 	if err != nil {
+		// if the file doesn't exist, it is likely that the cpuset controller
+		// is not enabled in the kernel.
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	if strings.Trim(string(data), "\n") != "" {


### PR DESCRIPTION
if cpuset.cpus[.effective] file is missing, then ignore the error
since it means the cpuset controller is not enabled in the kernel,
rather than returning an error.

Closes: https://github.com/containers/common/issues/1134

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
