### PR TITLE
add proper handling for golang ssh

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -588,9 +588,10 @@ image_copy_tmp_dir="storage"`
 			cfg, err = ReadCustomConfig()
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-			u, i, err := cfg.ActiveDestination()
+			u, i, m, err := cfg.ActiveDestination()
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
+			gomega.Expect(m).To(gomega.Equal(false))
 			gomega.Expect(u).To(gomega.Equal("https://qa/run/podman/podman.sock"))
 			gomega.Expect(i).To(gomega.Equal("/.ssh/id_rsa"))
 		})
@@ -620,7 +621,7 @@ image_copy_tmp_dir="storage"`
 			oldContainerConnection, hostEnvSet := os.LookupEnv("CONTAINER_CONNECTION")
 			os.Setenv("CONTAINER_CONNECTION", "QB")
 
-			u, i, err := cfg.ActiveDestination()
+			u, i, m, err := cfg.ActiveDestination()
 			// Undo that
 			if hostEnvSet {
 				os.Setenv("CONTAINER_CONNECTION", oldContainerConnection)
@@ -628,6 +629,7 @@ image_copy_tmp_dir="storage"`
 				os.Unsetenv("CONTAINER_CONNECTION")
 			}
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Expect(m).To(gomega.Equal(false))
 
 			gomega.Expect(u).To(gomega.Equal("https://qb/run/podman/podman.sock"))
 			gomega.Expect(i).To(gomega.Equal("/.ssh/qb_id_rsa"))
@@ -660,7 +662,8 @@ image_copy_tmp_dir="storage"`
 			os.Setenv("CONTAINER_HOST", "foo.bar")
 			os.Setenv("CONTAINER_SSHKEY", "/.ssh/newid_rsa")
 
-			u, i, err := cfg.ActiveDestination()
+			u, i, m, err := cfg.ActiveDestination()
+
 			// Undo that
 			if hostEnvSet {
 				os.Setenv("CONTAINER_HOST", oldContainerHost)
@@ -675,6 +678,7 @@ image_copy_tmp_dir="storage"`
 			}
 
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Expect(m).To(gomega.Equal(false))
 
 			gomega.Expect(u).To(gomega.Equal("foo.bar"))
 			gomega.Expect(i).To(gomega.Equal("/.ssh/newid_rsa"))
@@ -684,7 +688,7 @@ image_copy_tmp_dir="storage"`
 			cfg, err := ReadCustomConfig()
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-			_, _, err = cfg.ActiveDestination()
+			_, _, _, err = cfg.ActiveDestination()
 			gomega.Expect(err).Should(gomega.HaveOccurred())
 		})
 

--- a/pkg/ssh/types.go
+++ b/pkg/ssh/types.go
@@ -27,12 +27,13 @@ type ConnectionCreateOptions struct {
 }
 
 type ConnectionDialOptions struct {
-	Host     string
-	Identity string
-	User     *url.Userinfo
-	Port     int
-	Auth     []string
-	Timeout  time.Duration
+	Host                        string
+	Identity                    string
+	User                        *url.Userinfo
+	Port                        int
+	Auth                        []string
+	Timeout                     time.Duration
+	InsecureIsMachineConnection bool
 }
 
 type ConnectionDialReport struct {

--- a/pkg/ssh/utils.go
+++ b/pkg/ssh/utils.go
@@ -21,6 +21,7 @@ func Validate(user *url.Userinfo, path string, port int, identity string) (*conf
 	if strings.Contains(path, "/run") {
 		sock = strings.Split(path, "/run")[1]
 	}
+	// url.Parse NEEDS ssh://, if this ever fails or returns some nonsense, that is why.
 	uri, err := url.Parse(path)
 	if err != nil {
 		return nil, nil, err
@@ -33,9 +34,9 @@ func Validate(user *url.Userinfo, path string, port int, identity string) (*conf
 
 	if uri.Port() == "" {
 		if port != 0 {
-			uri.Host = net.JoinHostPort(uri.Hostname(), strconv.Itoa(port))
+			uri.Host = net.JoinHostPort(uri.Host, strconv.Itoa(port))
 		} else {
-			uri.Host = net.JoinHostPort(uri.Hostname(), "22")
+			uri.Host = net.JoinHostPort(uri.Host, "22")
 		}
 	}
 


### PR DESCRIPTION
podman machine and podman-remote need some softer handling when it comes to key verification
this ensures that podman machine will still work (until we want to make this mandatory). I made the call back function more verbose so we know what is happening from now on.

Signed-off-by: Charlie Doern <cdoern@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
