### PR TITLE
Change default cgroups mode to enabled on FreeBSD

### DIFF
--- a/pkg/config/default_freebsd.go
+++ b/pkg/config/default_freebsd.go
@@ -1,7 +1,7 @@
 package config
 
 func getDefaultCgroupsMode() string {
-	return "disabled"
+	return "enabled"
 }
 
 // In theory, FreeBSD should be able to use shm locks but in practice,


### PR DESCRIPTION
Setting it to disabled triggers NoCgroups logic in podman which adds
extra validation and changes the conmon command line in ways that are
messy to work around. It turns out that pretending cgroups is enabled
even though the platform doesn't support it is easier.

Signed-off-by: Doug Rabson <dfr@rabson.org>

