### PR TITLE
Fix stutters

### DIFF
--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -413,7 +413,7 @@ func checkRegistrySourcesAllows(dest types.ImageReference) (insecure *bool, err 
 		AllowedRegistries  []string `json:"allowedRegistries,omitempty"`
 	}
 	if err := json.Unmarshal([]byte(registrySources), &sources); err != nil {
-		return nil, fmt.Errorf("error parsing $BUILD_REGISTRY_SOURCES (%q) as JSON: %w", registrySources, err)
+		return nil, fmt.Errorf("parsing $BUILD_REGISTRY_SOURCES (%q) as JSON: %w", registrySources, err)
 	}
 	blocked := false
 	if len(sources.BlockedRegistries) > 0 {

--- a/libimage/manifests/manifests.go
+++ b/libimage/manifests/manifests.go
@@ -87,11 +87,11 @@ func Create() List {
 func LoadFromImage(store storage.Store, image string) (string, List, error) {
 	img, err := store.Image(image)
 	if err != nil {
-		return "", nil, fmt.Errorf("error locating image %q for loading manifest list: %w", image, err)
+		return "", nil, fmt.Errorf("locating image %q for loading manifest list: %w", image, err)
 	}
 	manifestBytes, err := store.ImageBigData(img.ID, storage.ImageDigestManifestBigDataNamePrefix)
 	if err != nil {
-		return "", nil, fmt.Errorf("error locating image %q for loading manifest list: %w", image, err)
+		return "", nil, fmt.Errorf("locating image %q for loading manifest list: %w", image, err)
 	}
 	manifestList, err := manifests.FromBlob(manifestBytes)
 	if err != nil {
@@ -103,10 +103,10 @@ func LoadFromImage(store storage.Store, image string) (string, List, error) {
 	}
 	instancesBytes, err := store.ImageBigData(img.ID, instancesData)
 	if err != nil {
-		return "", nil, fmt.Errorf("error locating image %q for loading instance list: %w", image, err)
+		return "", nil, fmt.Errorf("locating image %q for loading instance list: %w", image, err)
 	}
 	if err := json.Unmarshal(instancesBytes, &list.instances); err != nil {
-		return "", nil, fmt.Errorf("error decoding instance list for image %q: %w", image, err)
+		return "", nil, fmt.Errorf("decoding instance list for image %q: %w", image, err)
 	}
 	list.instances[""] = img.ID
 	return img.ID, list, err
@@ -152,18 +152,18 @@ func (l *list) SaveToImage(store storage.Store, imageID string, names []string, 
 		}
 		return imageID, nil
 	}
-	return "", fmt.Errorf("error creating image to hold manifest list: %w", err)
+	return "", fmt.Errorf("creating image to hold manifest list: %w", err)
 }
 
 // Reference returns an image reference for the composite image being built
 // in the list, or an error if the list has never been saved to a local image.
 func (l *list) Reference(store storage.Store, multiple cp.ImageListSelection, instances []digest.Digest) (types.ImageReference, error) {
 	if l.instances[""] == "" {
-		return nil, fmt.Errorf("error building reference to list: %w", ErrListImageUnknown)
+		return nil, fmt.Errorf("building reference to list: %w", ErrListImageUnknown)
 	}
 	s, err := is.Transport.ParseStoreReference(store, l.instances[""])
 	if err != nil {
-		return nil, fmt.Errorf("error creating ImageReference from image %q: %w", l.instances[""], err)
+		return nil, fmt.Errorf("creating ImageReference from image %q: %w", l.instances[""], err)
 	}
 	references := make([]types.ImageReference, 0, len(l.instances))
 	whichInstances := make([]digest.Digest, 0, len(l.instances))
@@ -187,7 +187,7 @@ func (l *list) Reference(store storage.Store, multiple cp.ImageListSelection, in
 		imageName := l.instances[instance]
 		ref, err := alltransports.ParseImageName(imageName)
 		if err != nil {
-			return nil, fmt.Errorf("error creating ImageReference from image %q: %w", imageName, err)
+			return nil, fmt.Errorf("creating ImageReference from image %q: %w", imageName, err)
 		}
 		references = append(references, ref)
 	}
@@ -199,7 +199,7 @@ func (l *list) Push(ctx context.Context, dest types.ImageReference, options Push
 	// Load the system signing policy.
 	pushPolicy, err := signature.DefaultPolicy(options.SystemContext)
 	if err != nil {
-		return nil, "", fmt.Errorf("error obtaining default signature policy: %w", err)
+		return nil, "", fmt.Errorf("obtaining default signature policy: %w", err)
 	}
 
 	// Override the settings for local storage to make sure that we can always read the source "image".
@@ -207,7 +207,7 @@ func (l *list) Push(ctx context.Context, dest types.ImageReference, options Push
 
 	policyContext, err := signature.NewPolicyContext(pushPolicy)
 	if err != nil {
-		return nil, "", fmt.Errorf("error creating new signature policy context: %w", err)
+		return nil, "", fmt.Errorf("creating new signature policy context: %w", err)
 	}
 	defer func() {
 		if err2 := policyContext.Destroy(); err2 != nil {
@@ -273,7 +273,7 @@ func (l *list) Push(ctx context.Context, dest types.ImageReference, options Push
 func (l *list) Add(ctx context.Context, sys *types.SystemContext, ref types.ImageReference, all bool) (digest.Digest, error) {
 	src, err := ref.NewImageSource(ctx, sys)
 	if err != nil {
-		return "", fmt.Errorf("error setting up to read manifest and configuration from %q: %w", transports.ImageName(ref), err)
+		return "", fmt.Errorf("setting up to read manifest and configuration from %q: %w", transports.ImageName(ref), err)
 	}
 	defer src.Close()
 
@@ -288,13 +288,13 @@ func (l *list) Add(ctx context.Context, sys *types.SystemContext, ref types.Imag
 
 	primaryManifestBytes, primaryManifestType, err := src.GetManifest(ctx, nil)
 	if err != nil {
-		return "", fmt.Errorf("error reading manifest from %q: %w", transports.ImageName(ref), err)
+		return "", fmt.Errorf("reading manifest from %q: %w", transports.ImageName(ref), err)
 	}
 
 	if manifest.MIMETypeIsMultiImage(primaryManifestType) {
 		lists, err := manifests.FromBlob(primaryManifestBytes)
 		if err != nil {
-			return "", fmt.Errorf("error parsing manifest list in %q: %w", transports.ImageName(ref), err)
+			return "", fmt.Errorf("parsing manifest list in %q: %w", transports.ImageName(ref), err)
 		}
 		if all {
 			for i, instance := range lists.OCIv1().Manifests {
@@ -318,11 +318,11 @@ func (l *list) Add(ctx context.Context, sys *types.SystemContext, ref types.Imag
 		} else {
 			list, err := manifest.ListFromBlob(primaryManifestBytes, primaryManifestType)
 			if err != nil {
-				return "", fmt.Errorf("error parsing manifest list in %q: %w", transports.ImageName(ref), err)
+				return "", fmt.Errorf("parsing manifest list in %q: %w", transports.ImageName(ref), err)
 			}
 			instanceDigest, err := list.ChooseInstance(sys)
 			if err != nil {
-				return "", fmt.Errorf("error selecting image from manifest list in %q: %w", transports.ImageName(ref), err)
+				return "", fmt.Errorf("selecting image from manifest list in %q: %w", transports.ImageName(ref), err)
 			}
 			added := false
 			for i, instance := range lists.OCIv1().Manifests {
@@ -364,11 +364,11 @@ func (l *list) Add(ctx context.Context, sys *types.SystemContext, ref types.Imag
 		if instanceInfo.OS == "" || instanceInfo.Architecture == "" {
 			img, err := image.FromUnparsedImage(ctx, sys, image.UnparsedInstance(src, instanceInfo.instanceDigest))
 			if err != nil {
-				return "", fmt.Errorf("error reading configuration blob from %q: %w", transports.ImageName(ref), err)
+				return "", fmt.Errorf("reading configuration blob from %q: %w", transports.ImageName(ref), err)
 			}
 			config, err := img.OCIConfig(ctx)
 			if err != nil {
-				return "", fmt.Errorf("error reading info about config blob from %q: %w", transports.ImageName(ref), err)
+				return "", fmt.Errorf("reading info about config blob from %q: %w", transports.ImageName(ref), err)
 			}
 			if instanceInfo.OS == "" {
 				instanceInfo.OS = config.OS
@@ -382,12 +382,12 @@ func (l *list) Add(ctx context.Context, sys *types.SystemContext, ref types.Imag
 		}
 		manifestBytes, manifestType, err := src.GetManifest(ctx, instanceInfo.instanceDigest)
 		if err != nil {
-			return "", fmt.Errorf("error reading manifest from %q, instance %q: %w", transports.ImageName(ref), instanceInfo.instanceDigest, err)
+			return "", fmt.Errorf("reading manifest from %q, instance %q: %w", transports.ImageName(ref), instanceInfo.instanceDigest, err)
 		}
 		if instanceInfo.instanceDigest == nil {
 			manifestDigest, err = manifest.Digest(manifestBytes)
 			if err != nil {
-				return "", fmt.Errorf("error computing digest of manifest from %q: %w", transports.ImageName(ref), err)
+				return "", fmt.Errorf("computing digest of manifest from %q: %w", transports.ImageName(ref), err)
 			}
 			instanceInfo.instanceDigest = &manifestDigest
 			instanceInfo.Size = int64(len(manifestBytes))
@@ -396,7 +396,7 @@ func (l *list) Add(ctx context.Context, sys *types.SystemContext, ref types.Imag
 		}
 		err = l.List.AddInstance(*instanceInfo.instanceDigest, instanceInfo.Size, manifestType, instanceInfo.OS, instanceInfo.Architecture, instanceInfo.OSVersion, instanceInfo.OSFeatures, instanceInfo.Variant, instanceInfo.Features, instanceInfo.Annotations)
 		if err != nil {
-			return "", fmt.Errorf("error adding instance with digest %q: %w", *instanceInfo.instanceDigest, err)
+			return "", fmt.Errorf("adding instance with digest %q: %w", *instanceInfo.instanceDigest, err)
 		}
 		if _, ok := l.instances[*instanceInfo.instanceDigest]; !ok {
 			l.instances[*instanceInfo.instanceDigest] = transports.ImageName(ref)

--- a/libimage/normalize.go
+++ b/libimage/normalize.go
@@ -18,7 +18,7 @@ func NormalizeName(name string) (reference.Named, error) {
 	// NOTE: this code is in symmetrie with containers/image/pkg/shortnames.
 	ref, err := reference.Parse(name)
 	if err != nil {
-		return nil, fmt.Errorf("error normalizing name %q: %w", name, err)
+		return nil, fmt.Errorf("normalizing name %q: %w", name, err)
 	}
 
 	named, ok := ref.(reference.Named)

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -163,7 +163,7 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 	for _, name := range pulledImages {
 		image, _, err := r.LookupImage(name, nil)
 		if err != nil {
-			return nil, fmt.Errorf("error locating pulled image %q name in containers storage: %w", name, err)
+			return nil, fmt.Errorf("locating pulled image %q name in containers storage: %w", name, err)
 		}
 
 		// Note that we can ignore the 2nd return value here. Some
@@ -318,7 +318,7 @@ func (r *Runtime) storageReferencesReferencesFromArchiveReader(ctx context.Conte
 	for _, destName := range destNames {
 		destRef, err := storageTransport.Transport.ParseStoreReference(r.store, destName)
 		if err != nil {
-			return nil, nil, fmt.Errorf("error parsing dest reference name %#v: %w", destName, err)
+			return nil, nil, fmt.Errorf("parsing dest reference name %#v: %w", destName, err)
 		}
 		references = append(references, destRef)
 	}
@@ -399,7 +399,7 @@ func (r *Runtime) copyFromRegistry(ctx context.Context, ref types.ImageReference
 		}
 		tagged, err := reference.WithTag(named, tag)
 		if err != nil {
-			return nil, fmt.Errorf("error creating tagged reference (name %s, tag %s): %w", named.String(), tag, err)
+			return nil, fmt.Errorf("creating tagged reference (name %s, tag %s): %w", named.String(), tag, err)
 		}
 		pulled, err := r.copySingleImageFromRegistry(ctx, tagged.String(), pullPolicy, options)
 		if err != nil {

--- a/libimage/search.go
+++ b/libimage/search.go
@@ -281,7 +281,7 @@ func searchRepositoryTags(ctx context.Context, sys *types.SystemContext, registr
 	}
 	tags, err := registryTransport.GetRepositoryTags(ctx, sys, imageRef)
 	if err != nil {
-		return nil, fmt.Errorf("error getting repository tags: %v", err)
+		return nil, fmt.Errorf("getting repository tags: %v", err)
 	}
 	limit := searchMaxQueries
 	if len(tags) < limit {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -158,7 +158,7 @@ func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginO
 	}
 	if unauthorized, ok := err.(docker.ErrUnauthorizedForCredentials); ok {
 		logrus.Debugf("error logging into %q: %v", key, unauthorized)
-		return fmt.Errorf("error logging into %q: invalid username/password", key)
+		return fmt.Errorf("logging into %q: invalid username/password", key)
 	}
 	return fmt.Errorf("authenticating creds for %q: %w", key, err)
 }

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -145,7 +145,7 @@ func getAvailableControllers(exclude map[string]controllerHandler, cgroup2 bool)
 		}
 		controllersFileBytes, err := ioutil.ReadFile(controllersFile)
 		if err != nil {
-			return nil, fmt.Errorf("failed while reading controllers for cgroup v2 from %q: %w", controllersFile, err)
+			return nil, fmt.Errorf("failed while reading controllers for cgroup v2: %w", err)
 		}
 		for _, controllerName := range strings.Fields(string(controllersFileBytes)) {
 			c := controller{
@@ -264,7 +264,7 @@ func (c *CgroupControl) initialize() (err error) {
 	}()
 	if c.cgroup2 {
 		if err := createCgroupv2Path(filepath.Join(cgroupRoot, c.path)); err != nil {
-			return fmt.Errorf("error creating cgroup path %s: %w", c.path, err)
+			return fmt.Errorf("creating cgroup path %s: %w", c.path, err)
 		}
 	}
 	for name, handler := range handlers {
@@ -285,7 +285,7 @@ func (c *CgroupControl) initialize() (err error) {
 			}
 			path := c.getCgroupv1Path(ctr.name)
 			if err := os.MkdirAll(path, 0o755); err != nil {
-				return fmt.Errorf("error creating cgroup path for %s: %w", ctr.name, err)
+				return fmt.Errorf("creating cgroup path for %s: %w", ctr.name, err)
 			}
 		}
 	}

--- a/pkg/cgroups/cgroups_linux.go
+++ b/pkg/cgroups/cgroups_linux.go
@@ -98,7 +98,7 @@ func getAvailableControllers(exclude map[string]controllerHandler, cgroup2 bool)
 		}
 		controllersFileBytes, err := ioutil.ReadFile(controllersFile)
 		if err != nil {
-			return nil, fmt.Errorf("failed while reading controllers for cgroup v2 from %q: %w", controllersFile, err)
+			return nil, fmt.Errorf("failed while reading controllers for cgroup v2: %w", err)
 		}
 		for _, controllerName := range strings.Fields(string(controllersFileBytes)) {
 			c := controller{
@@ -217,7 +217,7 @@ func (c *CgroupControl) initialize() (err error) {
 	}()
 	if c.cgroup2 {
 		if err := createCgroupv2Path(filepath.Join(cgroupRoot, c.config.Path)); err != nil {
-			return fmt.Errorf("error creating cgroup path %s: %w", c.config.Path, err)
+			return fmt.Errorf("creating cgroup path %s: %w", c.config.Path, err)
 		}
 	}
 	for name, handler := range handlers {
@@ -238,7 +238,7 @@ func (c *CgroupControl) initialize() (err error) {
 			}
 			path := c.getCgroupv1Path(ctr.name)
 			if err := os.MkdirAll(path, 0o755); err != nil {
-				return fmt.Errorf("error creating cgroup path for %s: %w", ctr.name, err)
+				return fmt.Errorf("creating cgroup path for %s: %w", ctr.name, err)
 			}
 		}
 	}

--- a/pkg/cgroups/cgroups_supported.go
+++ b/pkg/cgroups/cgroups_supported.go
@@ -80,7 +80,7 @@ func UserOwnsCurrentSystemdCgroup() (bool, error) {
 		}
 		s := st.Sys()
 		if s == nil {
-			return false, fmt.Errorf("error stat cgroup path %s", cgroupPath)
+			return false, fmt.Errorf("stat cgroup path %s", cgroupPath)
 		}
 
 		if int(s.(*syscall.Stat_t).Uid) != uid {

--- a/pkg/cgroups/utils.go
+++ b/pkg/cgroups/utils.go
@@ -26,7 +26,7 @@ func readAcctList(ctr *CgroupControl, name string) ([]uint64, error) {
 	p := filepath.Join(ctr.getCgroupv1Path(CPUAcct), name)
 	data, err := ioutil.ReadFile(p)
 	if err != nil {
-		return nil, fmt.Errorf("reading %s: %w", p, err)
+		return nil, err
 	}
 	r := []uint64{}
 	for _, s := range strings.Split(string(data), " ") {
@@ -92,7 +92,7 @@ func cpusetCopyFileFromParent(dir, file string, cgroupv2 bool) ([]byte, error) {
 	}
 	data, err := ioutil.ReadFile(parentPath)
 	if err != nil {
-		return nil, fmt.Errorf("open %s: %w", path, err)
+		return nil, err
 	}
 	if strings.Trim(string(data), "\n") != "" {
 		return data, nil
@@ -169,7 +169,7 @@ func (c *CgroupControl) createCgroupDirectory(controller string) (bool, error) {
 	}
 
 	if err := os.MkdirAll(cPath, 0o755); err != nil {
-		return false, fmt.Errorf("error creating cgroup for %s: %w", controller, err)
+		return false, fmt.Errorf("creating cgroup for %s: %w", controller, err)
 	}
 	return true, nil
 }

--- a/pkg/configmaps/configmaps.go
+++ b/pkg/configmaps/configmaps.go
@@ -173,12 +173,12 @@ func (s *ConfigMapManager) Store(name string, data []byte, driverType string, dr
 	}
 	err = driver.Store(secr.ID, data)
 	if err != nil {
-		return "", fmt.Errorf("error creating configMap %s: %w", name, err)
+		return "", fmt.Errorf("creating configMap %s: %w", name, err)
 	}
 
 	err = s.store(secr)
 	if err != nil {
-		return "", fmt.Errorf("error creating configMap %s: %w", name, err)
+		return "", fmt.Errorf("creating configMap %s: %w", name, err)
 	}
 
 	return secr.ID, nil
@@ -208,12 +208,12 @@ func (s *ConfigMapManager) Delete(nameOrID string) (string, error) {
 
 	err = driver.Delete(configMapID)
 	if err != nil {
-		return "", fmt.Errorf("error deleting configMap %s: %w", nameOrID, err)
+		return "", fmt.Errorf("deleting configMap %s: %w", nameOrID, err)
 	}
 
 	err = s.delete(configMapID)
 	if err != nil {
-		return "", fmt.Errorf("error deleting configMap %s: %w", nameOrID, err)
+		return "", fmt.Errorf("deleting configMap %s: %w", nameOrID, err)
 	}
 	return configMapID, nil
 }

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -452,23 +452,23 @@ func (l *list) Serialize(mimeType string) ([]byte, error) {
 		if l.preferOCI() {
 			res, err = json.Marshal(&l.oci)
 			if err != nil {
-				return nil, fmt.Errorf("error marshalling OCI image index: %w", err)
+				return nil, fmt.Errorf("marshalling OCI image index: %w", err)
 			}
 		} else {
 			res, err = json.Marshal(&l.docker)
 			if err != nil {
-				return nil, fmt.Errorf("error marshalling Docker manifest list: %w", err)
+				return nil, fmt.Errorf("marshalling Docker manifest list: %w", err)
 			}
 		}
 	case v1.MediaTypeImageIndex:
 		res, err = json.Marshal(&l.oci)
 		if err != nil {
-			return nil, fmt.Errorf("error marshalling OCI image index: %w", err)
+			return nil, fmt.Errorf("marshalling OCI image index: %w", err)
 		}
 	case manifest.DockerV2ListMediaType:
 		res, err = json.Marshal(&l.docker)
 		if err != nil {
-			return nil, fmt.Errorf("error marshalling Docker manifest list: %w", err)
+			return nil, fmt.Errorf("marshalling Docker manifest list: %w", err)
 		}
 	default:
 		return nil, fmt.Errorf("serializing list to type %q not implemented: %w", mimeType, ErrManifestTypeNotSupported)

--- a/pkg/parse/parse_unix.go
+++ b/pkg/parse/parse_unix.go
@@ -39,7 +39,7 @@ func DeviceFromPath(device string) ([]devices.Device, error) {
 	// If source device is a directory
 	srcDevices, err := devices.GetDevices(src)
 	if err != nil {
-		return nil, fmt.Errorf("error getting source devices from directory %s: %w", src, err)
+		return nil, fmt.Errorf("getting source devices from directory %s: %w", src, err)
 	}
 	devs := make([]devices.Device, 0, len(srcDevices))
 	for _, d := range srcDevices {

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -183,12 +183,12 @@ func (s *SecretsManager) Store(name string, data []byte, driverType string, driv
 	}
 	err = driver.Store(secr.ID, data)
 	if err != nil {
-		return "", fmt.Errorf("error creating secret %s: %w", name, err)
+		return "", fmt.Errorf("creating secret %s: %w", name, err)
 	}
 
 	err = s.store(secr)
 	if err != nil {
-		return "", fmt.Errorf("error creating secret %s: %w", name, err)
+		return "", fmt.Errorf("creating secret %s: %w", name, err)
 	}
 
 	return secr.ID, nil
@@ -218,12 +218,12 @@ func (s *SecretsManager) Delete(nameOrID string) (string, error) {
 
 	err = driver.Delete(secretID)
 	if err != nil {
-		return "", fmt.Errorf("error deleting secret %s: %w", nameOrID, err)
+		return "", fmt.Errorf("deleting secret %s: %w", nameOrID, err)
 	}
 
 	err = s.delete(secretID)
 	if err != nil {
-		return "", fmt.Errorf("error deleting secret %s: %w", nameOrID, err)
+		return "", fmt.Errorf("deleting secret %s: %w", nameOrID, err)
 	}
 	return secretID, nil
 }

--- a/pkg/ssh/connection_golang.go
+++ b/pkg/ssh/connection_golang.go
@@ -275,7 +275,7 @@ func ValidateAndConfigure(uri *url.URL, iden string) (*ssh.ClientConfig, error) 
 	keyFilePath := filepath.Join(homedir.Get(), ".ssh", "known_hosts")
 	known, err := knownhosts.New(keyFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("error creating host key callback function for %s: %w", keyFilePath, err)
+		return nil, fmt.Errorf("creating host key callback function for %s: %w", keyFilePath, err)
 	}
 
 	cfg := &ssh.ClientConfig{

--- a/pkg/subscriptions/subscriptions.go
+++ b/pkg/subscriptions/subscriptions.go
@@ -256,7 +256,7 @@ func addSubscriptionsFromMountsFile(filePath, mountLabel, containerRunDir string
 				}
 				for _, s := range data {
 					if err := s.saveTo(ctrDirOrFileOnHost); err != nil {
-						return nil, fmt.Errorf("error saving data to container filesystem on host %q: %w", ctrDirOrFileOnHost, err)
+						return nil, fmt.Errorf("saving data to container filesystem on host %q: %w", ctrDirOrFileOnHost, err)
 					}
 				}
 			case mode.IsRegular():
@@ -278,7 +278,7 @@ func addSubscriptionsFromMountsFile(filePath, mountLabel, containerRunDir string
 
 			err = label.Relabel(ctrDirOrFileOnHost, mountLabel, false)
 			if err != nil {
-				return nil, fmt.Errorf("error applying correct labels: %w", err)
+				return nil, fmt.Errorf("applying correct labels: %w", err)
 			}
 			if uid != 0 || gid != 0 {
 				if err := rchown(ctrDirOrFileOnHost, uid, gid); err != nil {

--- a/pkg/supplemented/supplemented.go
+++ b/pkg/supplemented/supplemented.go
@@ -58,7 +58,7 @@ func Reference(ref types.ImageReference, supplemental []types.ImageReference, mu
 func (s *supplementedImageReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
 	src, err := s.NewImageSource(ctx, sys)
 	if err != nil {
-		return nil, fmt.Errorf("error building a new Image using an ImageSource: %w", err)
+		return nil, fmt.Errorf("building a new Image using an ImageSource: %w", err)
 	}
 	return image.FromSource(ctx, sys, src)
 }
@@ -75,7 +75,7 @@ func (s *supplementedImageReference) NewImageSource(ctx context.Context, sys *ty
 	// Open the default instance for reading.
 	top, err := s.ImageReference.NewImageSource(ctx, sys)
 	if err != nil {
-		return nil, fmt.Errorf("error opening %q as image source: %w", transports.ImageName(s.ImageReference), err)
+		return nil, fmt.Errorf("opening %q as image source: %w", transports.ImageName(s.ImageReference), err)
 	}
 
 	defer func() {
@@ -105,14 +105,14 @@ func (s *supplementedImageReference) NewImageSource(ctx context.Context, sys *ty
 		// Mark this instance as being associated with this ImageSource.
 		manifestDigest, err := manifest.Digest(manifestBytes)
 		if err != nil {
-			return fmt.Errorf("error computing digest over manifest %q: %w", string(manifestBytes), err)
+			return fmt.Errorf("computing digest over manifest %q: %w", string(manifestBytes), err)
 		}
 		sources[manifestDigest] = src
 
 		// Parse the manifest as a single image.
 		man, err := manifest.FromBlob(manifestBytes, manifestType)
 		if err != nil {
-			return fmt.Errorf("error parsing manifest %q: %w", string(manifestBytes), err)
+			return fmt.Errorf("parsing manifest %q: %w", string(manifestBytes), err)
 		}
 
 		// Log the config blob's digest and the blobs of its layers as associated with this manifest.
@@ -135,14 +135,14 @@ func (s *supplementedImageReference) NewImageSource(ctx context.Context, sys *ty
 		// Mark this instance as being associated with this ImageSource.
 		manifestDigest, err := manifest.Digest(manifestBytes)
 		if err != nil {
-			return fmt.Errorf("error computing manifest digest: %w", err)
+			return fmt.Errorf("computing manifest digest: %w", err)
 		}
 		sources[manifestDigest] = src
 
 		// Parse the manifest as a list of images.
 		list, err := manifest.ListFromBlob(manifestBytes, manifestType)
 		if err != nil {
-			return fmt.Errorf("error parsing manifest blob %q as a %q: %w", string(manifestBytes), manifestType, err)
+			return fmt.Errorf("parsing manifest blob %q as a %q: %w", string(manifestBytes), manifestType, err)
 		}
 
 		// Figure out which of its instances we want to look at.
@@ -151,7 +151,7 @@ func (s *supplementedImageReference) NewImageSource(ctx context.Context, sys *ty
 		case cp.CopySystemImage:
 			instance, err := list.ChooseInstance(sys)
 			if err != nil {
-				return fmt.Errorf("error selecting appropriate instance from list: %w", err)
+				return fmt.Errorf("selecting appropriate instance from list: %w", err)
 			}
 			chaseInstances = []digest.Digest{instance}
 		case cp.CopySpecificImages:
@@ -194,14 +194,14 @@ func (s *supplementedImageReference) NewImageSource(ctx context.Context, sys *ty
 		} else {
 			src, err = ref.NewImageSource(ctx, sys)
 			if err != nil {
-				return nil, fmt.Errorf("error opening %q as image source: %w", transports.ImageName(ref), err)
+				return nil, fmt.Errorf("opening %q as image source: %w", transports.ImageName(ref), err)
 			}
 		}
 
 		// Read the default manifest for the image.
 		manifestBytes, manifestType, err := src.GetManifest(ctx, nil)
 		if err != nil {
-			return nil, fmt.Errorf("error reading default manifest from image %q: %w", transports.ImageName(ref), err)
+			return nil, fmt.Errorf("reading default manifest from image %q: %w", transports.ImageName(ref), err)
 		}
 
 		// If this is the first image, mark it as our starting point.
@@ -223,18 +223,18 @@ func (s *supplementedImageReference) NewImageSource(ctx context.Context, sys *ty
 		// Record the digest of the ImageSource's default instance's manifest.
 		manifestDigest, err := manifest.Digest(manifestBytes)
 		if err != nil {
-			return nil, fmt.Errorf("error computing digest of manifest from image %q: %w", transports.ImageName(ref), err)
+			return nil, fmt.Errorf("computing digest of manifest from image %q: %w", transports.ImageName(ref), err)
 		}
 		sis.sourceDefaultInstances[src] = manifestDigest
 
 		// If the ImageSource's default manifest is a list, parse each of its instances.
 		if manifest.MIMETypeIsMultiImage(manifestType) {
 			if err = addMulti(manifestBytes, manifestType, src); err != nil {
-				return nil, fmt.Errorf("error adding multi-image %q: %w", transports.ImageName(ref), err)
+				return nil, fmt.Errorf("adding multi-image %q: %w", transports.ImageName(ref), err)
 			}
 		} else {
 			if err = addSingle(manifestBytes, manifestType, src); err != nil {
-				return nil, fmt.Errorf("error adding single image %q: %w", transports.ImageName(ref), err)
+				return nil, fmt.Errorf("adding single image %q: %w", transports.ImageName(ref), err)
 			}
 		}
 	}
@@ -261,18 +261,18 @@ func (s *supplementedImageReference) NewImageSource(ctx context.Context, sys *ty
 			// Trust that we either don't need it, or that it's in another reference.
 			// continue
 			// }
-			return nil, fmt.Errorf("error reading manifest for instance %q: %w", manifestToRead.instance, err)
+			return nil, fmt.Errorf("reading manifest for instance %q: %w", manifestToRead.instance, err)
 		}
 
 		if manifest.MIMETypeIsMultiImage(manifestType) {
 			// Add the list's contents.
 			if err = addMulti(manifestBytes, manifestType, manifestToRead.src); err != nil {
-				return nil, fmt.Errorf("error adding single image instance %q: %w", manifestToRead.instance, err)
+				return nil, fmt.Errorf("adding single image instance %q: %w", manifestToRead.instance, err)
 			}
 		} else {
 			// Add the single image's contents.
 			if err = addSingle(manifestBytes, manifestType, manifestToRead.src); err != nil {
-				return nil, fmt.Errorf("error adding single image instance %q: %w", manifestToRead.instance, err)
+				return nil, fmt.Errorf("adding single image instance %q: %w", manifestToRead.instance, err)
 			}
 		}
 	}
@@ -313,17 +313,17 @@ func (s *supplementedImageSource) GetManifest(ctx context.Context, instanceDiges
 		}
 		return sourceInstance.GetManifest(ctx, requestInstanceDigest)
 	}
-	return nil, "", fmt.Errorf("error getting manifest for digest %q: %w", *instanceDigest, ErrDigestNotFound)
+	return nil, "", fmt.Errorf("getting manifest for digest %q: %w", *instanceDigest, ErrDigestNotFound)
 }
 
 func (s *supplementedImageSource) GetBlob(ctx context.Context, blob types.BlobInfo, bic types.BlobInfoCache) (io.ReadCloser, int64, error) {
 	sourceInstance, ok := s.instancesByBlobDigest[blob.Digest]
 	if !ok {
-		return nil, -1, fmt.Errorf("error blob %q in known instances: %w", blob.Digest, ErrBlobNotFound)
+		return nil, -1, fmt.Errorf("blob %q in known instances: %w", blob.Digest, ErrBlobNotFound)
 	}
 	src, ok := s.sourceInstancesByInstance[sourceInstance]
 	if !ok {
-		return nil, -1, fmt.Errorf("error getting image source for instance %q: %w", sourceInstance, ErrDigestNotFound)
+		return nil, -1, fmt.Errorf("getting image source for instance %q: %w", sourceInstance, ErrDigestNotFound)
 	}
 	return src.GetBlob(ctx, blob, bic)
 }
@@ -364,7 +364,7 @@ func (s *supplementedImageSource) GetSignatures(ctx context.Context, instanceDig
 	if src != nil {
 		return src.GetSignatures(ctx, requestInstanceDigest)
 	}
-	return nil, fmt.Errorf("error finding instance for instance digest %q to read signatures: %w", digest, ErrDigestNotFound)
+	return nil, fmt.Errorf("finding instance for instance digest %q to read signatures: %w", digest, ErrDigestNotFound)
 }
 
 func (s *supplementedImageSource) LayerInfosForCopy(ctx context.Context, instanceDigest *digest.Digest) ([]types.BlobInfo, error) {
@@ -387,7 +387,7 @@ func (s *supplementedImageSource) LayerInfosForCopy(ctx context.Context, instanc
 	if src != nil {
 		blobInfos, err := src.LayerInfosForCopy(ctx, requestInstanceDigest)
 		if err != nil {
-			return nil, fmt.Errorf("error reading layer infos for copy from instance %q: %w", instanceDigest, err)
+			return nil, fmt.Errorf("reading layer infos for copy from instance %q: %w", instanceDigest, err)
 		}
 		var manifestDigest digest.Digest
 		if instanceDigest != nil {
@@ -398,5 +398,5 @@ func (s *supplementedImageSource) LayerInfosForCopy(ctx context.Context, instanc
 		}
 		return blobInfos, nil
 	}
-	return nil, fmt.Errorf("error finding instance for instance digest %q to copy layers: %w", errMsgDigest, ErrDigestNotFound)
+	return nil, fmt.Errorf("finding instance for instance digest %q to copy layers: %w", errMsgDigest, ErrDigestNotFound)
 }


### PR DESCRIPTION
Podman adds an Error: to every error message. So starting an error
message with "error" ends up being reported to the user as

Error: error ...

This patch removes the stutter.

Also ioutil.ReadFile errors report the Path, so wrapping the err message
with the path causes a stutter.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

[NO NEW TESTS NEEDED]

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
