### PR TITLE
pkg/report: handle newline in template string

### DIFF
--- a/pkg/report/formatter_test.go
+++ b/pkg/report/formatter_test.go
@@ -82,6 +82,8 @@ func TestFormatter_ParseTable(t *testing.T) {
 		},
 		{&bytes.Buffer{}, OriginUser, "{{range .}}{{.ID}}\tID\n{{end}}", "c061a0839e\tID\nf10fc2e11057\tID\n1eb6fab5aa8f4b5cbfd3e66aa35e9b2a\tID\n\n"},
 		{&bytes.Buffer{}, OriginUser, `{{range .}}{{.ID}}{{end -}}`, "c061a0839ef10fc2e110571eb6fab5aa8f4b5cbfd3e66aa35e9b2a"},
+		// regression test for https://bugzilla.redhat.com/show_bug.cgi?id=2059658 and https://github.com/containers/podman/issues/13446
+		{&bytes.Buffer{}, OriginUser, `{{range .}}{{printf "\n"}}{{end -}}`, "\n\n\n"},
 	}
 
 	for loop, tc := range testCase {

--- a/pkg/report/template_test.go
+++ b/pkg/report/template_test.go
@@ -178,10 +178,10 @@ func TestTemplate_Newlines(t *testing.T) {
 		{Field1: "Three", Field2: 3, Field3: "Third"},
 	}
 
-	hdrs := Headers(input[0], map[string]string{"Field1": "Ein", "Field2": "Zwei", "Field3": "Drei"})
+	hdrs := Headers(input[0], map[string]string{"Field1": "Eins", "Field2": "Zwei", "Field3": "Drei"})
 
 	// Ensure no blank lines in table
-	expected := "EIN\tZWEI\tDREI\nOne\t1\tFirst\nTwo\t2\tSecond\nThree\t3\tThird\n"
+	expected := "EINS\tZWEI\tDREI\nOne\t1\tFirst\nTwo\t2\tSecond\nThree\t3\tThird\n"
 
 	format := NormalizeFormat("{{.Field1}}\t{{.Field2}}\t{{.Field3}}")
 	format = EnforceRange(format)


### PR DESCRIPTION
Docker tries to be smart and replaces \n with the actual newline character.
For compat we do the same but this will break formats such as '{{printf "\n"}}'
To be backwards compatible with the previous behavior we try to replace and
parse the template. If it fails use the original text and parse again.

This fix will not be enough. It requires many changes in podman since
most commands will do their own NormalizeFormat() call before using this
backend which seems wrong and creates a lot of duplication. This has to
be fixed in Podman.

Required for https://bugzilla.redhat.com/show_bug.cgi?id=2059658
and https://github.com/containers/podman/issues/13446.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
