### PR TITLE
Use StoreOpts for secret store API

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -80,7 +80,7 @@ type Secret struct {
 	CreatedAt time.Time `json:"createdAt"`
 	// Driver is the driver used to store secret data
 	Driver string `json:"driver"`
-	// DriverOptions is other metadata needed to use the driver
+	// DriverOptions are extra options used to run this driver
 	DriverOptions map[string]string `json:"driverOptions"`
 }
 
@@ -100,6 +100,16 @@ type SecretsDriver interface {
 	Store(id string, data []byte) error
 	// Delete deletes a secret's data from the driver
 	Delete(id string) error
+}
+
+// StoreOptions are optional metadata fields that can be set when storing a new secret
+type StoreOptions struct {
+	// DriverOptions are extra options used to run this driver
+	DriverOpts map[string]string
+	// Metadata stores extra metadata on the secret
+	Metadata map[string]string
+	// Labels are labels on the secret
+	Labels map[string]string
 }
 
 // NewManager creates a new secrets manager
@@ -131,7 +141,7 @@ func NewManager(rootPath string) (*SecretsManager, error) {
 // Store takes a name, creates a secret and stores the secret metadata and the secret payload.
 // It returns a generated ID that is associated with the secret.
 // The max size for secret data is 512kB.
-func (s *SecretsManager) Store(name string, data []byte, driverType string, driverOpts map[string]string, metadata map[string]string, labels map[string]string) (string, error) {
+func (s *SecretsManager) Store(name string, data []byte, driverType string, options StoreOptions) (string, error) {
 	err := validateSecretName(name)
 	if err != nil {
 		return "", err
@@ -170,17 +180,23 @@ func (s *SecretsManager) Store(name string, data []byte, driverType string, driv
 		}
 	}
 
-	if metadata == nil {
-		metadata = make(map[string]string)
+	if options.Metadata == nil {
+		options.Metadata = make(map[string]string)
+	}
+	if options.Labels == nil {
+		options.Labels = make(map[string]string)
+	}
+	if options.DriverOpts == nil {
+		options.DriverOpts = make(map[string]string)
 	}
 
 	secr.Driver = driverType
-	secr.Metadata = metadata
+	secr.Metadata = options.Metadata
 	secr.CreatedAt = time.Now()
-	secr.DriverOptions = driverOpts
-	secr.Labels = labels
+	secr.DriverOptions = options.DriverOpts
+	secr.Labels = options.Labels
 
-	driver, err := getDriver(driverType, driverOpts)
+	driver, err := getDriver(driverType, options.DriverOpts)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -39,7 +39,13 @@ func TestAddSecretAndLookupData(t *testing.T) {
 	labels["foo"] = "bar"
 	labels["another"] = "label"
 
-	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, opts, metaData, labels)
+	storeOpts := StoreOptions{
+		DriverOpts: opts,
+		Metadata:   metaData,
+		Labels:     labels,
+	}
+
+	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, storeOpts)
 	require.NoError(t, err)
 
 	_, err = manager.lookupSecret("mysecret")
@@ -66,29 +72,33 @@ func TestAddSecretName(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(testpath)
 
+	storeOpts := StoreOptions{
+		DriverOpts: opts,
+	}
+
 	// test one char secret name
-	_, err = manager.Store("a", []byte("mydata"), drivertype, opts, nil, nil)
+	_, err = manager.Store("a", []byte("mydata"), drivertype, storeOpts)
 	require.NoError(t, err)
 
 	_, err = manager.lookupSecret("a")
 	require.NoError(t, err)
 
 	// name too short
-	_, err = manager.Store("", []byte("mydata"), drivertype, opts, nil, nil)
+	_, err = manager.Store("", []byte("mydata"), drivertype, storeOpts)
 	require.Error(t, err)
 	// name too long
-	_, err = manager.Store("uatqsbssrapurkuqoapubpifvsrissslzjehalxcesbhpxcvhsozlptrmngrivaiz", []byte("mydata"), drivertype, opts, nil, nil)
+	_, err = manager.Store("uatqsbssrapurkuqoapubpifvsrissslzjehalxcesbhpxcvhsozlptrmngrivaiz", []byte("mydata"), drivertype, storeOpts)
 	require.Error(t, err)
 	// invalid chars
-	_, err = manager.Store("??", []byte("mydata"), drivertype, opts, nil, nil)
+	_, err = manager.Store("??", []byte("mydata"), drivertype, storeOpts)
 	require.Error(t, err)
-	_, err = manager.Store("-a", []byte("mydata"), drivertype, opts, nil, nil)
+	_, err = manager.Store("-a", []byte("mydata"), drivertype, storeOpts)
 	require.Error(t, err)
-	_, err = manager.Store("a-", []byte("mydata"), drivertype, opts, nil, nil)
+	_, err = manager.Store("a-", []byte("mydata"), drivertype, storeOpts)
 	require.Error(t, err)
-	_, err = manager.Store(".a", []byte("mydata"), drivertype, opts, nil, nil)
+	_, err = manager.Store(".a", []byte("mydata"), drivertype, storeOpts)
 	require.Error(t, err)
-	_, err = manager.Store("a.", []byte("mydata"), drivertype, opts, nil, nil)
+	_, err = manager.Store("a.", []byte("mydata"), drivertype, storeOpts)
 	require.Error(t, err)
 }
 
@@ -97,10 +107,14 @@ func TestAddMultipleSecrets(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(testpath)
 
-	id, err := manager.Store("mysecret", []byte("mydata"), drivertype, opts, nil, nil)
+	storeOpts := StoreOptions{
+		DriverOpts: opts,
+	}
+
+	id, err := manager.Store("mysecret", []byte("mydata"), drivertype, storeOpts)
 	require.NoError(t, err)
 
-	id2, err := manager.Store("mysecret2", []byte("mydata2"), drivertype, opts, nil, nil)
+	id2, err := manager.Store("mysecret2", []byte("mydata2"), drivertype, storeOpts)
 	require.NoError(t, err)
 
 	secrets, err := manager.List()
@@ -131,10 +145,14 @@ func TestAddSecretDupName(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(testpath)
 
-	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, opts, nil, nil)
+	storeOpts := StoreOptions{
+		DriverOpts: opts,
+	}
+
+	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, storeOpts)
 	require.NoError(t, err)
 
-	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, opts, nil, nil)
+	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, storeOpts)
 	require.Error(t, err)
 }
 
@@ -143,12 +161,16 @@ func TestAddSecretPrefix(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(testpath)
 
+	storeOpts := StoreOptions{
+		DriverOpts: opts,
+	}
+
 	// If the randomly generated secret id is something like "abcdeiuoergnadufigh"
 	// we should still allow someone to store a secret with the name "abcd" or "a"
-	secretID, err := manager.Store("mysecret", []byte("mydata"), drivertype, opts, nil, nil)
+	secretID, err := manager.Store("mysecret", []byte("mydata"), drivertype, storeOpts)
 	require.NoError(t, err)
 
-	_, err = manager.Store(secretID[0:5], []byte("mydata"), drivertype, opts, nil, nil)
+	_, err = manager.Store(secretID[0:5], []byte("mydata"), drivertype, storeOpts)
 	require.NoError(t, err)
 }
 
@@ -157,7 +179,11 @@ func TestRemoveSecret(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(testpath)
 
-	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, opts, nil, nil)
+	storeOpts := StoreOptions{
+		DriverOpts: opts,
+	}
+
+	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, storeOpts)
 	require.NoError(t, err)
 
 	_, err = manager.lookupSecret("mysecret")
@@ -187,7 +213,11 @@ func TestLookupAllSecrets(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(testpath)
 
-	id, err := manager.Store("mysecret", []byte("mydata"), drivertype, opts, nil, nil)
+	storeOpts := StoreOptions{
+		DriverOpts: opts,
+	}
+
+	id, err := manager.Store("mysecret", []byte("mydata"), drivertype, storeOpts)
 	require.NoError(t, err)
 
 	// inspect using secret name
@@ -201,7 +231,11 @@ func TestInspectSecretId(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(testpath)
 
-	id, err := manager.Store("mysecret", []byte("mydata"), drivertype, opts, nil, nil)
+	storeOpts := StoreOptions{
+		DriverOpts: opts,
+	}
+
+	id, err := manager.Store("mysecret", []byte("mydata"), drivertype, storeOpts)
 	require.NoError(t, err)
 
 	_, err = manager.lookupSecret("mysecret")
@@ -233,9 +267,13 @@ func TestSecretList(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(testpath)
 
-	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, opts, nil, nil)
+	storeOpts := StoreOptions{
+		DriverOpts: opts,
+	}
+
+	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, storeOpts)
 	require.NoError(t, err)
-	_, err = manager.Store("mysecret2", []byte("mydata2"), drivertype, opts, nil, nil)
+	_, err = manager.Store("mysecret2", []byte("mydata2"), drivertype, storeOpts)
 	require.NoError(t, err)
 
 	allSecrets, err := manager.List()


### PR DESCRIPTION
Clean up store code by using StoreOpts instead of multiple args as opts for storing secrets.

Signed-off-by: Ashley Cui <acui@redhat.com>

Mentioned in: https://github.com/containers/common/pull/1147#discussion_r965635116

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
