### PR TITLE
phg/config: do not force default EventsLogFilePath

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -365,7 +365,7 @@ image_copy_tmp_dir="storage"`
 				gomega.Expect(config.Engine.EventsLogger).To(gomega.BeEquivalentTo("file"))
 				gomega.Expect(config.Containers.LogDriver).To(gomega.BeEquivalentTo("k8s-file"))
 			}
-			gomega.Expect(config.Engine.EventsLogFilePath).To(gomega.BeEquivalentTo(config.Engine.TmpDir + "/events/events.log"))
+			gomega.Expect(config.Engine.EventsLogFilePath).To(gomega.BeEquivalentTo(""))
 			gomega.Expect(uint64(config.Engine.EventsLogFileMaxSize)).To(gomega.Equal(DefaultEventsLogSizeMax))
 			gomega.Expect(config.Engine.PodExitPolicy).To(gomega.Equal(PodExitPolicyContinue))
 		})

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -280,8 +280,6 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	}
 	c.TmpDir = tmp
 
-	c.EventsLogFilePath = filepath.Join(c.TmpDir, "events", "events.log")
-
 	c.EventsLogFileMaxSize = eventsLogMaxSize(DefaultEventsLogSizeMax)
 
 	c.CompatAPIEnforceDockerHub = true


### PR DESCRIPTION
The problem with setting such defaults in c/common is that podman cannot know if a user set this or it is the default. EventsLogFilePath is not a static path, it depends on the --tmpdir value from podman.

check
https://github.com/containers/podman/blob/b0b36430b88da32b63774bc6a9a1f330252b0fd6/libpod/runtime.go#L1041-L1043

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
