### PR TITLE
libimage: remove: fix event

### DIFF
--- a/libimage/image.go
+++ b/libimage/image.go
@@ -477,8 +477,10 @@ func (i *Image) removeRecursive(ctx context.Context, rmMap map[string]*RemoveIma
 	}
 
 	report.Untagged = append(report.Untagged, i.Names()...)
-	for _, name := range i.Names() {
-		i.runtime.writeEvent(&Event{ID: i.ID(), Name: name, Time: time.Now(), Type: EventTypeImageUntag})
+	if i.runtime.eventChannel != nil {
+		for _, name := range i.Names() {
+			i.runtime.writeEvent(&Event{ID: i.ID(), Name: name, Time: time.Now(), Type: EventTypeImageUntag})
+		}
 	}
 
 	if !hasChildren {


### PR DESCRIPTION
Wrap in a `nil` check to make sure that consumers not using events are not bothered with log messages.  It's probably worth moving the check into the function but I do not want start Yak shaving in a quick fix.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
