### PR TITLE
Stop using stringid.GenerateNonCryptoID

### DIFF
--- a/libnetwork/cni/run_test.go
+++ b/libnetwork/cni/run_test.go
@@ -123,7 +123,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							defNet: {InterfaceName: intName},
 						},
@@ -157,7 +157,7 @@ var _ = Describe("run CNI", func() {
 				ip := net.ParseIP("10.88.5.5")
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							defNet: {
 								InterfaceName: intName,
@@ -188,12 +188,12 @@ var _ = Describe("run CNI", func() {
 			protocol := proto
 			It("run with exposed ports protocol "+protocol, func() {
 				runTest(func() {
-					testdata := stringid.GenerateNonCryptoID()
+					testdata := stringid.GenerateRandomID()
 					defNet := types.DefaultNetworkName
 					intName := "eth0"
 					setupOpts := types.SetupOptions{
 						NetworkOptions: types.NetworkOptions{
-							ContainerID: stringid.GenerateNonCryptoID(),
+							ContainerID: stringid.GenerateRandomID(),
 							PortMappings: []types.PortMapping{{
 								Protocol:      protocol,
 								HostIP:        "127.0.0.1",
@@ -246,7 +246,7 @@ var _ = Describe("run CNI", func() {
 					intName := "eth0"
 					setupOpts := types.SetupOptions{
 						NetworkOptions: types.NetworkOptions{
-							ContainerID: stringid.GenerateNonCryptoID(),
+							ContainerID: stringid.GenerateRandomID(),
 							PortMappings: []types.PortMapping{{
 								Protocol:      protocol,
 								HostIP:        "127.0.0.1",
@@ -277,7 +277,7 @@ var _ = Describe("run CNI", func() {
 						port := p
 						var wg sync.WaitGroup
 						wg.Add(1)
-						testdata := stringid.GenerateNonCryptoID()
+						testdata := stringid.GenerateRandomID()
 						// start a listener in the container ns
 						err = netNSContainer.Do(func(_ ns.NetNS) error {
 							defer GinkgoRecover()
@@ -308,7 +308,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						PortMappings: []types.PortMapping{{
 							Protocol:      "tcp,udp",
 							HostIP:        "127.0.0.1",
@@ -333,7 +333,7 @@ var _ = Describe("run CNI", func() {
 					// copy proto to extra var to keep correct references in the goroutines
 					protocol := proto
 
-					testdata := stringid.GenerateNonCryptoID()
+					testdata := stringid.GenerateRandomID()
 					var wg sync.WaitGroup
 					wg.Add(1)
 					// start tcp listener in the container ns
@@ -368,7 +368,7 @@ var _ = Describe("run CNI", func() {
 				intName1 := "eth0"
 				netName1 := network1.Name
 
-				containerID := stringid.GenerateNonCryptoID()
+				containerID := stringid.GenerateRandomID()
 
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
@@ -559,7 +559,7 @@ var _ = Describe("run CNI", func() {
 
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							netName1: {
 								InterfaceName: intName1,
@@ -685,7 +685,7 @@ var _ = Describe("run CNI", func() {
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
 						ContainerName: "mycon",
-						ContainerID:   stringid.GenerateNonCryptoID(),
+						ContainerID:   stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							netName: {
 								InterfaceName: interfaceName,
@@ -782,7 +782,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							netName: {
 								InterfaceName: intName,
@@ -845,7 +845,7 @@ var _ = Describe("run CNI", func() {
 
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							netName1: {
 								InterfaceName: intName1,
@@ -954,7 +954,7 @@ var _ = Describe("run CNI", func() {
 				netName := "dualstack"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID:   stringid.GenerateNonCryptoID(),
+						ContainerID:   stringid.GenerateRandomID(),
 						ContainerName: containerName,
 						Networks: map[string]types.PerNetworkOptions{
 							netName: {
@@ -1057,7 +1057,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							defNet: {
 								InterfaceName: intName,
@@ -1080,7 +1080,7 @@ var _ = Describe("run CNI", func() {
 				ip := "1.1.1.1"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							defNet: {
 								InterfaceName: intName,
@@ -1101,7 +1101,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							defNet: {
 								InterfaceName: intName,
@@ -1121,7 +1121,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							defNet: {
 								InterfaceName: intName,
@@ -1159,7 +1159,7 @@ var _ = Describe("run CNI", func() {
 			runTest(func() {
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 					},
 				}
 				_, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
@@ -1173,7 +1173,7 @@ var _ = Describe("run CNI", func() {
 				defNet := types.DefaultNetworkName
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							defNet: {
 								InterfaceName: "",
@@ -1214,7 +1214,7 @@ var _ = Describe("run CNI", func() {
 
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							netName1: {
 								InterfaceName: intName1,
@@ -1259,7 +1259,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						PortMappings: []types.PortMapping{{
 							Protocol:      "someproto",
 							HostIP:        "127.0.0.1",
@@ -1283,7 +1283,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						PortMappings: []types.PortMapping{{
 							Protocol:      "",
 							HostIP:        "127.0.0.1",
@@ -1307,7 +1307,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							defNet: {InterfaceName: intName},
 						},
@@ -1325,7 +1325,7 @@ var _ = Describe("run CNI", func() {
 				netName := "somenet"
 				teardownOpts := types.TeardownOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							netName: {
 								InterfaceName: interfaceName,
@@ -1352,7 +1352,7 @@ var _ = Describe("run CNI", func() {
 				netName := network1.Name
 				teardownOpts := types.TeardownOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							netName: {
 								InterfaceName: interfaceName,

--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -52,7 +52,7 @@ func (n *netavarkNetwork) networkCreate(newNetwork *types.Network, defaultNet bo
 		// generate random network ID
 		var i int
 		for i = 0; i < 1000; i++ {
-			id := stringid.GenerateNonCryptoID()
+			id := stringid.GenerateRandomID()
 			if _, err := n.getNetwork(id); err != nil {
 				newNetwork.ID = id
 				break

--- a/libnetwork/netavark/run_test.go
+++ b/libnetwork/netavark/run_test.go
@@ -192,7 +192,7 @@ var _ = Describe("run netavark", func() {
 			Expect(addrs).To(ContainElements(EqualSubnet(subnet)))
 
 			wg := &sync.WaitGroup{}
-			expected := stringid.GenerateNonCryptoID()
+			expected := stringid.GenerateRandomID()
 			// now check ip connectivity
 			err = netNSContainer.Do(func(_ ns.NetNS) error {
 				wg.Add(1)
@@ -259,7 +259,7 @@ var _ = Describe("run netavark", func() {
 			intName := "eth0"
 			setupOpts1 := types.SetupOptions{
 				NetworkOptions: types.NetworkOptions{
-					ContainerID: stringid.GenerateNonCryptoID(),
+					ContainerID: stringid.GenerateRandomID(),
 					Networks: map[string]types.PerNetworkOptions{
 						defNet: {InterfaceName: intName},
 					},
@@ -277,7 +277,7 @@ var _ = Describe("run netavark", func() {
 
 			setupOpts2 := types.SetupOptions{
 				NetworkOptions: types.NetworkOptions{
-					ContainerID: stringid.GenerateNonCryptoID(),
+					ContainerID: stringid.GenerateRandomID(),
 					Networks: map[string]types.PerNetworkOptions{
 						defNet: {InterfaceName: intName},
 					},
@@ -323,7 +323,7 @@ var _ = Describe("run netavark", func() {
 
 			setupOpts := types.SetupOptions{
 				NetworkOptions: types.NetworkOptions{
-					ContainerID: stringid.GenerateNonCryptoID(),
+					ContainerID: stringid.GenerateRandomID(),
 					Networks: map[string]types.PerNetworkOptions{
 						netName: {InterfaceName: intName},
 					},
@@ -414,7 +414,7 @@ var _ = Describe("run netavark", func() {
 
 			setupOpts := types.SetupOptions{
 				NetworkOptions: types.NetworkOptions{
-					ContainerID: stringid.GenerateNonCryptoID(),
+					ContainerID: stringid.GenerateRandomID(),
 					Networks: map[string]types.PerNetworkOptions{
 						netName1: {InterfaceName: intName1},
 						netName2: {InterfaceName: intName2},
@@ -507,12 +507,12 @@ var _ = Describe("run netavark", func() {
 		protocol := proto
 		It("run with exposed ports protocol "+protocol, func() {
 			runTest(func() {
-				testdata := stringid.GenerateNonCryptoID()
+				testdata := stringid.GenerateRandomID()
 				defNet := types.DefaultNetworkName
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						PortMappings: []types.PortMapping{{
 							Protocol:      protocol,
 							HostIP:        "127.0.0.1",
@@ -565,7 +565,7 @@ var _ = Describe("run netavark", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						PortMappings: []types.PortMapping{{
 							Protocol:      protocol,
 							HostIP:        "127.0.0.1",
@@ -596,7 +596,7 @@ var _ = Describe("run netavark", func() {
 					port := p
 					var wg sync.WaitGroup
 					wg.Add(1)
-					testdata := stringid.GenerateNonCryptoID()
+					testdata := stringid.GenerateRandomID()
 					// start a listener in the container ns
 					err = netNSContainer.Do(func(_ ns.NetNS) error {
 						defer GinkgoRecover()
@@ -715,7 +715,7 @@ var _ = Describe("run netavark", func() {
 
 			setupOpts := types.SetupOptions{
 				NetworkOptions: types.NetworkOptions{
-					ContainerID: stringid.GenerateNonCryptoID(),
+					ContainerID: stringid.GenerateRandomID(),
 					Networks: map[string]types.PerNetworkOptions{
 						netName1: {
 							InterfaceName: intName1,

--- a/pkg/configmaps/configmaps.go
+++ b/pkg/configmaps/configmaps.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/containers/common/pkg/configmaps/filedriver"
+	"github.com/containers/common/pkg/randid"
 	"github.com/containers/storage/pkg/lockfile"
-	"github.com/containers/storage/pkg/stringid"
 )
 
 // maxConfigMapSize is the max size for configMap data - 512kB
@@ -148,9 +148,7 @@ func (s *ConfigMapManager) Store(name string, data []byte, driverType string, dr
 	secr.Name = name
 
 	for {
-		newID := stringid.GenerateNonCryptoID()
-		// GenerateNonCryptoID() gives 64 characters, so we truncate to correct length
-		newID = newID[0:configMapIDLength]
+		newID := randid.Get(configMapIDLength)
 		_, err := s.lookupConfigMap(newID)
 		if err != nil {
 			if errors.Is(err, ErrNoSuchConfigMap) {

--- a/pkg/randid/randid.go
+++ b/pkg/randid/randid.go
@@ -1,0 +1,21 @@
+package randid
+
+import (
+	"encoding/hex"
+	"math/rand"
+)
+
+// Get generates a pseudorandom ID string of requested length.
+// The string is composed of 0-9a-f characters.
+//
+// The string returned is random but is not guaranteed to be unique; the caller
+// is expected to check if such ID is already in use and retry.
+func Get(length int) string {
+	b := make([]byte, length/2+length%2)
+	if _, err := rand.Read(b); err != nil {
+		panic(err) // This never happens.
+	}
+
+	// If the length is odd, we have to slice the result by one byte.
+	return hex.EncodeToString(b)[:length]
+}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containers/common/pkg/randid"
 	"github.com/containers/common/pkg/secrets/filedriver"
 	"github.com/containers/common/pkg/secrets/passdriver"
 	"github.com/containers/common/pkg/secrets/shelldriver"
 	"github.com/containers/storage/pkg/lockfile"
-	"github.com/containers/storage/pkg/stringid"
 )
 
 // maxSecretSize is the max size for secret data - 512kB
@@ -166,9 +166,7 @@ func (s *SecretsManager) Store(name string, data []byte, driverType string, opti
 	secr.Name = name
 
 	for {
-		newID := stringid.GenerateNonCryptoID()
-		// GenerateNonCryptoID() gives 64 characters, so we truncate to correct length
-		newID = newID[0:secretIDLength]
+		newID := randid.Get(secretIDLength)
 		_, err := s.lookupSecret(newID)
 		if err != nil {
 			if errors.Is(err, ErrNoSuchSecret) {


### PR DESCRIPTION
1. Replace stringid.GenerateNonCryptoID with a small randid package (see commit for details).

2. In view of containers/storage#1337, do this:

	for f in $(git grep -l stringid.GenerateNonCryptoID); do
		sed -i 's/stringid.GenerateNonCryptoID/stringid.GenerateRandomID/g' $f;
	done