### PR TITLE
config: look user id instead of rootless

### DIFF
--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -23,7 +23,7 @@ func customConfigFile() (string, error) {
 	if path, found := os.LookupEnv("CONTAINERS_CONF"); found {
 		return path, nil
 	}
-	if unshare.IsRootless() {
+	if unshare.GetRootlessUID() > 0 {
 		path, err := rootlessConfigPath()
 		if err != nil {
 			return "", err
@@ -34,7 +34,7 @@ func customConfigFile() (string, error) {
 }
 
 func ifRootlessConfigPath() (string, error) {
-	if unshare.IsRootless() {
+	if unshare.GetRootlessUID() > 0 {
 		path, err := rootlessConfigPath()
 		if err != nil {
 			return "", err

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -180,7 +180,7 @@ func DefaultConfig() (*Config, error) {
 	}
 
 	defaultEngineConfig.SignaturePolicyPath = DefaultSignaturePolicyPath
-	if unshare.IsRootless() {
+	if unshare.GetRootlessUID() > 0 {
 		configHome, err := homedir.GetConfigHome()
 		if err != nil {
 			return nil, err
@@ -289,7 +289,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 			return nil, err
 		}
 	}
-	storeOpts, err := types.DefaultStoreOptions(unshare.IsRootless(), unshare.GetRootlessUID())
+	storeOpts, err := types.DefaultStoreOptions(unshare.GetRootlessUID() > 0, unshare.GetRootlessUID())
 	if err != nil {
 		return nil, err
 	}
@@ -427,7 +427,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 }
 
 func defaultTmpDir() (string, error) {
-	if !unshare.IsRootless() {
+	if unshare.GetRootlessUID() != 0 {
 		return getLibpodTmpDir(), nil
 	}
 


### PR DESCRIPTION
Change the check to look for the UID to decide whether to load the default configuration files from the user directory instead of the system path.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
