### PR TITLE
config: correct the check for root

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -427,7 +427,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 }
 
 func defaultTmpDir() (string, error) {
-	if unshare.GetRootlessUID() != 0 {
+	if unshare.GetRootlessUID() == 0 {
 		return getLibpodTmpDir(), nil
 	}
 


### PR DESCRIPTION
originally the code had the condition "!unshare.IsRootless()", and commit 52108b71e1a2abc82f1c104ca30792548d8937b9 introduced the issue by replacing it with "unshare.GetRootlessUID() != 0".

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
