### PR TITLE
libimage.NormalizePlatform: normalize default `variant` as per specified `arch`

### DIFF
--- a/libimage/normalize_test.go
+++ b/libimage/normalize_test.go
@@ -54,6 +54,34 @@ func TestNormalizePlatform(t *testing.T) {
 			platform{"linux", "aarch64", ""},
 			platform{"linux", "arm64", ""},
 		},
+		// Verify: https://github.com/containerd/containerd/blob/main/platforms/database.go#L97
+		{
+			platform{"linux", "arm64", "8"},
+			platform{"linux", "arm64", "v8"},
+		},
+		// Verify: https://github.com/containerd/containerd/blob/main/platforms/database.go#L100
+		{
+			platform{"linux", "armhf", ""},
+			platform{"linux", "arm", "v7"},
+		},
+		{
+			platform{"linux", "armhf", "v7"},
+			platform{"linux", "arm", "v7"},
+		},
+		// Verify: https://github.com/containerd/containerd/blob/main/platforms/database.go#L103
+		{
+			platform{"linux", "armel", ""},
+			platform{"linux", "arm", "v6"},
+		},
+		// Verify: https://github.com/containerd/containerd/blob/main/platforms/database.go#L103
+		{
+			platform{"linux", "armel", "v6"},
+			platform{"linux", "arm", "v6"},
+		},
+		{
+			platform{"linux", "armel", ""},
+			platform{"linux", "arm", "v6"},
+		},
 	} {
 		os, arch, variant := NormalizePlatform(test.input.os, test.input.arch, test.input.variant)
 		assert.Equal(t, test.expected.os, os, test.input)


### PR DESCRIPTION
Following PR attempts to unify code being using in buildah and other part, so a common code chunk can be used as a source of truth for normalizing platforms.

As of now NormalizePlatform ignores normalizing or setting default variants for specific arch types thus producing empty variants in results even when default variants were expected for such cases.

Example consider: `linux/armhf` -> `{os:linux, arch: arm, variant: v7}`

See: https://github.com/containers/buildah/pull/4286 for more details.