### PR TITLE
util, GetRuntimeDir: don't error out early if `XDG_RUNTIME_DIR` is not set.

### DIFF
--- a/pkg/util/util_supported.go
+++ b/pkg/util/util_supported.go
@@ -34,8 +34,7 @@ func GetRuntimeDir() (string, error) {
 	rootlessRuntimeDirOnce.Do(func() {
 		runtimeDir, err := homedir.GetRuntimeDir()
 		if err != nil {
-			rootlessRuntimeDirError = err
-			return
+			logrus.Debug(err)
 		}
 		if runtimeDir != "" {
 			st, err := os.Stat(runtimeDir)


### PR DESCRIPTION
We must try out all possible alternatives for rootless users instead of failing eary if `XDG_RUNTIME_DIR` is not set.

Commit which introduced regression: https://github.com/containers/common/commit/48f90f538f3e49ee6a66f1e4efad1a6498800efe

[NO NEW TESTS NEEDED]
[NO TESTS NEEDED]

