### PR TITLE
Fix Windows regression introduced by PR #1161

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -180,7 +180,7 @@ func DefaultConfig() (*Config, error) {
 	}
 
 	defaultEngineConfig.SignaturePolicyPath = DefaultSignaturePolicyPath
-	if unshare.GetRootlessUID() > 0 {
+	if useUserConfigLocations() {
 		configHome, err := homedir.GetConfigHome()
 		if err != nil {
 			return nil, err
@@ -289,7 +289,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 			return nil, err
 		}
 	}
-	storeOpts, err := types.DefaultStoreOptions(unshare.GetRootlessUID() > 0, unshare.GetRootlessUID())
+	storeOpts, err := types.DefaultStoreOptions(useUserConfigLocations(), unshare.GetRootlessUID())
 	if err != nil {
 		return nil, err
 	}
@@ -427,7 +427,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 }
 
 func defaultTmpDir() (string, error) {
-	if unshare.GetRootlessUID() == 0 {
+	if !useUserConfigLocations() {
 		return getLibpodTmpDir(), nil
 	}
 
@@ -679,3 +679,10 @@ func getDefaultSSHConfig() string {
 	dirname := homedir.Get()
 	return filepath.Join(dirname, ".ssh", "config")
 }
+
+func useUserConfigLocations() bool {
+	// NOTE: For now we want Windows to use system locations.
+	// GetRootlessUID == -1 on Windows, so exclude negative range
+	return unshare.GetRootlessUID() > 0
+}
+


### PR DESCRIPTION
Before 52108b71e1a2abc this code used unshare.IsRootless() which on Windows always returns false (the behavior we want).

After 52108b71e1a2abc, a condition was unintentionally inverted, allowing Windows to function.

Commit f8f2c4f2ee56 fixed the inversion, but unintentionally excluded Windows since it used == 0 instead of <= 0 (Windows returns -1)

Move the logic behind a function with a comment since the Windows path is a bit exotic.

In the future, the Windows path should likely be refactored to be more intuitive; however, this will get things working for now.
