### PR TITLE
[v0.48] Cirrus: Resuscitate CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,7 +21,7 @@ env:
     #### image names to test with (double-quotes around names are critical)
     ####
     FEDORA_NAME: "fedora-35"
-    IMAGE_SUFFIX: "c6454758209748992"
+    IMAGE_SUFFIX: "c5814666029957120"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
 
@@ -79,7 +79,7 @@ meta_task:
     container:
         cpu: 2
         memory: 2
-        image: quay.io/libpod/imgts:$IMAGE_SUFFIX
+        image: quay.io/libpod/imgts:latest
     env:
         # Space-separated list of images used by this repository state
         IMGNAMES: >-

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,12 +1,14 @@
 name: validate
 on:
   push:
-    tags:
-      - v*
     branches:
       - main
-      - v*
   pull_request:
+    branches:
+      - main
+
+permissions: read-all
+
 env:
   LINT_VERSION: v1.45
 


### PR DESCRIPTION
No release-branch monitoring or maintenance is/was performed for this repo.  Due to disuse, release-branch CI VM images were pruned.  Attempt to resuscitate the patient using high-voltage defibrillator:  Steal the CI VM images from the podman:v4.0-rhel branch.  Also update the meta task to help these images stay alive (maybe).

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
