### PR TITLE
GHA: Limit operations to `main` branch only

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,12 +2,11 @@ name: validate
 
 on:
   push:
-    tags:
-      - v*
     branches:
       - main
-      - v*
   pull_request:
+    branches:
+      - main
 
 permissions: read-all
 


### PR DESCRIPTION
Due to it's design, github-actions workflows source their configuration from different locations depending on the event-type.  This is impossible for humans to manage, let alone on repos with multiple release-branches.  One would need to:

1. Understand the config-source for all utilized trigger events.
2. Ensure upon creation of a new branch or tag, the relevant source is updated to support reliable long-term operations.
3. Repeat for infinity.

Fix this by removing all GHA trigger events except `pull_request`.  For all pull requests, only trigger code validation if the target is `main`.

Also, for `push` (merge) events, limit validation to `main` to prevent (new) validate from trying to run against (old) release branches - it will fail.