### PR TITLE
libnetwork: add `DNSServers` to `NetworkOptions`

### DIFF
--- a/libnetwork/types/network.go
+++ b/libnetwork/types/network.go
@@ -226,6 +226,9 @@ type NetworkOptions struct {
 	// Networks contains all networks with the PerNetworkOptions.
 	// The map should contain at least one element.
 	Networks map[string]PerNetworkOptions `json:"networks"`
+	// List of custom DNS server for podman's DNS resolver.
+	// Priority order will be kept as defined by user in the configuration.
+	DNSServers []string `json:"dns_servers,omitempty"`
 }
 
 // PortMapping is one or more ports that will be mapped into the container.


### PR DESCRIPTION
Netavark now accepts `dns_servers` for each container which allows containers to use custom DNS servers as resolvers instead of falling back to host's resolver.

Following field allows users of libnetwork to pass newly added field to `netavark` and `aarvark-dns`

Actual feature implemented here:
* https://github.com/containers/aardvark-dns/pull/240
* https://github.com/containers/netavark/pull/452