### PR TITLE
ci,codespell: ignore function `ShouldNot`

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
       # Version of codespell bundled with Ubuntu is way old, so use pip.
       run: pip install codespell
     - name: run codespell
-      run: codespell -L ro,hastable
+      run: codespell -L ro,hastable,shouldnot
   lint:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
Codespell is getting angry on function name `ShouldNot` which should be acceptable.

Ignore in-code function name
https://github.com/containers/common/blob/main/pkg/config/config_test.go#L537 and unblock CI