### PR TITLE
libimage: add LayersDiskUsage

### DIFF
--- a/libimage/corrupted_test.go
+++ b/libimage/corrupted_test.go
@@ -43,6 +43,8 @@ func TestCorruptedLayers(t *testing.T) {
 	// Disk usage works.
 	_, err = runtime.DiskUsage(ctx)
 	require.NoError(t, err, "disk usage works on healthy image")
+	_, err = runtime.LayersDiskUsage(ctx)
+	require.NoError(t, err, "layers disk usage works on healthy image")
 
 	// Now remove one layer from the layers.json index in the storage.  The
 	// image will still be listed in the container storage but attempting

--- a/libimage/disk_usage.go
+++ b/libimage/disk_usage.go
@@ -5,6 +5,21 @@ import (
 	"time"
 )
 
+// LayersDiskUsage returns the sum of the size of all layers in the current store.
+func (r *Runtime) LayersDiskUsage(ctx context.Context) (int64, error) {
+	layers, err := r.store.Layers()
+	if err != nil {
+		return -1, err
+	}
+
+	var size int64
+	for _, l := range layers {
+		size += l.UncompressedSize
+	}
+
+	return size, nil
+}
+
 // ImageDiskUsage reports the total size of an image.  That is the size
 type ImageDiskUsage struct {
 	// Number of containers using the image.


### PR DESCRIPTION
Add an API to query the sum of the layer sizes.  This data is needed to fix containers/podman/issues/16135.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
