### PR TITLE
config: Add config entry for ocijail

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -843,7 +843,7 @@ func (m *MachineConfig) URI() string {
 
 func (c *EngineConfig) findRuntime() string {
 	// Search for crun first followed by runc, kata, runsc
-	for _, name := range []string{"crun", "runc", "runj", "kata", "runsc"} {
+	for _, name := range []string{"crun", "runc", "runj", "kata", "runsc", "ocijail"} {
 		for _, v := range c.OCIRuntimes[name] {
 			if _, err := os.Stat(v); err == nil {
 				return name

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -195,6 +195,9 @@ image_copy_tmp_dir="storage"`
 					"/usr/bin/krun",
 					"/usr/local/bin/krun",
 				},
+				"ocijail": {
+					"/usr/local/bin/ocijail",
+				},
 			}
 
 			pluginDirs := []string{

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -368,6 +368,9 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 			"/usr/bin/krun",
 			"/usr/local/bin/krun",
 		},
+		"ocijail": {
+			"/usr/local/bin/ocijail",
+		},
 	}
 	// Needs to be called after populating c.OCIRuntimes.
 	c.OCIRuntime = c.findRuntime()


### PR DESCRIPTION
Another experimental OCI runtime for FreeBSD, similar to runj but with a focus on podman/buildah compatiblity.

Signed-off-by: Doug Rabson <dfr@rabson.org>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
