### PR TITLE
libnetwork/netavark: disable dns for macvlan

### DIFF
--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -170,6 +170,11 @@ func createMacvlan(network *types.Network) error {
 		}
 	}
 
+	// always turn dns off with macvlan, it is not implemented in netavark
+	// and makes little sense to support with macvlan
+	// see https://github.com/containers/netavark/pull/467
+	network.DNSEnabled = false
+
 	// we already validated the drivers before so we just have to set the default here
 	switch network.IPAMOptions[types.Driver] {
 	case "":

--- a/libnetwork/types/network.go
+++ b/libnetwork/types/network.go
@@ -54,7 +54,7 @@ type Network struct {
 	// to public or other Networks.
 	Internal bool `json:"internal"`
 	// DNSEnabled is whether name resolution is active for container on
-	// this Network.
+	// this Network. Only supported with the bridge driver.
 	DNSEnabled bool `json:"dns_enabled"`
 	// Labels is a set of key-value labels that have been applied to the
 	// Network.


### PR DESCRIPTION
This is not supported in netavark so we should set to false by default to make sure podman inspect will show the correct info.


<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
