### PR TITLE
Add support for route metric in network configs

### DIFF
--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -116,6 +116,11 @@ func (n *netavarkNetwork) networkCreate(newNetwork *types.Network, defaultNet bo
 				}
 				// rust only support "true" or "false" while go can parse 1 and 0 as well so we need to change it
 				newNetwork.Options[types.IsolateOption] = strconv.FormatBool(val)
+			case types.MetricOption:
+				_, err := strconv.ParseUint(value, 10, 32)
+				if err != nil {
+					return nil, err
+				}
 			default:
 				return nil, fmt.Errorf("unsupported bridge network option %s", key)
 			}

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -1072,7 +1072,7 @@ var _ = Describe("Config", func() {
 		It("load networks from disk", func() {
 			nets, err := libpodNet.NetworkList()
 			Expect(err).To(BeNil())
-			Expect(nets).To(HaveLen(7))
+			Expect(nets).To(HaveLen(8))
 			// test the we do not show logrus warnings/errors
 			logString := logBuffer.String()
 			Expect(logString).To(BeEmpty())
@@ -1081,12 +1081,12 @@ var _ = Describe("Config", func() {
 		It("change network struct fields should not affect network struct in the backend", func() {
 			nets, err := libpodNet.NetworkList()
 			Expect(err).To(BeNil())
-			Expect(nets).To(HaveLen(7))
+			Expect(nets).To(HaveLen(8))
 
 			nets[0].Name = "myname"
 			nets, err = libpodNet.NetworkList()
 			Expect(err).To(BeNil())
-			Expect(nets).To(HaveLen(7))
+			Expect(nets).To(HaveLen(8))
 			Expect(nets).ToNot(ContainElement(HaveNetworkName("myname")))
 
 			network, err := libpodNet.NetworkInspect("bridge")
@@ -1164,6 +1164,18 @@ var _ = Describe("Config", func() {
 			Expect(network.Subnets).To(HaveLen(1))
 			Expect(network.Labels).To(HaveLen(1))
 			Expect(network.Labels).To(HaveKeyWithValue("mykey", "value"))
+		})
+
+		It("bridge network with route metric", func() {
+			network, err := libpodNet.NetworkInspect("metric")
+			Expect(err).To(BeNil())
+			Expect(network.Name).To(Equal("metric"))
+			Expect(network.ID).To(HaveLen(64))
+			Expect(network.NetworkInterface).To(Equal("podman100"))
+			Expect(network.Driver).To(Equal("bridge"))
+			Expect(network.Subnets).To(HaveLen(1))
+			Expect(network.Options).To(HaveLen(1))
+			Expect(network.Options).To(HaveKeyWithValue("metric", "255"))
 		})
 
 		It("dual stack network", func() {
@@ -1257,10 +1269,10 @@ var _ = Describe("Config", func() {
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
 			Expect(err).To(BeNil())
-			Expect(networks).To(HaveLen(7))
+			Expect(networks).To(HaveLen(8))
 			Expect(networks).To(ConsistOf(HaveNetworkName("internal"), HaveNetworkName("bridge"),
 				HaveNetworkName("mtu"), HaveNetworkName("vlan"), HaveNetworkName("podman"),
-				HaveNetworkName("label"), HaveNetworkName("dualstack")))
+				HaveNetworkName("label"), HaveNetworkName("dualstack"), HaveNetworkName("metric")))
 		})
 
 		It("network list with filters (label)", func() {

--- a/libnetwork/netavark/testfiles/valid/metric.json
+++ b/libnetwork/netavark/testfiles/valid/metric.json
@@ -1,0 +1,22 @@
+{
+    "name": "metric",
+    "id": "83f6a2b55958cacd9b319c302114a3b633586cab241866c87397e9ea6e7004ac",
+    "driver": "bridge",
+    "network_interface": "podman100",
+    "created": "2021-10-06T18:50:54.25770461+02:00",
+    "subnets": [
+        {
+            "subnet": "10.89.99.0/24",
+            "gateway": "10.89.99.1"
+        }
+    ],
+    "ipv6_enabled": false,
+    "internal": false,
+    "dns_enabled": true,
+    "options": {
+	"metric": "255"
+    },
+    "ipam_options": {
+        "driver": "host-local"
+    }
+}

--- a/libnetwork/types/const.go
+++ b/libnetwork/types/const.go
@@ -40,6 +40,7 @@ const (
 	MTUOption     = "mtu"
 	ModeOption    = "mode"
 	IsolateOption = "isolate"
+	MetricOption  = "metric"
 )
 
 type NetworkBackend string


### PR DESCRIPTION
All the gruntwork is done by Netavark, so all that's needed it to know the key exists and verify that it parses as a uint.
