### PR TITLE
libimage: format platform warning

### DIFF
--- a/libimage/platform.go
+++ b/libimage/platform.go
@@ -96,5 +96,5 @@ func (i *Image) matchesPlatform(ctx context.Context, os, arch, variant string) (
 		return nil, customPlatform, nil
 	}
 
-	return fmt.Errorf("image platform (%s) does not match the expected platform (%s)", fromImage, expected), customPlatform, nil
+	return fmt.Errorf("image platform (%s) does not match the expected platform (%s)", platforms.Format(fromImage), platforms.Format(expected)), customPlatform, nil
 }


### PR DESCRIPTION
Before:
`WARNING: image platform ({amd64 linux  [] }) does not match the expected platform ({arm64 linux  [] })`

After:
`WARNING: image platform (linux/amd64) does not match the expected platform (linux/arm64)`

Fixes: containers/podman/issues/16392
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
