### PR TITLE
config: add support for `platform_to_oci_runtime` and default entries for `wasi/wasm`

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -684,6 +684,10 @@ used as the backend for Podman named volumes. Individual plugins are specified
 below, as a map of the plugin name (what the plugin will be called) to its path
 (filepath of the plugin's unix socket).
 
+**[engine.platform_to_oci_runtime]**
+
+Allows end users to switch the OCI runtime on the bases of container image's platform string.
+Following config field contains a map of `platform/string = oci_runtime`.
 
 ## SECRET TABLE
 The `secret` table contains settings for the configuration of the secret subsystem.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -358,6 +358,9 @@ type EngineConfig struct {
 	// OCIRuntimes are the set of configured OCI runtimes (default is runc).
 	OCIRuntimes map[string][]string `toml:"runtimes,omitempty"`
 
+	// PlatformToOCIRuntime requests specific OCI runtime for a specified platform of image.
+	PlatformToOCIRuntime map[string]string `toml:"platform_to_oci_runtime,omitempty"`
+
 	// PodExitPolicy determines the behaviour when the last container of a pod exits.
 	PodExitPolicy PodExitPolicy `toml:"pod_exit_policy,omitempty"`
 
@@ -617,6 +620,16 @@ type Destination struct {
 
 	// isMachine describes if the remote destination is a machine.
 	IsMachine bool `toml:"is_machine,omitempty"`
+}
+
+// Consumes container image's os and arch and returns if any dedicated runtime was
+// configured otherwise returns default runtime.
+func (c *EngineConfig) ImagePlatformToRuntime(os string, arch string) string {
+	platformString := os + "/" + arch
+	if val, ok := c.PlatformToOCIRuntime[platformString]; ok {
+		return val
+	}
+	return c.OCIRuntime
 }
 
 // NewConfig creates a new Config. It starts with an empty config and, if

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -155,6 +155,13 @@ image_copy_tmp_dir="storage"`
 
 			err := readConfigFromFile("testdata/containers_default.conf", defaultConfig)
 
+			crunWasm := "crun-wasm"
+			PlatformToOCIRuntimeMap := map[string]string{
+				"wasi/wasm":   crunWasm,
+				"wasi/wasm32": crunWasm,
+				"wasi/wasm64": crunWasm,
+			}
+
 			OCIRuntimeMap := map[string][]string{
 				"kata": {
 					"/usr/bin/kata-runtime",
@@ -181,6 +188,15 @@ image_copy_tmp_dir="storage"`
 				"crun": {
 					"/usr/bin/crun",
 					"/usr/local/bin/crun",
+				},
+				"crun-wasm": {
+					"/usr/bin/crun-wasm",
+					"/usr/sbin/crun-wasm",
+					"/usr/local/bin/crun-wasm",
+					"/usr/local/sbin/crun-wasm",
+					"/sbin/crun-wasm",
+					"/bin/crun-wasm",
+					"/run/current-system/sw/bin/crun-wasm",
 				},
 				"runsc": {
 					"/usr/bin/runsc",
@@ -236,6 +252,7 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(defaultConfig.Network.CNIPluginDirs).To(gomega.Equal(pluginDirs))
 			gomega.Expect(defaultConfig.Engine.NumLocks).To(gomega.BeEquivalentTo(2048))
 			gomega.Expect(defaultConfig.Engine.OCIRuntimes).To(gomega.Equal(OCIRuntimeMap))
+			gomega.Expect(defaultConfig.Engine.PlatformToOCIRuntime).To(gomega.Equal(PlatformToOCIRuntimeMap))
 			gomega.Expect(defaultConfig.Containers.HTTPProxy).To(gomega.Equal(false))
 			gomega.Expect(defaultConfig.Engine.NetworkCmdOptions).To(gomega.BeNil())
 			gomega.Expect(defaultConfig.Engine.HelperBinariesDir).To(gomega.Equal(helperDirs))
@@ -405,6 +422,19 @@ image_copy_tmp_dir="storage"`
 			} else {
 				os.Unsetenv("CONTAINERS_CONF")
 			}
+
+			crunWasm := "crun-wasm"
+			PlatformToOCIRuntimeMap := map[string]string{
+				"hello":       "world",
+				"wasi/wasm":   crunWasm,
+				"wasi/wasm32": crunWasm,
+				"wasi/wasm64": crunWasm,
+			}
+
+			// Also test `ImagePlatformToRuntimes
+			runtimes := config.Engine.ImagePlatformToRuntime("wasi", "wasm")
+			gomega.Expect(runtimes).To(gomega.Equal(crunWasm))
+
 			// Then
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(config).ToNot(gomega.BeNil())
@@ -413,6 +443,7 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(config.Containers.LogTag).To(gomega.Equal("{{.Name}}|{{.ID}}"))
 			gomega.Expect(config.Containers.LogSizeMax).To(gomega.Equal(int64(100000)))
 			gomega.Expect(config.Engine.ImageParallelCopies).To(gomega.Equal(uint(10)))
+			gomega.Expect(config.Engine.PlatformToOCIRuntime).To(gomega.Equal(PlatformToOCIRuntimeMap))
 			gomega.Expect(config.Engine.ImageDefaultFormat).To(gomega.Equal("v2s2"))
 			gomega.Expect(config.Engine.EventsLogFilePath).To(gomega.BeEquivalentTo("/tmp/events.log"))
 			path, err := config.ImageCopyTmpDir()

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -263,6 +263,11 @@ default_sysctls = [
 # If it is empty or commented out, no volumes will be added
 #
 #volumes = []
+#
+#[engine.platform_to_oci_runtime]
+#"wasi/wasm" = ["crun-wasm"]
+#"wasi/wasm32" = ["crun-wasm"]
+#"wasi/wasm64" = ["crun-wasm"]
 
 [secrets]
 #driver = "file"

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -332,6 +332,15 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 			"/bin/crun",
 			"/run/current-system/sw/bin/crun",
 		},
+		"crun-wasm": {
+			"/usr/bin/crun-wasm",
+			"/usr/sbin/crun-wasm",
+			"/usr/local/bin/crun-wasm",
+			"/usr/local/sbin/crun-wasm",
+			"/sbin/crun-wasm",
+			"/bin/crun-wasm",
+			"/run/current-system/sw/bin/crun-wasm",
+		},
 		"runc": {
 			"/usr/bin/runc",
 			"/usr/sbin/runc",
@@ -377,6 +386,11 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 		"ocijail": {
 			"/usr/local/bin/ocijail",
 		},
+	}
+	c.PlatformToOCIRuntime = map[string]string{
+		"wasi/wasm":   "crun-wasm",
+		"wasi/wasm32": "crun-wasm",
+		"wasi/wasm64": "crun-wasm",
 	}
 	// Needs to be called after populating c.OCIRuntimes.
 	c.OCIRuntime = c.findRuntime()

--- a/pkg/config/testdata/containers_override.conf
+++ b/pkg/config/testdata/containers_override.conf
@@ -13,6 +13,9 @@ events_logfile_path = "/tmp/events.log"
 events_logfile_max_size="500"
 pod_exit_policy="stop"
 
+[engine.platform_to_oci_runtime]
+hello = "world"
+
 [machine]
 # The image used when creating a podman-machine VM.
 image = "https://example.com/$OS/$ARCH/foobar.ami"


### PR DESCRIPTION
Containers.conf now supports `platform_to_oci_runtime` which allows end users to map variant of OCI runtime for a particular platform.

Most ideal use-case of this feature is switching to crun's variant when platform string is `wasm32/wasi`.

Example
```toml
[engine.platform_to_oci_runtime]
"wasi/wasm" = "crun-wasm"
"wasi/wasm32" = "crun-wasm"
"wasi/wasm64" = "crun-wasm"
```
