### PR TITLE
pkg/report: fix IsJSON()

### DIFF
--- a/pkg/report/validate.go
+++ b/pkg/report/validate.go
@@ -1,8 +1,6 @@
 package report
 
-import "regexp"
-
-var jsonRegex = regexp.MustCompile(`^\s*(json|{{\s*json\s*(\.)?\s*}})\s*$`)
+import "strings"
 
 // JSONFormat test CLI --format string to be a JSON request
 //
@@ -10,5 +8,5 @@ var jsonRegex = regexp.MustCompile(`^\s*(json|{{\s*json\s*(\.)?\s*}})\s*$`)
 //	  ... process JSON and output
 //	}
 func IsJSON(s string) bool {
-	return jsonRegex.MatchString(s)
+	return strings.TrimSpace(s) == "json"
 }

--- a/pkg/report/validate_test.go
+++ b/pkg/report/validate_test.go
@@ -17,17 +17,16 @@ func TestIsJSON(t *testing.T) {
 		{" json", true},
 		{" json ", true},
 		{"  json   ", true},
-		{"{{json}}", true},
-		{"{{json }}", true},
-		{"{{json .}}", true},
-		{"{{ json .}}", true},
-		{"{{ json . }}", true},
-		{"  {{   json   .  }}  ", true},
+		{"{{json}}", false},
+		{"{{json }}", false},
+		{"{{json .}}", false},
+		{"{{ json .}}", false},
+		{"{{ json . }}", false},
+		{"  {{   json   .  }}  ", false},
 		{"{{ json .", false},
 		{"json . }}", false},
 		{"{{.ID }} json .", false},
 		{"json .", false},
-		{"{{json.}}", true},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
When a user request --format `{{json .}}` they would want the go template parser to handle it. Currently we overwrite this and assume that `{{json .}}` equals `json`. This is not correct. When the output is a range (array), i.e. podman ps, it should return one json object per line and not a json array which is the case with `json`.

This is required for docker compat.

Fixes containers/podman#16436

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
