### PR TITLE
pkg/report: fix IsJSON() #2

### DIFF
--- a/pkg/report/validate.go
+++ b/pkg/report/validate.go
@@ -1,6 +1,12 @@
 package report
 
-import "strings"
+import (
+	"regexp"
+)
+
+// Check for json, {{json }} and {{ json. }} which are not valid go template,
+// {{json .}} is valid and thus not matched to let the template handle it like docker does.
+var jsonRegex = regexp.MustCompile(`^\s*(json|{{\s*json\.?\s*}})\s*$`)
 
 // JSONFormat test CLI --format string to be a JSON request
 //
@@ -8,5 +14,5 @@ import "strings"
 //	  ... process JSON and output
 //	}
 func IsJSON(s string) bool {
-	return strings.TrimSpace(s) == "json"
+	return jsonRegex.MatchString(s)
 }

--- a/pkg/report/validate_test.go
+++ b/pkg/report/validate_test.go
@@ -17,9 +17,12 @@ func TestIsJSON(t *testing.T) {
 		{" json", true},
 		{" json ", true},
 		{"  json   ", true},
-		{"{{json}}", false},
-		{"{{json }}", false},
-		{"{{json .}}", false},
+		// special case, previous regex allowed this template string but it is not actually a valid template
+		{"{{json}}", true},
+		{"{{json }}", true},
+		{"{{json.}}", true},
+		{"{{ json. }}", true},
+
 		{"{{ json .}}", false},
 		{"{{ json . }}", false},
 		{"  {{   json   .  }}  ", false},


### PR DESCRIPTION
The PR #1226 was merged to soon, it breaks podman tests and backwards compat. `{{json}}` is not a valid template but it worked before the same as `json` so we should keep that.

Fixes up commit 152c8409709b


<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
