### PR TITLE
pkg/config: Fix DefaultSignaturePath on FreeBSD

### DIFF
--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -10,6 +10,10 @@ const (
 
 	// DefaultContainersConfig holds the default containers config path
 	DefaultContainersConfig = "/usr/share/" + _configPath
+
+	// DefaultSignaturePolicyPath is the default value for the
+	// policy.json file.
+	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
 )
 
 // podman remote clients on darwin cannot use unshare.isRootless() to determine the configuration file locations.

--- a/pkg/config/config_freebsd.go
+++ b/pkg/config/config_freebsd.go
@@ -10,6 +10,10 @@ const (
 
 	// DefaultContainersConfig holds the default containers config path
 	DefaultContainersConfig = "/usr/local/share/" + _configPath
+
+	// DefaultSignaturePolicyPath is the default value for the
+	// policy.json file.
+	DefaultSignaturePolicyPath = "/usr/local/etc/containers/policy.json"
 )
 
 // podman remote clients on freebsd cannot use unshare.isRootless() to determine the configuration file locations.

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -13,6 +13,10 @@ const (
 
 	// DefaultContainersConfig holds the default containers config path
 	DefaultContainersConfig = "/usr/share/" + _configPath
+
+	// DefaultSignaturePolicyPath is the default value for the
+	// policy.json file.
+	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
 )
 
 func selinuxEnabled() bool {

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -8,6 +8,10 @@ const (
 
 	// DefaultContainersConfig holds the default containers config path
 	DefaultContainersConfig = "/usr/share/" + _configPath
+
+	// DefaultSignaturePolicyPath is the default value for the
+	// policy.json file.
+	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
 )
 
 // podman remote clients on windows cannot use unshare.isRootless() to determine the configuration file locations.

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -149,9 +149,6 @@ const (
 	DefaultPidsLimit = 2048
 	// DefaultPullPolicy pulls the image if it does not exist locally.
 	DefaultPullPolicy = "missing"
-	// DefaultSignaturePolicyPath is the default value for the
-	// policy.json file.
-	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
 	// DefaultSubnet is the subnet that will be used for the default
 	// network.
 	DefaultSubnet = "10.88.0.0/16"


### PR DESCRIPTION
The correct location on FreeBSD is /usr/local/etc/containers/policy.json which is consistent with path conventions for installed packages. This fixes 'podman commit' on FreeBSD.

There are several definitions of this path:

- c/image/signature has builtinDefaultPolicyPath and DefaultPolicy
- c/podman/pkg/trust has systemDefaultPolicyPath and DefaultPolicyPath
- c/common/pkg/config has DefaultSignaturePolicyPath

As far as I can tell, buildah uses c/image/signature which is why 'buildah commit' was already working for me. Podman is using the c/common one. Very confusing.

[NO NEW TESTS NEEDED]

Signed-off-by: Doug Rabson <dfr@rabson.org>
