### PR TITLE
libnetwork, Network: add field `NetworkDNSServers` for network scoped dns

### DIFF
--- a/libnetwork/cni/config.go
+++ b/libnetwork/cni/config.go
@@ -36,6 +36,9 @@ func (n *cniNetwork) NetworkCreate(net types.Network) (types.Network, error) {
 // networkCreate will fill out the given network struct and return the new network entry.
 // If defaultNet is true it will not validate against used subnets and it will not write the cni config to disk.
 func (n *cniNetwork) networkCreate(newNetwork *types.Network, defaultNet bool) (*network, error) {
+	if len(newNetwork.NetworkDNSServers) > 0 {
+		return nil, fmt.Errorf("NetworkDNSServers cannot be configured for backend CNI: %w", types.ErrInvalidArg)
+	}
 	// if no driver is set use the default one
 	if newNetwork.Driver == "" {
 		newNetwork.Driver = types.DefaultNetworkDriver

--- a/libnetwork/cni/config_test.go
+++ b/libnetwork/cni/config_test.go
@@ -143,6 +143,16 @@ var _ = Describe("Config", func() {
 			Expect(network2.Subnets[0].Subnet.Contains(network1.Subnets[0].Subnet.IP)).To(BeFalse())
 		})
 
+		It("create network with NetworDNSServers with DNSEnabled=false", func() {
+			network := types.Network{
+				NetworkDNSServers: []string{"8.8.8.8", "3.3.3.3"},
+				DNSEnabled:        false,
+			}
+			_, err := libpodNet.NetworkCreate(network)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`NetworkDNSServers cannot be configured for backend CNI`))
+		})
+
 		It("create bridge config", func() {
 			network := types.Network{Driver: "bridge"}
 			network1, err := libpodNet.NetworkCreate(network)

--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -137,6 +137,17 @@ func (n *netavarkNetwork) networkCreate(newNetwork *types.Network, defaultNet bo
 	// when we do not have ipam we must disable dns
 	internalutil.IpamNoneDisableDNS(newNetwork)
 
+	// process NetworkDNSServers
+	if len(newNetwork.NetworkDNSServers) > 0 && !newNetwork.DNSEnabled {
+		return nil, fmt.Errorf("Cannot set NetworkDNSServers if DNS is not enabled for the network: %w", types.ErrInvalidArg)
+	}
+	// validate ip address
+	for _, dnsServer := range newNetwork.NetworkDNSServers {
+		if net.ParseIP(dnsServer) == nil {
+			return nil, fmt.Errorf("Unable to parse ip %s specified in NetworkDNSServers: %w", dnsServer, types.ErrInvalidArg)
+		}
+	}
+
 	// add gateway when not internal or dns enabled
 	addGateway := !newNetwork.Internal || newNetwork.DNSEnabled
 	err = internalutil.ValidateSubnets(newNetwork, addGateway, usedNetworks)

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -618,6 +618,36 @@ var _ = Describe("Config", func() {
 			Expect(network1.Internal).To(BeTrue())
 		})
 
+		It("create network with NetworDNSServers", func() {
+			network := types.Network{
+				NetworkDNSServers: []string{"8.8.8.8", "3.3.3.3"},
+				DNSEnabled:        true,
+			}
+			network1, err := libpodNet.NetworkCreate(network)
+			Expect(err).To(BeNil())
+			Expect(network1.NetworkDNSServers).To(Equal([]string{"8.8.8.8", "3.3.3.3"}))
+		})
+
+		It("create network with NetworDNSServers with invalid IP", func() {
+			network := types.Network{
+				NetworkDNSServers: []string{"a.b.c.d", "3.3.3.3"},
+				DNSEnabled:        true,
+			}
+			_, err := libpodNet.NetworkCreate(network)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`Unable to parse ip a.b.c.d`))
+		})
+
+		It("create network with NetworDNSServers with DNSEnabled=false", func() {
+			network := types.Network{
+				NetworkDNSServers: []string{"8.8.8.8", "3.3.3.3"},
+				DNSEnabled:        false,
+			}
+			_, err := libpodNet.NetworkCreate(network)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`Cannot set NetworkDNSServers if DNS is not enabled for the network`))
+		})
+
 		It("create network with labels", func() {
 			network := types.Network{
 				Labels: map[string]string{

--- a/libnetwork/types/network.go
+++ b/libnetwork/types/network.go
@@ -56,6 +56,10 @@ type Network struct {
 	// DNSEnabled is whether name resolution is active for container on
 	// this Network. Only supported with the bridge driver.
 	DNSEnabled bool `json:"dns_enabled"`
+	// List of custom DNS server for podman's DNS resolver at network level,
+	// all the containers attached to this network will consider resolvers
+	// configured at network level.
+	NetworkDNSServers []string `json:"network_dns_servers,omitempty"`
 	// Labels is a set of key-value labels that have been applied to the
 	// Network.
 	Labels map[string]string `json:"labels,omitempty"`


### PR DESCRIPTION
libnetwork must allow to pass network_dns_servers so aardvark and netavark can consume it and enabled network scoped dns.

Feature implemented at netavark and aardvark end
* Netavark: https://github.com/containers/netavark/pull/497
