### PR TITLE
Deprecate UserNSSize, since we don't use it

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -275,11 +275,6 @@ Options are:
   `private` Create private USER Namespace for the container.
   `host`    Share host USER Namespace with the container.
 
-**userns_size**=65536
-
-Number of UIDs to allocate for the automatic container creation. UIDs are
-allocated from the “container” UIDs listed in /etc/subuid & /etc/subgid.
-
 **utsns**="private"
 
 Default way to to create a UTS namespace for the container.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -214,6 +214,7 @@ type ContainersConfig struct {
 	UserNS string `toml:"userns,omitempty"`
 
 	// UserNSSize how many UIDs to allocate for automatically created UserNS
+	// Deprecated: no user of this field is known.
 	UserNSSize int `toml:"userns_size,omitempty,omitzero"`
 }
 

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -244,12 +244,6 @@ default_sysctls = [
 #
 #userns = "host"
 
-# Number of UIDs to allocate for the automatic container creation.
-# UIDs are allocated from the "container" UIDs listed in
-# /etc/subuid & /etc/subgid
-#
-#userns_size = 65536
-
 # Default way to to create a UTS namespace for the container
 # Options are:
 # `private`        Create private UTS Namespace for the container.

--- a/pkg/config/containers.conf-freebsd
+++ b/pkg/config/containers.conf-freebsd
@@ -212,12 +212,6 @@ default_sysctls = [
 #
 #userns = "host"
 
-# Number of UIDs to allocate for the automatic container creation.
-# UIDs are allocated from the "container" UIDs listed in
-# /etc/subuid & /etc/subgid
-#
-#userns_size = 65536
-
 # Default way to to create a UTS namespace for the container
 # Options are:
 # `private`        Create private UTS Namespace for the container.

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -158,6 +158,7 @@ const (
 	// DefaultShmSize is the default upper limit on the size of tmpfs mounts.
 	DefaultShmSize = "65536k"
 	// DefaultUserNSSize indicates the default number of UIDs allocated for user namespace within a container.
+	// Deprecated: no user of this field is known.
 	DefaultUserNSSize = 65536
 	// OCIBufSize limits maximum LogSizeMax.
 	OCIBufSize = 8192
@@ -232,7 +233,7 @@ func DefaultConfig() (*Config, error) {
 			TZ:         "",
 			Umask:      "0022",
 			UTSNS:      "private",
-			UserNSSize: DefaultUserNSSize,
+			UserNSSize: DefaultUserNSSize, // Deprecated
 		},
 		Network: NetworkConfig{
 			DefaultNetwork:     "podman",


### PR DESCRIPTION
Podman and Buildah do not use this field, and I
know of no users of it, remove it from docs and
the default conf file, so users will not expect
it to do anything.

Leaving implementation in the slight chance someone has used it in a non containers project.

Fixes: https://github.com/containers/podman/issues/16562

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
