### PR TITLE
Rework default list of capabilities to minimal

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -88,21 +88,23 @@ List of default capabilities for containers.
 The default list is:
 ```
 default_capabilities = [
-"AUDIT_WRITE",
       "CHOWN",
       "DAC_OVERRIDE",
       "FOWNER",
       "FSETID",
       "KILL",
-      "MKNOD",
       "NET_BIND_SERVICE",
-      "NET_RAW",
+      "SETFCAP",
       "SETGID",
       "SETPCAP",
       "SETUID",
-      "SYS_CHROOT",
 ]
 ```
+
+Note, by default container engines using containers.conf, run with less
+capabilities than Docker. Docker runs additionally with "AUDIT_WRITE", "MKNOD",
+"NET_RAW", "CHROOT". If you need to add one of these capabilities for a
+particular container, you can use the --cap-add option or edit your system's containers.conf.
 
 **default_sysctls**=[]
 

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -52,19 +52,18 @@
 # List of default capabilities for containers. If it is empty or commented out,
 # the default capabilities defined in the container engine will be added.
 #
-default_capabilities = [
-  "CHOWN",
-  "DAC_OVERRIDE",
-  "FOWNER",
-  "FSETID",
-  "KILL",
-  "NET_BIND_SERVICE",
-  "SETFCAP",
-  "SETGID",
-  "SETPCAP",
-  "SETUID",
-  "SYS_CHROOT"
-]
+#default_capabilities = [
+#  "CHOWN",
+#  "DAC_OVERRIDE",
+#  "FOWNER",
+#  "FSETID",
+#  "KILL",
+#  "NET_BIND_SERVICE",
+#  "SETFCAP",
+#  "SETGID",
+#  "SETPCAP",
+#  "SETUID",
+#]
 
 # A list of sysctls to be set in containers by default,
 # specified as "name=value",

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -76,20 +76,16 @@ var (
 	DefaultHooksDirs = []string{"/usr/share/containers/oci/hooks.d"}
 	// DefaultCapabilities is the default for the default_capabilities option in the containers.conf file.
 	DefaultCapabilities = []string{
-		"CAP_AUDIT_WRITE",
 		"CAP_CHOWN",
 		"CAP_DAC_OVERRIDE",
 		"CAP_FOWNER",
 		"CAP_FSETID",
 		"CAP_KILL",
-		"CAP_MKNOD",
 		"CAP_NET_BIND_SERVICE",
-		"CAP_NET_RAW",
 		"CAP_SETFCAP",
 		"CAP_SETGID",
 		"CAP_SETPCAP",
 		"CAP_SETUID",
-		"CAP_SYS_CHROOT",
 	}
 
 	// Search these locations in which CNIPlugins can be installed.


### PR DESCRIPTION
For a couple of years now we have been shipping containers.conf settings to use only 10 capabities. Docker uses 14, with the difference being CAP_AUDIT_ALLOW, CAP_NET_RAW, CAP_MKNOD, CAP_CHROOT.

This allows us to run with a tighter security then Docker.

This PR makes the change to default config, so that if no containers.conf overrides are present, we will run with the tighter security. Currently most distros that ship the containers.conf already run with this setting, but this makes it formal, and changes the man page to match the defaults.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
