### PR TITLE
Revert "Rework default list of capabilities to minimal"

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -88,23 +88,21 @@ List of default capabilities for containers.
 The default list is:
 ```
 default_capabilities = [
+"AUDIT_WRITE",
       "CHOWN",
       "DAC_OVERRIDE",
       "FOWNER",
       "FSETID",
       "KILL",
+      "MKNOD",
       "NET_BIND_SERVICE",
-      "SETFCAP",
+      "NET_RAW",
       "SETGID",
       "SETPCAP",
       "SETUID",
+      "SYS_CHROOT",
 ]
 ```
-
-Note, by default container engines using containers.conf, run with less
-capabilities than Docker. Docker runs additionally with "AUDIT_WRITE", "MKNOD",
-"NET_RAW", "CHROOT". If you need to add one of these capabilities for a
-particular container, you can use the --cap-add option or edit your system's containers.conf.
 
 **default_sysctls**=[]
 

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -52,18 +52,19 @@
 # List of default capabilities for containers. If it is empty or commented out,
 # the default capabilities defined in the container engine will be added.
 #
-#default_capabilities = [
-#  "CHOWN",
-#  "DAC_OVERRIDE",
-#  "FOWNER",
-#  "FSETID",
-#  "KILL",
-#  "NET_BIND_SERVICE",
-#  "SETFCAP",
-#  "SETGID",
-#  "SETPCAP",
-#  "SETUID",
-#]
+default_capabilities = [
+  "CHOWN",
+  "DAC_OVERRIDE",
+  "FOWNER",
+  "FSETID",
+  "KILL",
+  "NET_BIND_SERVICE",
+  "SETFCAP",
+  "SETGID",
+  "SETPCAP",
+  "SETUID",
+  "SYS_CHROOT"
+]
 
 # A list of sysctls to be set in containers by default,
 # specified as "name=value",

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -76,16 +76,20 @@ var (
 	DefaultHooksDirs = []string{"/usr/share/containers/oci/hooks.d"}
 	// DefaultCapabilities is the default for the default_capabilities option in the containers.conf file.
 	DefaultCapabilities = []string{
+		"CAP_AUDIT_WRITE",
 		"CAP_CHOWN",
 		"CAP_DAC_OVERRIDE",
 		"CAP_FOWNER",
 		"CAP_FSETID",
 		"CAP_KILL",
+		"CAP_MKNOD",
 		"CAP_NET_BIND_SERVICE",
+		"CAP_NET_RAW",
 		"CAP_SETFCAP",
 		"CAP_SETGID",
 		"CAP_SETPCAP",
 		"CAP_SETUID",
+		"CAP_SYS_CHROOT",
 	}
 
 	// Search these locations in which CNIPlugins can be installed.


### PR DESCRIPTION
This reverts commit f39f2a3f8c7680b9e456b9d235570e511807d6c6. As shown in containers/podman/pull/16610 the changes require a number of changes in Podman's CI.  While many issues have been fixed in that PR, there are some potentially controversial changes such as dropping NET_RAW.

Let's revert the commit to unblock ongoing work.  For the next iteration, Podman CI must be green before merging.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
