### PR TITLE
libnetwork: extend API to support `NetworkUpdate`

### DIFF
--- a/libnetwork/cni/config.go
+++ b/libnetwork/cni/config.go
@@ -15,6 +15,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func (n *cniNetwork) NetworkUpdate(name string, options types.NetworkUpdateOptions) error {
+	return fmt.Errorf("NetworkUpdate is not supported for backend CNI: %w", types.ErrInvalidArg)
+}
+
 // NetworkCreate will take a partial filled Network and fill the
 // missing fields. It creates the Network and returns the full Network.
 func (n *cniNetwork) NetworkCreate(net types.Network, options *types.NetworkCreateOptions) (types.Network, error) {

--- a/libnetwork/cni/config_test.go
+++ b/libnetwork/cni/config_test.go
@@ -499,7 +499,7 @@ var _ = Describe("Config", func() {
 						"driver": "none",
 					},
 				}
-				network1, err := libpodNet.NetworkCreate(network)
+				network1, err := libpodNet.NetworkCreate(network, nil)
 				Expect(err).To(BeNil())
 				Expect(network1.Driver).To(Equal(driver))
 				Expect(network1.IPAMOptions).To(HaveKeyWithValue("driver", "none"))

--- a/libnetwork/netavark/run.go
+++ b/libnetwork/netavark/run.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/containers/common/libnetwork/internal/util"
 	"github.com/containers/common/libnetwork/types"
@@ -16,6 +17,11 @@ import (
 type netavarkOptions struct {
 	types.NetworkOptions
 	Networks map[string]*types.Network `json:"network_info"`
+}
+
+func (n *netavarkNetwork) execUpdate(networkName string, networkDNSServers []string) error {
+	retErr := n.execNetavark([]string{"update", networkName, "--network-dns-servers", strings.Join(networkDNSServers, ",")}, nil, nil)
+	return retErr
 }
 
 // Setup will setup the container network namespace. It returns

--- a/libnetwork/types/network.go
+++ b/libnetwork/types/network.go
@@ -10,6 +10,8 @@ type ContainerNetwork interface {
 	// NetworkCreate will take a partial filled Network and fill the
 	// missing fields. It creates the Network and returns the full Network.
 	NetworkCreate(Network, *NetworkCreateOptions) (Network, error)
+	// NetworkUpdate will take network name and ID and updates network DNS Servers.
+	NetworkUpdate(nameOrID string, options NetworkUpdateOptions) error
 	// NetworkRemove will remove the Network with the given name or ID.
 	NetworkRemove(nameOrID string) error
 	// NetworkList will return all known Networks. Optionally you can
@@ -68,6 +70,14 @@ type Network struct {
 	Options map[string]string `json:"options,omitempty"`
 	// IPAMOptions contains options used for the ip assignment.
 	IPAMOptions map[string]string `json:"ipam_options,omitempty"`
+}
+
+// NetworkOptions for a given container.
+type NetworkUpdateOptions struct {
+	// List of custom DNS server for podman's DNS resolver.
+	// Priority order will be kept as defined by user in the configuration.
+	AddDNSServers    []string `json:"add_dns_servers,omitempty"`
+	RemoveDNSServers []string `json:"remove_dns_servers,omitempty"`
 }
 
 // IPNet is used as custom net.IPNet type to add Marshal/Unmarshal methods.


### PR DESCRIPTION
New features in netavark/aardvark allows users to update network dns servers and all the containers attached to those networks uses updated resolvers.

Following PR adds support in `libnetwork` to support

* Add support for higher level `NetworkUpdate` API
* Add support for `Update` exec call which can invoke netavark with a new update option added here: https://github.com/containers/netavark/pull/503
