### PR TITLE
cgroups: use SessionBusPrivateNoAutoStartup

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -431,7 +431,7 @@ func (c *CgroupControl) CreateSystemdUnit(path string) error {
 // GetUserConnection returns an user connection to D-BUS
 func GetUserConnection(uid int) (*systemdDbus.Conn, error) {
 	return systemdDbus.NewConnection(func() (*dbus.Conn, error) {
-		return dbusAuthConnection(uid, dbus.SessionBusPrivate)
+		return dbusAuthConnection(uid, dbus.SessionBusPrivateNoAutoStartup)
 	})
 }
 


### PR DESCRIPTION
do not start up a dbus daemon if it is not already running.

[NO NEW TESTS NEEDED] the fix is in a dependency.

Closes: https://github.com/containers/podman/issues/16718

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
