### PR TITLE
libnetwork/cni: fix panic with ipam driver none

### DIFF
--- a/libnetwork/cni/cni_types.go
+++ b/libnetwork/cni/cni_types.go
@@ -287,7 +287,7 @@ func newVLANPlugin(pluginType, device, mode string, mtu int, ipam *ipamConfig) V
 	caps := make(map[string]bool)
 	caps["ips"] = true
 	// if we use host-local set the ips cap to ensure we can set static ips via runtime config
-	if ipam.PluginType == types.HostLocalIPAMDriver {
+	if m.IPAM.PluginType == types.HostLocalIPAMDriver {
 		m.Capabilities = caps
 	}
 	return m


### PR DESCRIPTION
When creating macvlan or ipvlan network configs with the none ipam driver we would always cause a segfault because of a nil pointer dereference.

Add a test for both to prevent a regression.

Fixes containers/podman#16620



<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
