### PR TITLE
pkg/netns: UnmountNS() accept netns path as string

### DIFF
--- a/libnetwork/cni/run_test.go
+++ b/libnetwork/cni/run_test.go
@@ -109,10 +109,10 @@ var _ = Describe("run CNI", func() {
 		logrus.SetLevel(logrus.InfoLevel)
 		_ = os.RemoveAll(cniConfDir)
 
-		_ = netns.UnmountNS(netNSTest)
+		_ = netns.UnmountNS(netNSTest.Path())
 		_ = netNSTest.Close()
 
-		_ = netns.UnmountNS(netNSContainer)
+		_ = netns.UnmountNS(netNSContainer.Path())
 		_ = netNSContainer.Close()
 	})
 

--- a/libnetwork/netavark/run_test.go
+++ b/libnetwork/netavark/run_test.go
@@ -108,10 +108,10 @@ var _ = Describe("run netavark", func() {
 		logrus.SetLevel(logrus.InfoLevel)
 		_ = os.RemoveAll(confDir)
 
-		_ = netns.UnmountNS(netNSTest)
+		_ = netns.UnmountNS(netNSTest.Path())
 		_ = netNSTest.Close()
 
-		_ = netns.UnmountNS(netNSContainer)
+		_ = netns.UnmountNS(netNSContainer.Path())
 		_ = netNSContainer.Close()
 
 		_ = os.Unsetenv("NETAVARK_FW")
@@ -286,8 +286,8 @@ var _ = Describe("run netavark", func() {
 
 			netNSContainer2, err := netns.NewNS()
 			Expect(err).ToNot(HaveOccurred())
-			defer netns.UnmountNS(netNSContainer2) //nolint:errcheck
-			defer netNSContainer2.Close()          //nolint:errcheck
+			defer netns.UnmountNS(netNSContainer2.Path()) //nolint:errcheck
+			defer netNSContainer2.Close()                 //nolint:errcheck
 
 			res, err = libpodNet.Setup(netNSContainer2.Path(), setupOpts2)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -179,14 +179,13 @@ func NewNSWithName(name string) (ns.NetNS, error) {
 	return ns.GetNS(nsPath)
 }
 
-// UnmountNS unmounts the NS held by the netns object
-func UnmountNS(netns ns.NetNS) error {
+// UnmountNS unmounts the given netns path
+func UnmountNS(nsPath string) error {
 	nsRunDir, err := GetNSRunDir()
 	if err != nil {
 		return err
 	}
 
-	nsPath := netns.Path()
 	// Only unmount if it's been bind-mounted (don't touch namespaces in /proc...)
 	if strings.HasPrefix(nsPath, nsRunDir) {
 		if err := unix.Unmount(nsPath, unix.MNT_DETACH); err != nil {


### PR DESCRIPTION
I want to switch podman over to only using strings for the netns path. So we no longer pass this interface around. Buildah doesn't use this so we only need to fix it in Podman. I have a WIP PR[1] for that.

[1] https://github.com/containers/podman/pull/16756


<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
