### PR TITLE
Add godoc headers for report package

### DIFF
--- a/pkg/report/doc.go
+++ b/pkg/report/doc.go
@@ -1,6 +1,8 @@
 /*
 Package report provides helper structs/methods/funcs for formatting output
 
+# Examples
+
 To format output for an array of structs:
 
 ExamplePodman:
@@ -54,7 +56,7 @@ Helpers:
 		... "table" keyword prefix in format text
 	}
 
-Template Functions:
+# Template Functions
 
 The following template functions are added to the template when parsed:
   - join  strings.Join, {{join .Field separator}}


### PR DESCRIPTION
This adds some simple headers to the godoc for the reports package. This will allow, when viewed on https://pkg.go.dev/github.com/containers/common/pkg/report, to link directly to sections like the "Template Functions" section.

This is related to https://github.com/containers/skopeo/pull/1822