### PR TITLE
Add to default machine volumes for MacOS

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -745,6 +745,8 @@ Environment variables like $HOME as well as complete paths are supported for
 the source and destination. An optional third field `:ro` can be used to
 tell the container engines to mount the volume readonly.
 
+On Mac, the default volumes are: `"/Users:/Users", "/private:/private", "/var/folders:/var/folders"`
+
 # FILES
 
 **containers.conf**

--- a/pkg/config/default_darwin.go
+++ b/pkg/config/default_darwin.go
@@ -14,5 +14,9 @@ func getLibpodTmpDir() string {
 
 // getDefaultMachineVolumes returns default mounted volumes (possibly with env vars, which will be expanded)
 func getDefaultMachineVolumes() []string {
-	return []string{"$HOME:$HOME"}
+	return []string{
+		"/Users:/Users",
+		"/private:/private",
+		"/var/folders:/var/folders",
+	}
 }


### PR DESCRIPTION
On MacOS, mount /Users, /private/, /var/folders by default for better docker compat. The homedir on MacOS is /Users/<username>, so that will be mounted automatically anyway with this change.

Docker also mounts /Volumes and /tmp, /Volumes fails with a Too many levels of symbolic links, as Volumes on Mac is just a symlink to / which seems like a bad idea to mount anyway. /tmp fails because the Podman machine uses the tmp directory inside the machine and writes content to it on boot, causing the mount to fail. However, on Mac, /tmp is symlinked to /private/tmp anyway, so those files are accessible from there.

Signed-off-by: Ashley Cui <acui@redhat.com>

Part of: https://github.com/containers/podman/issues/16447

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
