### PR TITLE
Create netavark.lock in the run directory

### DIFF
--- a/libnetwork/netavark/network.go
+++ b/libnetwork/netavark/network.go
@@ -95,7 +95,7 @@ type InitConfig struct {
 // Note: The networks are not loaded from disk until a method is called.
 func NewNetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
 	// TODO: consider using a shared memory lock
-	lock, err := lockfile.GetLockFile(filepath.Join(conf.NetworkConfigDir, "netavark.lock"))
+	lock, err := lockfile.GetLockFile(filepath.Join(conf.NetworkRunDir, "netavark.lock"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Quack,

It tried to create the file in /etc but SELinux blocked it. One observed consequence is the podman API service failing to start.

I don't know much about the golang ecosystem and failed to see this change was in a separate repository and initially made a PR in the podman project (containers/podman#16846).
I checked it builds fine on the podman main branch but did not run the binary.
I backported it to podman 3.4.1 (the version in CentOS 9 Stream I'm using) and the API service was able to start properly.
I'm not sure how you test modules separately but at least in my use case it works when built inside the podman vendor/ directory; I'll leave it to the CI to make further checks.

Regards.
\\_o<