### PR TITLE
[0.49] cgroups: use SessionBusPrivateNoAutoStartup

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -432,7 +432,7 @@ func (c *CgroupControl) CreateSystemdUnit(path string) error {
 // GetUserConnection returns an user connection to D-BUS
 func GetUserConnection(uid int) (*systemdDbus.Conn, error) {
 	return systemdDbus.NewConnection(func() (*dbus.Conn, error) {
-		return dbusAuthConnection(uid, dbus.SessionBusPrivate)
+		return dbusAuthConnection(uid, dbus.SessionBusPrivateNoAutoStartup)
 	})
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.49.2"
+const Version = "0.49.3"


### PR DESCRIPTION
do not start up a dbus daemon if it is not already running.

[NO NEW TESTS NEEDED] the fix is in a dependency.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2153894

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit 12a939e1048a65cb4085a4bb4d42f4ecf86a0faf)

We'll need to cut a new release afterward

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
