### PR TITLE
--format '{{ json . }}' should be valid

### DIFF
--- a/pkg/report/validate.go
+++ b/pkg/report/validate.go
@@ -6,7 +6,7 @@ import (
 
 // Check for json, {{json }} and {{ json. }} which are not valid go template,
 // {{json .}} is valid and thus not matched to let the template handle it like docker does.
-var jsonRegex = regexp.MustCompile(`^\s*(json|{{\s*json\.?\s*}})\s*$`)
+var jsonRegex = regexp.MustCompile(`^\s*(json|{{\s*json *\.?\s*}})\s*$`)
 
 // JSONFormat test CLI --format string to be a JSON request
 //

--- a/pkg/report/validate_test.go
+++ b/pkg/report/validate_test.go
@@ -22,10 +22,6 @@ func TestIsJSON(t *testing.T) {
 		{"{{json }}", true},
 		{"{{json.}}", true},
 		{"{{ json. }}", true},
-
-		{"{{ json .}}", false},
-		{"{{ json . }}", false},
-		{"  {{   json   .  }}  ", false},
 		{"{{ json .", false},
 		{"json . }}", false},
 		{"{{.ID }} json .", false},


### PR DESCRIPTION
The following formats are all valid
```
{{ json .}}
{{ json . }}
{{   json   .  }}
```

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
