### PR TITLE
libnetwork: change lock path to tmpfs for root

### DIFF
--- a/libnetwork/cni/network.go
+++ b/libnetwork/cni/network.go
@@ -18,9 +18,11 @@ import (
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/storage/pkg/lockfile"
+	"github.com/containers/storage/pkg/unshare"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
+
+const defaultRootLockPath = "/run/lock/podman-cni.lock"
 
 type cniNetwork struct {
 	// cniConfigDir is directory where the cni config files are stored.
@@ -81,19 +83,15 @@ type InitConfig struct {
 // NewCNINetworkInterface creates the ContainerNetwork interface for the CNI backend.
 // Note: The networks are not loaded from disk until a method is called.
 func NewCNINetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
-	// TODO: consider using a shared memory lock
-	lock, err := lockfile.GetLockFile(filepath.Join(conf.CNIConfigDir, "cni.lock"))
+	// root needs to use a globally unique lock because there is only one host netns
+	lockPath := defaultRootLockPath
+	if unshare.IsRootless() {
+		lockPath = filepath.Join(conf.CNIConfigDir, "cni.lock")
+	}
+
+	lock, err := lockfile.GetLockFile(lockPath)
 	if err != nil {
-		// If we're on a read-only filesystem, there is no risk of
-		// contention. Fall back to a local lockfile.
-		if errors.Is(err, unix.EROFS) {
-			lock, err = lockfile.GetLockFile(filepath.Join(conf.RunDir, "cni.lock"))
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	defaultNetworkName := conf.DefaultNetwork

--- a/libnetwork/netavark/const.go
+++ b/libnetwork/netavark/const.go
@@ -4,3 +4,5 @@
 package netavark
 
 const defaultBridgeName = "podman"
+
+const defaultRootLockPath = "/run/lock/netavark.lock"

--- a/libnetwork/netavark/network.go
+++ b/libnetwork/netavark/network.go
@@ -94,8 +94,13 @@ type InitConfig struct {
 // NewNetworkInterface creates the ContainerNetwork interface for the netavark backend.
 // Note: The networks are not loaded from disk until a method is called.
 func NewNetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
-	// TODO: consider using a shared memory lock
-	lock, err := lockfile.GetLockFile(filepath.Join(conf.NetworkConfigDir, "netavark.lock"))
+	// root needs to use a globally unique lock because there is only one host netns
+	lockPath := defaultRootLockPath
+	if unshare.IsRootless() {
+		lockPath = filepath.Join(conf.NetworkConfigDir, "netavark.lock")
+	}
+
+	lock, err := lockfile.GetLockFile(lockPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The default /etc/containers/networks location might not be writeable, while this breaks podman network create it does not need to break all podman commands since the lock is created on libpod initialization.

ref https://github.com/containers/common/pull/1270

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
