### PR TITLE
`--sign-by-sigstore` infrastructure

### DIFF
--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/signature"
+	"github.com/containers/image/v5/signature/signer"
 	storageTransport "github.com/containers/image/v5/storage"
 	"github.com/containers/image/v5/types"
 	encconfig "github.com/containers/ocicrypt/config"
@@ -99,6 +100,9 @@ type CopyOptions struct {
 	PolicyAllowStorage bool
 	// SignaturePolicyPath to overwrite the default one.
 	SignaturePolicyPath string
+	// If non-empty, asks for signatures to be added during the copy
+	// using the provided signers.
+	Signers []*signer.Signer
 	// If non-empty, asks for a signature to be added during the copy, and
 	// specifies a key ID.
 	SignBy string
@@ -299,6 +303,7 @@ func (r *Runtime) newCopier(options *CopyOptions) (*copier, error) {
 	c.imageCopyOptions.OciEncryptLayers = options.OciEncryptLayers
 	c.imageCopyOptions.OciDecryptConfig = options.OciDecryptConfig
 	c.imageCopyOptions.RemoveSignatures = options.RemoveSignatures
+	c.imageCopyOptions.Signers = options.Signers
 	c.imageCopyOptions.SignBy = options.SignBy
 	c.imageCopyOptions.SignPassphrase = options.SignPassphrase
 	c.imageCopyOptions.SignBySigstorePrivateKeyFile = options.SignBySigstorePrivateKeyFile

--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -452,6 +452,7 @@ func (m *ManifestList) Push(ctx context.Context, destination string, options *Ma
 		ImageListSelection:               options.ImageListSelection,
 		Instances:                        options.Instances,
 		ReportWriter:                     options.Writer,
+		Signers:                          options.Signers,
 		SignBy:                           options.SignBy,
 		SignPassphrase:                   options.SignPassphrase,
 		SignBySigstorePrivateKeyFile:     options.SignBySigstorePrivateKeyFile,

--- a/libimage/manifests/manifests.go
+++ b/libimage/manifests/manifests.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/signature"
+	"github.com/containers/image/v5/signature/signer"
 	is "github.com/containers/image/v5/storage"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/transports/alltransports"
@@ -61,6 +62,7 @@ type PushOptions struct {
 	ImageListSelection               cp.ImageListSelection // set to either CopySystemImage, CopyAllImages, or CopySpecificImages
 	Instances                        []digest.Digest       // instances to copy if ImageListSelection == CopySpecificImages
 	ReportWriter                     io.Writer             // will be used to log the writing of the list and any blobs
+	Signers                          []*signer.Signer      // if non-empty, asks for signatures to be added during the copy using the provided signers.
 	SignBy                           string                // fingerprint of GPG key to use to sign images
 	SignPassphrase                   string                // passphrase to use when signing with the key ID from SignBy.
 	SignBySigstorePrivateKeyFile     string                // if non-empty, asks for a signature to be added during the copy, using a sigstore private key file at the provided path.
@@ -244,6 +246,7 @@ func (l *list) Push(ctx context.Context, dest types.ImageReference, options Push
 		DestinationCtx:                   options.SystemContext,
 		ReportWriter:                     options.ReportWriter,
 		RemoveSignatures:                 options.RemoveSignatures,
+		Signers:                          options.Signers,
 		SignBy:                           options.SignBy,
 		SignPassphrase:                   options.SignPassphrase,
 		SignBySigstorePrivateKeyFile:     options.SignBySigstorePrivateKeyFile,


### PR DESCRIPTION
This is infrastructure for Podman supporting something like https://github.com/containers/skopeo/pull/1849 .

RFC . I’m not quite sure how to deal with the inevitable interactivity of Fulcio. Right now Fulcio interactivity is done here in c/common, and passphrase interactivity happens in Podman.

One consistent option would be to move all interactivity to Podman, i.e. to require Podman to provide a finished `c/image/signature/signer.Signer` (and then, within Podman, would that interactivity be in the top-level CLI, or only in the local engine implementation?).

Another consistent option would be to move all interactivity to c/common, i.e. to implement proper passphrase prompting down here in c/common.

I guess I weakly prefer Podman-side interactivity.

@vrothberg WDYT?