### PR TITLE
Add Provider to MachineConfig

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -747,6 +747,12 @@ tell the container engines to mount the volume readonly.
 
 On Mac, the default volumes are: `"/Users:/Users", "/private:/private", "/var/folders:/var/folders"`
 
+**provider**=""
+
+Virtualization provider to be used for running a podman-machine VM. Empty value
+is interpreted as the default provider for the current host OS. On Linux/Mac
+default is `QEMU` and on Windows it is `WSL`.
+
 # FILES
 
 **containers.conf**

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -609,7 +609,7 @@ type MachineConfig struct {
 	CPUs uint64 `toml:"cpus,omitempty,omitzero"`
 	// DiskSize is the size of the disk in GB created when init-ing a podman-machine VM
 	DiskSize uint64 `toml:"disk_size,omitempty,omitzero"`
-	// MachineImage is the image used when init-ing a podman-machine VM
+	// Image is the image used when init-ing a podman-machine VM
 	Image string `toml:"image,omitempty"`
 	// Memory in MB a machine is created with.
 	Memory uint64 `toml:"memory,omitempty,omitzero"`
@@ -617,6 +617,8 @@ type MachineConfig struct {
 	User string `toml:"user,omitempty"`
 	// Volumes are host directories mounted into the VM by default.
 	Volumes []string `toml:"volumes"`
+	// Provider is the virtualization provider used to run podman-machine VM
+	Provider string `toml:"provider,omitempty"`
 }
 
 // Destination represents destination for remote service

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -693,7 +693,7 @@ default_sysctls = [
 # "https://example.com/linux/amd64/foobar.ami" on a Linux AMD machine.
 # The default value is `testing`.
 #
-# image = "testing"
+#image = "testing"
 
 # Memory in MB a machine is created with.
 #
@@ -709,9 +709,14 @@ default_sysctls = [
 # the source and destination. An optional third field `:ro` can be used to
 # tell the container engines to mount the volume readonly.
 #
-# volumes = [
+#volumes = [
 #  "$HOME:$HOME",
 #]
+
+# Virtualization provider used to run Podman machine.
+# If it is empty or commented out, the default provider will be used.
+#
+#provider = ""
 
 # The [machine] table MUST be the last entry in this file.
 # (Unless another table is added)

--- a/pkg/config/containers.conf-freebsd
+++ b/pkg/config/containers.conf-freebsd
@@ -626,9 +626,14 @@ default_sysctls = [
 # the source and destination. An optional third field `:ro` can be used to
 # tell the container engines to mount the volume readonly.
 #
-# volumes = [
+#volumes = [
 #  "$HOME:$HOME",
 #]
+
+# Virtualization provider used to run Podman machine.
+# If it is empty or commented out, the default provider will be used.
+#
+#provider = ""
 
 # The [machine] table MUST be the last entry in this file.
 # (Unless another table is added)


### PR DESCRIPTION
It is needed to implement https://github.com/containers/podman/issues/17116

The work in progress implementation used to verify POC could be found here https://github.com/arixmkii/podman/commit/e443a7034955d21347eed3bf6b708e1ca38cf093 It is not a PR for Podman yet as this will not compile without this change inside common.

Additionally fixed inconsistency between doc comment and field name for `Image` field.

Signed-off-by: Arthur Sengileyev <arthur.sengileyev@gmail.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
