### PR TITLE
Enable DHCP macvlan

### DIFF
--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -251,9 +251,6 @@ func createMacvlan(network *types.Network) error {
 	// we already validated the drivers before so we just have to set the default here
 	switch network.IPAMOptions[types.Driver] {
 	case "":
-		if len(network.Subnets) == 0 {
-			return fmt.Errorf("macvlan driver needs at least one subnet specified, DHCP is not yet supported with netavark")
-		}
 		network.IPAMOptions[types.Driver] = types.HostLocalIPAMDriver
 	case types.HostLocalIPAMDriver:
 		if len(network.Subnets) == 0 {
@@ -353,13 +350,11 @@ func (n *netavarkNetwork) NetworkInspect(nameOrID string) (types.Network, error)
 func validateIPAMDriver(n *types.Network) error {
 	ipamDriver := n.IPAMOptions[types.Driver]
 	switch ipamDriver {
-	case "", types.HostLocalIPAMDriver:
+	case "", types.HostLocalIPAMDriver, types.DHCPIPAMDriver:
 	case types.NoneIPAMDriver:
 		if len(n.Subnets) > 0 {
 			return errors.New("none ipam driver is set but subnets are given")
 		}
-	case types.DHCPIPAMDriver:
-		return errors.New("dhcp ipam driver is not yet supported with netavark")
 	default:
 		return fmt.Errorf("unsupported ipam driver %q", ipamDriver)
 	}

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -918,8 +918,7 @@ var _ = Describe("Config", func() {
 		It("create macvlan config without subnet", func() {
 			network := types.Network{Driver: "macvlan"}
 			_, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("macvlan driver needs at least one subnet specified, DHCP is not yet supported with netavark"))
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("create macvlan config with internal", func() {


### PR DESCRIPTION
With progress on netavark-dhcp-proxy, we can begin to macvlan with dhcp back into the fold for netavark.

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
