### PR TITLE
libnetwork/cni: mkdir network config dir

### DIFF
--- a/libnetwork/cni/cni_conversion.go
+++ b/libnetwork/cni/cni_conversion.go
@@ -327,6 +327,9 @@ func (n *cniNetwork) createCNIConfigListFromNetwork(network *types.Network, writ
 	}
 	cniPathName := ""
 	if writeToDisk {
+		if err := os.MkdirAll(n.cniConfigDir, 0o755); err != nil {
+			return nil, "", err
+		}
 		cniPathName = filepath.Join(n.cniConfigDir, network.Name+".conflist")
 		err = os.WriteFile(cniPathName, b, 0o644)
 		if err != nil {

--- a/libnetwork/cni/config_test.go
+++ b/libnetwork/cni/config_test.go
@@ -128,6 +128,10 @@ var _ = Describe("Config", func() {
 		})
 
 		It("create two networks", func() {
+			// remove the dir here since we do not expect it to exists in the real context as well
+			// the backend will create it for us
+			os.RemoveAll(cniConfDir)
+
 			network := types.Network{}
 			network1, err := libpodNet.NetworkCreate(network, nil)
 			Expect(err).To(BeNil())

--- a/libnetwork/cni/network.go
+++ b/libnetwork/cni/network.go
@@ -141,11 +141,15 @@ func (n *cniNetwork) DefaultNetworkName() string {
 
 func (n *cniNetwork) loadNetworks() error {
 	// check the mod time of the config dir
+	var modTime time.Time
 	f, err := os.Stat(n.cniConfigDir)
-	if err != nil {
+	// ignore error if the file does not exists
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-	modTime := f.ModTime()
+	if err == nil {
+		modTime = f.ModTime()
+	}
 
 	// skip loading networks if they are already loaded and
 	// if the config dir was not modified since the last call


### PR DESCRIPTION
Commit 4bf13f4b2946 caused a regression, previously the lockfile package create the config directory. Now this is no longer the case so we have to create it explicitly.

Note that netavark already did this so no change is needed there.

This was reported by the RHEL QE team.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
