### PR TITLE
Support docker-specific network create options via CLI

### DIFF
--- a/libnetwork/cni/config.go
+++ b/libnetwork/cni/config.go
@@ -86,6 +86,7 @@ func (n *cniNetwork) networkCreate(newNetwork *types.Network, defaultNet bool) (
 
 	switch newNetwork.Driver {
 	case types.BridgeNetworkDriver:
+		internalutil.MapDockerBridgeDriverOptions(newNetwork)
 		err = internalutil.CreateBridge(n, newNetwork, usedNetworks, n.defaultsubnetPools)
 		if err != nil {
 			return nil, err

--- a/libnetwork/cni/config_test.go
+++ b/libnetwork/cni/config_test.go
@@ -204,6 +204,32 @@ var _ = Describe("Config", func() {
 			Expect(network1.Internal).To(BeFalse())
 		})
 
+		It("create bridge config with com.docker.network.bridge.name", func() {
+			network := types.Network{
+				Driver: "bridge",
+				Options: map[string]string{
+					"com.docker.network.bridge.name": "foo",
+				},
+			}
+			network1, err := libpodNet.NetworkCreate(network, nil)
+			Expect(err).To(BeNil())
+			Expect(network1.Name).ToNot(BeEmpty())
+			Expect(filepath.Join(cniConfDir, network1.Name+".conflist")).To(BeARegularFile())
+			Expect(network1.ID).ToNot(BeEmpty())
+			Expect(network1.NetworkInterface).To(Equal("foo"))
+			Expect(network1.Driver).To(Equal("bridge"))
+			Expect(network1.Labels).To(BeEmpty())
+			Expect(network1.Options).To(BeEmpty())
+			Expect(network1.IPAMOptions).ToNot(BeEmpty())
+			Expect(network1.IPAMOptions).To(HaveKeyWithValue("driver", "host-local"))
+			Expect(network1.Subnets).To(HaveLen(1))
+			Expect(network1.Subnets[0].Subnet.String()).To(Equal("10.89.0.0/24"))
+			Expect(network1.Subnets[0].Gateway.String()).To(Equal("10.89.0.1"))
+			Expect(network1.Subnets[0].LeaseRange).To(BeNil())
+			Expect(network1.DNSEnabled).To(BeFalse())
+			Expect(network1.Internal).To(BeFalse())
+		})
+
 		It("create bridge config with none ipam driver", func() {
 			network := types.Network{
 				Driver: "bridge",
@@ -976,6 +1002,18 @@ var _ = Describe("Config", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
+		It("create bridge config with invalid com.docker.network.bridge.name", func() {
+			network := types.Network{
+				Driver: "bridge",
+				Options: map[string]string{
+					"com.docker.network.bridge.name": "myname@some",
+				},
+			}
+
+			_, err := libpodNet.NetworkCreate(network, nil)
+			Expect(err).To(HaveOccurred())
+		})
+
 		It("create network with ID should fail", func() {
 			id := "17f29b073143d8cd97b5bbe492bdeffec1c5fee55cc1fe2112c8b9335f8b6121"
 			network := types.Network{
@@ -1059,6 +1097,43 @@ var _ = Describe("Config", func() {
 			network = types.Network{
 				Options: map[string]string{
 					types.MTUOption: "-1",
+				},
+			}
+			_, err = libpodNet.NetworkCreate(network, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`mtu -1 is less than zero`))
+		})
+
+		It("create network with com.docker.network.driver.mtu option", func() {
+			network := types.Network{
+				Options: map[string]string{
+					"com.docker.network.driver.mtu": "1500",
+				},
+			}
+			network1, err := libpodNet.NetworkCreate(network, nil)
+			Expect(err).To(BeNil())
+			Expect(network1.Driver).To(Equal("bridge"))
+			Expect(network1.Options).ToNot(BeNil())
+			path := filepath.Join(cniConfDir, network1.Name+".conflist")
+			Expect(path).To(BeARegularFile())
+			grepInFile(path, `"mtu": "1500"`)
+			Expect(network1.Options).To(HaveKeyWithValue("mtu", "1500"))
+			Expect(network1.Options).ToNot(HaveKeyWithValue("com.docker.network.driver.mtu", "1500"))
+		})
+
+		It("create network with invalid com.docker.network.driver.mtu option", func() {
+			network := types.Network{
+				Options: map[string]string{
+					"com.docker.network.driver.mtu": "abc",
+				},
+			}
+			_, err := libpodNet.NetworkCreate(network, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`parsing "abc": invalid syntax`))
+
+			network = types.Network{
+				Options: map[string]string{
+					"com.docker.network.driver.mtu": "-1",
 				},
 			}
 			_, err = libpodNet.NetworkCreate(network, nil)

--- a/libnetwork/internal/util/util.go
+++ b/libnetwork/internal/util/util.go
@@ -129,3 +129,19 @@ func GetFreeIPv6NetworkSubnet(usedNetworks []*net.IPNet) (*types.Subnet, error) 
 	}
 	return nil, errors.New("failed to get random ipv6 subnet")
 }
+
+// Map docker driver network options to podman network options
+func MapDockerBridgeDriverOptions(n *types.Network) {
+	// validate the given options
+	for key, value := range n.Options {
+		switch key {
+		case "com.docker.network.driver.mtu":
+			n.Options[types.MTUOption] = value
+			delete(n.Options, "com.docker.network.driver.mtu")
+
+		case "com.docker.network.bridge.name":
+			n.NetworkInterface = value
+			delete(n.Options, "com.docker.network.bridge.name")
+		}
+	}
+}

--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -155,6 +155,7 @@ func (n *netavarkNetwork) networkCreate(newNetwork *types.Network, defaultNet bo
 
 	switch newNetwork.Driver {
 	case types.BridgeNetworkDriver:
+		internalutil.MapDockerBridgeDriverOptions(newNetwork)
 		err = internalutil.CreateBridge(n, newNetwork, usedNetworks, n.defaultsubnetPools)
 		if err != nil {
 			return nil, err
@@ -186,6 +187,7 @@ func (n *netavarkNetwork) networkCreate(newNetwork *types.Network, defaultNet bo
 				if err != nil {
 					return nil, err
 				}
+
 			default:
 				return nil, fmt.Errorf("unsupported bridge network option %s", key)
 			}


### PR DESCRIPTION
Signed-off-by: T K Chandra Hasan <t.k.chandra.hasan@ibm.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

Following docker specific network options are supported via CLI

1. com.docker.network.driver.mtu
2. com.docker.network.bridge.name

Fixes https://github.com/containers/podman/issues/15830