### PR TITLE
libimage: make sure all events have an ID

### DIFF
--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -116,10 +116,6 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 		return nil, fmt.Errorf("pulling all tags is not supported for %s transport", ref.Transport().Name())
 	}
 
-	if r.eventChannel != nil {
-		defer r.writeEvent(&Event{ID: "", Name: name, Time: time.Now(), Type: EventTypeImagePull})
-	}
-
 	// Some callers may set the platform via the system context at creation
 	// time of the runtime.  We need this information to decide whether we
 	// need to enforce pulling from a registry (see
@@ -182,6 +178,10 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 			} else {
 				fmt.Fprintf(options.Writer, "WARNING: %v\n", matchError)
 			}
+		}
+
+		if r.eventChannel != nil {
+			r.writeEvent(&Event{ID: image.ID(), Name: name, Time: time.Now(), Type: EventTypeImagePull})
 		}
 
 		localImages = append(localImages, image)


### PR DESCRIPTION
Make sure that all image events have an ID. I noticed that some (e.g., pull) did not include the ID which is confusing and renders the events less useful.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

@rhatdan @flouthoc @giuseppe PTAL