### PR TITLE
pkg/auth: add `NoWriteBack` option

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -143,16 +143,16 @@ func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginO
 	}
 
 	if err = docker.CheckAuth(ctx, systemContext, username, password, registry); err == nil {
-		// Write the new credentials to the authfile
-		desc, err := config.SetCredentials(systemContext, key, username, password)
-		if err != nil {
-			return err
+		if !opts.NoWriteBack {
+			// Write the new credentials to the authfile
+			desc, err := config.SetCredentials(systemContext, key, username, password)
+			if err != nil {
+				return err
+			}
+			if opts.Verbose {
+				fmt.Fprintln(opts.Stdout, "Used: ", desc)
+			}
 		}
-		if opts.Verbose {
-			fmt.Fprintln(opts.Stdout, "Used: ", desc)
-		}
-	}
-	if err == nil {
 		fmt.Fprintln(opts.Stdout, "Login Succeeded!")
 		return nil
 	}

--- a/pkg/auth/cli.go
+++ b/pkg/auth/cli.go
@@ -26,6 +26,7 @@ type LoginOptions struct {
 	Stdin                     io.Reader // set to os.Stdin
 	Stdout                    io.Writer // set to os.Stdout
 	AcceptUnspecifiedRegistry bool      // set to true if allows login with unspecified registry
+	NoWriteBack               bool      // set to true to not write the credentials to the authfile/cred helpers
 }
 
 // LogoutOptions represents the results for flags in logout


### PR DESCRIPTION
Add an option to not write back the credentials to the authfile or any credential helper.  The `/auth` compat endpoint of Podman is currently not using this code here which ultimately led to normalization errors surfacing in containers/podman/issues/17571.

The new option allows the endpoint to use this function without writing back the credentials.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
@containers/podman-maintainers PTAL