### PR TITLE
fix netavark IgnoreIfExists config test flake

### DIFF
--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -165,7 +165,7 @@ var _ = Describe("Config", func() {
 			network = types.Network{Name: network1.Name}
 			network2, err := libpodNet.NetworkCreate(network, &types.NetworkCreateOptions{IgnoreIfExists: true})
 			Expect(err).To(BeNil())
-			Expect(network2).To(Equal(network1))
+			EqualNetwork(network2, network1)
 		})
 
 		It("create bridge config", func() {


### PR DESCRIPTION
We cannot compare network with Expect().To(Equal()), the internal time.Time is not equal after parsing from file. There is some internal field offset that can be different but the date is still the same. Other tests have the same problem and to circumvent this we use EqualNetwork() there. Do the same here.

Fixes #1335

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
