### PR TITLE
pkg/auth/Login: return a typed error

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -19,6 +19,23 @@ import (
 	terminal "golang.org/x/term"
 )
 
+// ErrNewCredentialsInvalid means that the new user-provided credentials are
+// not accepted by the registry.
+type ErrNewCredentialsInvalid struct {
+	underlyingError error
+	message         string
+}
+
+// Error returns the error message as a string.
+func (e ErrNewCredentialsInvalid) Error() string {
+	return e.message
+}
+
+// Unwrap returns the underlying error.
+func (e ErrNewCredentialsInvalid) Unwrap() error {
+	return e.underlyingError
+}
+
 // GetDefaultAuthFile returns env value REGISTRY_AUTH_FILE as default
 // --authfile path used in multiple --authfile flag definitions
 // Will fail over to DOCKER_CONFIG if REGISTRY_AUTH_FILE environment is not set
@@ -158,7 +175,10 @@ func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginO
 	}
 	if unauthorized, ok := err.(docker.ErrUnauthorizedForCredentials); ok {
 		logrus.Debugf("error logging into %q: %v", key, unauthorized)
-		return fmt.Errorf("logging into %q: invalid username/password", key)
+		return ErrNewCredentialsInvalid{
+			underlyingError: err,
+			message:         fmt.Sprintf("logging into %q: invalid username/password", key),
+		}
 	}
 	return fmt.Errorf("authenticating creds for %q: %w", key, err)
 }


### PR DESCRIPTION
To preserve the knowledge about the error without string compares. Needed in Podman's REST API.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

@Luap99 @mtrmac @edsantiago PTAL

See https://github.com/containers/podman/pull/17581#issuecomment-1438663276.