### PR TITLE
Allow cgroup-conf settings to be stored in containers.conf

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -66,6 +66,12 @@ file. This must be either an absolute path or as special values "image" which
 uses the hosts file from the container image or "none" which means
 no base hosts file is used. The default is "" which will use /etc/hosts.
 
+**cgroup_conf**=[]
+
+List of cgroup_conf entries specifying a list of cgroup files to write to and
+their values. For example `memory.high=1073741824` sets the
+memory.high limit to 1GB.
+
 **cgroups**="enabled"
 
 Determines  whether  the  container will create CGroups.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -109,6 +109,10 @@ type ContainersConfig struct {
 	// Default cgroup configuration
 	Cgroups string `toml:"cgroups,omitempty"`
 
+	// CgroupConf entries specifies a list of cgroup files to write to and their values. For example
+	// "memory.high=1073741824" sets the memory.high limit to 1GB.
+	CgroupConf []string `toml:"cgroup_conf,omitempty"`
+
 	// Capabilities to add to all containers.
 	DefaultCapabilities []string `toml:"default_capabilities,omitempty"`
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -386,6 +386,7 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(config.Network.CNIPluginDirs).To(gomega.Equal(DefaultCNIPluginDirs))
 			gomega.Expect(config.Engine.NumLocks).To(gomega.BeEquivalentTo(2048))
 			gomega.Expect(config.Engine.OCIRuntimes["runc"]).To(gomega.Equal(OCIRuntimeMap["runc"]))
+			gomega.Expect(config.Containers.CgroupConf).To(gomega.BeNil())
 			if useSystemd() {
 				gomega.Expect(config.Engine.CgroupManager).To(gomega.BeEquivalentTo("systemd"))
 			} else {
@@ -408,6 +409,9 @@ image_copy_tmp_dir="storage"`
 			// When
 			config, err := NewConfig("testdata/containers_default.conf")
 			// Then
+			cgroupConf := []string{
+				"memory.high=1073741824",
+			}
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal("container-default"))
 			gomega.Expect(config.Containers.PidsLimit).To(gomega.BeEquivalentTo(2048))
@@ -420,6 +424,7 @@ image_copy_tmp_dir="storage"`
 			dbBackend, err := config.DBBackend()
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(dbBackend).To(gomega.BeEquivalentTo(DBBackendSQLite))
+			gomega.Expect(config.Containers.CgroupConf).To(gomega.Equal(cgroupConf))
 		})
 
 		It("contents of passed-in file should override others", func() {

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -33,6 +33,11 @@
 #
 #base_hosts_file = ""
 
+# List of cgroup_conf entries specifying a list of cgroup files to write to and
+# their values. For example `memory.high=1073741824` sets the
+# memory.high limit to 1GB.
+# cgroup_conf = []
+
 # Default way to to create a cgroup namespace for the container
 # Options are:
 # `private` Create private Cgroup Namespace for the container.

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -6,6 +6,10 @@
 
 [containers]
 
+cgroup_conf = [
+    "memory.high=1073741824",
+]
+
 # List of devices. Specified as
 # "<device-on-host>:<device-on-container>:<permissions>", for example: "--device=/dev/sdc:/dev/xvdc:rwm".
 #If it is empty or commented out, only the devices


### PR DESCRIPTION
This will allows users to set all containers to automatically set certain cgroup fields globally for all of their containers.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
