### PR TITLE
pkg/config.DBBackend(): support env variable

### DIFF
--- a/pkg/config/db_backend.go
+++ b/pkg/config/db_backend.go
@@ -1,6 +1,9 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
 // DBBackend determines which supported database backend Podman should use.
 type DBBackend int
@@ -55,6 +58,12 @@ func ParseDBBackend(raw string) (DBBackend, error) {
 }
 
 // DBBackend returns the configured database backend.
+// The values from the configuration files may be overridden by the
+// CONTAINERS_DATABASE_BACKEND environment variable.
 func (c *Config) DBBackend() (DBBackend, error) {
-	return ParseDBBackend(c.Engine.DBBackend)
+	value := c.Engine.DBBackend
+	if fromEnv := os.Getenv("CONTAINERS_DATABASE_BACKEND"); fromEnv != "" {
+		value = fromEnv
+	}
+	return ParseDBBackend(value)
 }


### PR DESCRIPTION
Allow for overriding the values from the config files via the CONTAINERS_DATABASE_BACKEND environment variable.  An env variable considerably simplifies testing the SQLite backend in Podman's system tests.  A global setting in a containers.conf won't work there since some tests use a custom one.  Adding the --db-backend flag does not work consistently either since Podman is sometimes executed in systemd etc.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

@mheon @edsantiago PTAL