### PR TITLE
libimage: ListImages: pre-compute dangling/parent

### DIFF
--- a/libimage/disk_usage.go
+++ b/libimage/disk_usage.go
@@ -29,12 +29,12 @@ type ImageDiskUsage struct {
 // storage.  Note that a single image may yield multiple usage reports, one for
 // each repository tag.
 func (r *Runtime) DiskUsage(ctx context.Context) ([]ImageDiskUsage, int64, error) {
-	images, err := r.ListImages(ctx, nil, nil)
+	layerTree, err := r.layerTree()
 	if err != nil {
 		return nil, -1, err
 	}
 
-	layerTree, err := r.layerTree(images)
+	images, err := r.ListImages(ctx, nil, nil)
 	if err != nil {
 		return nil, -1, err
 	}

--- a/libimage/disk_usage.go
+++ b/libimage/disk_usage.go
@@ -29,12 +29,12 @@ type ImageDiskUsage struct {
 // storage.  Note that a single image may yield multiple usage reports, one for
 // each repository tag.
 func (r *Runtime) DiskUsage(ctx context.Context) ([]ImageDiskUsage, int64, error) {
-	layerTree, err := r.layerTree()
+	images, err := r.ListImages(ctx, nil, nil)
 	if err != nil {
 		return nil, -1, err
 	}
 
-	images, err := r.ListImages(ctx, nil, nil)
+	layerTree, err := r.layerTree(images)
 	if err != nil {
 		return nil, -1, err
 	}

--- a/libimage/filters.go
+++ b/libimage/filters.go
@@ -81,7 +81,7 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 	var tree *layerTree
 	getTree := func() (*layerTree, error) {
 		if tree == nil {
-			t, err := r.layerTree()
+			t, err := r.layerTree(nil)
 			if err != nil {
 				return nil, err
 			}

--- a/libimage/filters.go
+++ b/libimage/filters.go
@@ -81,7 +81,7 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 	var tree *layerTree
 	getTree := func() (*layerTree, error) {
 		if tree == nil {
-			t, err := r.layerTree(nil)
+			t, err := r.layerTree()
 			if err != nil {
 				return nil, err
 			}

--- a/libimage/history.go
+++ b/libimage/history.go
@@ -24,7 +24,7 @@ func (i *Image) History(ctx context.Context) ([]ImageHistory, error) {
 		return nil, err
 	}
 
-	layerTree, err := i.runtime.layerTree()
+	layerTree, err := i.runtime.layerTree(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/libimage/history.go
+++ b/libimage/history.go
@@ -24,7 +24,7 @@ func (i *Image) History(ctx context.Context) ([]ImageHistory, error) {
 		return nil, err
 	}
 
-	layerTree, err := i.runtime.layerTree(nil)
+	layerTree, err := i.runtime.layerTree()
 	if err != nil {
 		return nil, err
 	}

--- a/libimage/image.go
+++ b/libimage/image.go
@@ -227,7 +227,7 @@ func (i *Image) TopLayer() string {
 
 // Parent returns the parent image or nil if there is none
 func (i *Image) Parent(ctx context.Context) (*Image, error) {
-	tree, err := i.runtime.layerTree(nil)
+	tree, err := i.runtime.layerTree()
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +261,7 @@ func (i *Image) Children(ctx context.Context) ([]*Image, error) {
 // created for this invocation only.
 func (i *Image) getChildren(ctx context.Context, all bool, tree *layerTree) ([]*Image, error) {
 	if tree == nil {
-		t, err := i.runtime.layerTree(nil)
+		t, err := i.runtime.layerTree()
 		if err != nil {
 			return nil, err
 		}

--- a/libimage/image.go
+++ b/libimage/image.go
@@ -227,7 +227,7 @@ func (i *Image) TopLayer() string {
 
 // Parent returns the parent image or nil if there is none
 func (i *Image) Parent(ctx context.Context) (*Image, error) {
-	tree, err := i.runtime.layerTree()
+	tree, err := i.runtime.layerTree(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +261,7 @@ func (i *Image) Children(ctx context.Context) ([]*Image, error) {
 // created for this invocation only.
 func (i *Image) getChildren(ctx context.Context, all bool, tree *layerTree) ([]*Image, error) {
 	if tree == nil {
-		t, err := i.runtime.layerTree()
+		t, err := i.runtime.layerTree(nil)
 		if err != nil {
 			return nil, err
 		}

--- a/libimage/image_tree.go
+++ b/libimage/image_tree.go
@@ -35,7 +35,7 @@ func (i *Image) Tree(traverseChildren bool) (string, error) {
 		fmt.Fprintf(sb, "No Image Layers")
 	}
 
-	layerTree, err := i.runtime.layerTree(nil)
+	layerTree, err := i.runtime.layerTree()
 	if err != nil {
 		return "", err
 	}

--- a/libimage/image_tree.go
+++ b/libimage/image_tree.go
@@ -35,7 +35,7 @@ func (i *Image) Tree(traverseChildren bool) (string, error) {
 		fmt.Fprintf(sb, "No Image Layers")
 	}
 
-	layerTree, err := i.runtime.layerTree()
+	layerTree, err := i.runtime.layerTree(nil)
 	if err != nil {
 		return "", err
 	}

--- a/libimage/layer_tree.go
+++ b/libimage/layer_tree.go
@@ -75,17 +75,15 @@ func (l *layerNode) repoTags() ([]string, error) {
 
 // layerTree extracts a layerTree from the layers in the local storage and
 // relates them to the specified images.
-func (r *Runtime) layerTree(images []*Image) (*layerTree, error) {
+func (r *Runtime) layerTree() (*layerTree, error) {
 	layers, err := r.store.Layers()
 	if err != nil {
 		return nil, err
 	}
 
-	if images == nil {
-		images, err = r.ListImages(context.Background(), nil, nil)
-		if err != nil {
-			return nil, err
-		}
+	images, err := r.ListImages(context.Background(), nil, nil)
+	if err != nil {
+		return nil, err
 	}
 
 	tree := layerTree{

--- a/libimage/layer_tree.go
+++ b/libimage/layer_tree.go
@@ -75,15 +75,17 @@ func (l *layerNode) repoTags() ([]string, error) {
 
 // layerTree extracts a layerTree from the layers in the local storage and
 // relates them to the specified images.
-func (r *Runtime) layerTree() (*layerTree, error) {
+func (r *Runtime) layerTree(images []*Image) (*layerTree, error) {
 	layers, err := r.store.Layers()
 	if err != nil {
 		return nil, err
 	}
 
-	images, err := r.ListImages(context.Background(), nil, nil)
-	if err != nil {
-		return nil, err
+	if images == nil {
+		images, err = r.ListImages(context.Background(), nil, nil)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	tree := layerTree{

--- a/libimage/push_test.go
+++ b/libimage/push_test.go
@@ -51,7 +51,7 @@ func TestPush(t *testing.T) {
 
 	// Now there should only be two images: alpine in Docker format and
 	// alpine in OCI format.
-	listOptions := ListImagesOptions{SetListData: true}
+	listOptions := ListImagesOptions{IsDangling: true}
 	listedImages, err := runtime.ListImages(ctx, nil, &listOptions)
 	require.NoError(t, err, "error listing images")
 	require.Len(t, listedImages, 2, "there should only be two images (alpine in Docke/OCI)")

--- a/libimage/push_test.go
+++ b/libimage/push_test.go
@@ -51,7 +51,7 @@ func TestPush(t *testing.T) {
 
 	// Now there should only be two images: alpine in Docker format and
 	// alpine in OCI format.
-	listOptions := ListImagesOptions{IsDangling: true}
+	listOptions := ListImagesOptions{SetListData: true}
 	listedImages, err := runtime.ListImages(ctx, nil, &listOptions)
 	require.NoError(t, err, "error listing images")
 	require.Len(t, listedImages, 2, "there should only be two images (alpine in Docke/OCI)")

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -537,18 +537,8 @@ type ListImagesOptions struct {
 	// used).  The definition of an external container can be set by
 	// callers.
 	IsExternalContainerFunc IsExternalContainerFunc
-	// Dangling instructs to pre-compute the ListData.IsDangling field for
-	// each image.
-	//
-	// Setting this field has significant performance benefits over calling
-	// `IsDangling()` for each image immediately after listing.
-	IsDangling bool
-	// Parent instructs to pre-compute the ListData.Parent field for each
-	// image.
-	//
-	// Setting this field has significant performance benefits over calling
-	// `Parent()` for each image immediately after listing.
-	Parent bool
+	// SetListData will populate the Image.ListData fields of returned images.
+	SetListData bool
 }
 
 // ListImages lists images in the local container storage.  If names are
@@ -582,7 +572,7 @@ func (r *Runtime) ListImages(ctx context.Context, names []string, options *ListI
 		return nil, err
 	}
 
-	if !(options.IsDangling || options.Parent) {
+	if !options.SetListData {
 		return filtered, nil
 	}
 
@@ -592,26 +582,23 @@ func (r *Runtime) ListImages(ctx context.Context, names []string, options *ListI
 	// as the layer tree will computed once for all instead of once for
 	// each individual image (see containers/podman/issues/17828).
 
-	tree, err := r.layerTree()
+	tree, err := r.layerTree(images)
 	if err != nil {
 		return nil, err
 	}
 
 	for i := range filtered {
-		if options.IsDangling {
-			isDangling, err := filtered[i].isDangling(ctx, tree)
-			if err != nil {
-				return nil, err
-			}
-			filtered[i].ListData.IsDangling = &isDangling
+		isDangling, err := filtered[i].isDangling(ctx, tree)
+		if err != nil {
+			return nil, err
 		}
-		if options.Parent {
-			parent, err := filtered[i].parent(ctx, tree)
-			if err != nil {
-				return nil, err
-			}
-			filtered[i].ListData.Parent = parent
+		filtered[i].ListData.IsDangling = &isDangling
+
+		parent, err := filtered[i].parent(ctx, tree)
+		if err != nil {
+			return nil, err
 		}
+		filtered[i].ListData.Parent = parent
 	}
 
 	return filtered, nil


### PR DESCRIPTION
Checking whether an image is dangling and finding a parent image requires building a layer tree.  Computing a layer tree is expensive, so add options to `ListImages` to pre-compute the dangling and parent information ahead of time;  that requires 1 layer tree instead of N. The information will then be cached in the images such that subsequent calls to `IsDangling()` and `Parent()` can return the cached data.

Context: containers/podman/issues/17828

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
