### PR TITLE
V0.51 backports

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -19,6 +19,23 @@ import (
 	terminal "golang.org/x/term"
 )
 
+// ErrNewCredentialsInvalid means that the new user-provided credentials are
+// not accepted by the registry.
+type ErrNewCredentialsInvalid struct {
+	underlyingError error
+	message         string
+}
+
+// Error returns the error message as a string.
+func (e ErrNewCredentialsInvalid) Error() string {
+	return e.message
+}
+
+// Unwrap returns the underlying error.
+func (e ErrNewCredentialsInvalid) Unwrap() error {
+	return e.underlyingError
+}
+
 // GetDefaultAuthFile returns env value REGISTRY_AUTH_FILE as default
 // --authfile path used in multiple --authfile flag definitions
 // Will fail over to DOCKER_CONFIG if REGISTRY_AUTH_FILE environment is not set
@@ -158,7 +175,10 @@ func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginO
 	}
 	if unauthorized, ok := err.(docker.ErrUnauthorizedForCredentials); ok {
 		logrus.Debugf("error logging into %q: %v", key, unauthorized)
-		return fmt.Errorf("logging into %q: invalid username/password", key)
+		return ErrNewCredentialsInvalid{
+			underlyingError: err,
+			message:         fmt.Sprintf("logging into %q: invalid username/password", key),
+		}
 	}
 	return fmt.Errorf("authenticating creds for %q: %w", key, err)
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -160,16 +160,16 @@ func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginO
 	}
 
 	if err = docker.CheckAuth(ctx, systemContext, username, password, registry); err == nil {
-		// Write the new credentials to the authfile
-		desc, err := config.SetCredentials(systemContext, key, username, password)
-		if err != nil {
-			return err
+		if !opts.NoWriteBack {
+			// Write the new credentials to the authfile
+			desc, err := config.SetCredentials(systemContext, key, username, password)
+			if err != nil {
+				return err
+			}
+			if opts.Verbose {
+				fmt.Fprintln(opts.Stdout, "Used: ", desc)
+			}
 		}
-		if opts.Verbose {
-			fmt.Fprintln(opts.Stdout, "Used: ", desc)
-		}
-	}
-	if err == nil {
 		fmt.Fprintln(opts.Stdout, "Login Succeeded!")
 		return nil
 	}

--- a/pkg/auth/cli.go
+++ b/pkg/auth/cli.go
@@ -26,6 +26,7 @@ type LoginOptions struct {
 	Stdin                     io.Reader // set to os.Stdin
 	Stdout                    io.Writer // set to os.Stdout
 	AcceptUnspecifiedRegistry bool      // set to true if allows login with unspecified registry
+	NoWriteBack               bool      // set to true to not write the credentials to the authfile/cred helpers
 }
 
 // LogoutOptions represents the results for flags in logout


### PR DESCRIPTION
Backports to the newly created v0.51 branch. See individual commits for details.

@rhatdan you can backport https://github.com/containers/common/pull/1373 to the same branch and then we can cut a new release.
