### PR TITLE
bump to v0.52.0-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.51.1-dev"
+const Version = "0.52.0-dev"


### PR DESCRIPTION
v0.51 is being used in RHEL, so I created a branch for it. To avoid confusion and potential risks, bump the main branch to the next minor v0.52.0-dev.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

@containers/podman-maintainers PTAL
we didn't created a v0.51 branch during vendor dance