### PR TITLE
pkg/config: add CONTAINERS_CONF_OVERRIDE

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -769,16 +769,25 @@ default is `QEMU` and on Windows it is `WSL`.
 **containers.conf**
 
 Distributions often provide a `/usr/share/containers/containers.conf` file to
-define default container configuration. Administrators can override fields in
-this file by creating `/etc/containers/containers.conf` to specify their own
-configuration. Rootless users can further override fields in the config by
-creating a config file stored in the `$HOME/.config/containers/containers.conf` file.
+provide a default configuration. Administrators can override fields in this
+file by creating `/etc/containers/containers.conf` to specify their own
+configuration. They may also drop `.conf` files in
+`/etc/containers/containers.conf.d` which will be loaded in alphanumeric order.
+Rootless users can further override fields in the config by creating a config
+file stored in the `$HOME/.config/containers/containers.conf` file or `.conf`
+files in `$HOME/.config/containers/containers.conf.d`.
 
-If the `CONTAINERS_CONF` path environment variable is set, just
-this path will be used. This is primarily used for testing.
+If the `CONTAINERS_CONF` environment variable is set, all system and user
+config files are ignored and only the specified config file will be loaded.
 
-Fields specified in the containers.conf file override the default options, as
-well as options in previously read containers.conf files.
+If the `CONTAINERS_CONF_OVERRIDE` path environment variable is set, the config
+file will be loaded last even when `CONTAINERS_CONF` is set.
+
+The values of both environment variables may be absolute or relative paths, for
+instance, `CONTAINERS_CONF=/tmp/my_containers.conf`.
+
+Fields specified in a containers.conf file override the default options, as
+well as options in previously loaded containers.conf files.
 
 **storage.conf**
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -913,4 +913,20 @@ env=["foo=bar"]`
 		err := ValidateImageVolumeMode("bogus")
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
+
+	It("CONTAINERS_CONF_OVERRIDE", func() {
+		os.Setenv("CONTAINERS_CONF_OVERRIDE", "testdata/containers_override.conf")
+		defer os.Unsetenv("CONTAINERS_CONF_OVERRIDE")
+		config, err := NewConfig("")
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal("overridden-default"))
+
+		// Make sure that _OVERRIDE is loaded even when CONTAINERS_CONF is set.
+		os.Setenv("CONTAINERS_CONF", "testdata/containers_default.conf")
+		defer os.Unsetenv("CONTAINERS_CONF")
+		config, err = NewConfig("")
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal("overridden-default"))
+		gomega.Expect(config.Containers.BaseHostsFile).To(gomega.Equal("/etc/hosts2"))
+	})
 })


### PR DESCRIPTION
Add yet another environment variable for loading containers.conf. When CONTAINERS_CONF_OVERRIDE is set, the specified config file will be loaded last - even when CONTAINERS_CONF is set.

This mechanism is needed to preserve system settings and other environment variables.  Setting CONTAINERS_CONF will load only the specified config file and ignore all system and user paths. That makes testing hard as many Podman tests use CONTAINERS_CONF for testing.

The intended use of CONTAINERS_CONF_OVERRIDE is to set it during tests and point it to a specific configuration of Podman (e.g., netavark with sqlite backend).

Similar needs have popped up talking to users in the automotive and high-performance computing space.  In a way, such a setting allows for specifying a specific "flavor" of Podman while preserving all existing settings on the system.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
