### PR TITLE
[release-v0.51] netavark,NetworkUpdate: `NetworkUpdateOptions` must be IP addresses

### DIFF
--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -57,6 +57,17 @@ func (n *netavarkNetwork) NetworkUpdate(name string, options types.NetworkUpdate
 	if err != nil {
 		return err
 	}
+	// Nameservers must be IP Addresses.
+	for _, dnsServer := range options.AddDNSServers {
+		if net.ParseIP(dnsServer) == nil {
+			return fmt.Errorf("unable to parse ip %s specified in AddDNSServer: %w", dnsServer, types.ErrInvalidArg)
+		}
+	}
+	for _, dnsServer := range options.RemoveDNSServers {
+		if net.ParseIP(dnsServer) == nil {
+			return fmt.Errorf("unable to parse ip %s specified in RemoveDNSServer: %w", dnsServer, types.ErrInvalidArg)
+		}
+	}
 	networkDNSServersBefore := network.NetworkDNSServers
 	networkDNSServersAfter := []string{}
 	for _, server := range networkDNSServersBefore {

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -666,6 +666,8 @@ var _ = Describe("Config", func() {
 			testNetwork, err := libpodNet.NetworkInspect("test-network")
 			Expect(err).To(BeNil())
 			Expect(testNetwork.NetworkDNSServers).To(Equal([]string{"8.8.8.8", "3.3.3.3", "7.7.7.7"}))
+			err = libpodNet.NetworkUpdate("test-network", types.NetworkUpdateOptions{AddDNSServers: []string{"fake"}})
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("update NetworkDNSServers RemoveDNSServers", func() {
@@ -690,6 +692,8 @@ var _ = Describe("Config", func() {
 			testNetwork, err := libpodNet.NetworkInspect("test-network")
 			Expect(err).To(BeNil())
 			Expect(testNetwork.NetworkDNSServers).To(Equal([]string{"8.8.8.8"}))
+			err = libpodNet.NetworkUpdate("test-network", types.NetworkUpdateOptions{RemoveDNSServers: []string{"fake"}})
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("update NetworkDNSServers Add and Remove DNSServers", func() {


### PR DESCRIPTION
We enforced NetworkDNSServers to be IP addresses and we follow this enfore rule while a user is creating network, see comment https://github.com/containers/common/pull/1237#pullrequestreview-1188001727 and PR https://github.com/containers/common/pull/1237

Following check was missed in `NetworkUpdateOptions` hence add this check now.

Backport of: https://github.com/containers/common/pull/1358

Bugzilla: **BZ#2182897** RHEL 8.8 and RHEL 9.2 **BZ#2182898**