### PR TITLE
libnetwork/netavark: error messages should start lower case

### DIFF
--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -217,12 +217,12 @@ func (n *netavarkNetwork) networkCreate(newNetwork *types.Network, defaultNet bo
 
 	// process NetworkDNSServers
 	if len(newNetwork.NetworkDNSServers) > 0 && !newNetwork.DNSEnabled {
-		return nil, fmt.Errorf("Cannot set NetworkDNSServers if DNS is not enabled for the network: %w", types.ErrInvalidArg)
+		return nil, fmt.Errorf("cannot set NetworkDNSServers if DNS is not enabled for the network: %w", types.ErrInvalidArg)
 	}
 	// validate ip address
 	for _, dnsServer := range newNetwork.NetworkDNSServers {
 		if net.ParseIP(dnsServer) == nil {
-			return nil, fmt.Errorf("Unable to parse ip %s specified in NetworkDNSServers: %w", dnsServer, types.ErrInvalidArg)
+			return nil, fmt.Errorf("unable to parse ip %s specified in NetworkDNSServers: %w", dnsServer, types.ErrInvalidArg)
 		}
 	}
 

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -775,7 +775,7 @@ var _ = Describe("Config", func() {
 			}
 			_, err := libpodNet.NetworkCreate(network, nil)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(`Unable to parse ip a.b.c.d`))
+			Expect(err.Error()).To(ContainSubstring(`unable to parse ip a.b.c.d`))
 		})
 
 		It("create network with NetworDNSServers with DNSEnabled=false", func() {
@@ -785,7 +785,7 @@ var _ = Describe("Config", func() {
 			}
 			_, err := libpodNet.NetworkCreate(network, nil)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(`Cannot set NetworkDNSServers if DNS is not enabled for the network`))
+			Expect(err.Error()).To(ContainSubstring(`cannot set NetworkDNSServers if DNS is not enabled for the network`))
 		})
 
 		It("create network with labels", func() {


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
