### PR TITLE
Add kube_generate_type to set default for kube generate

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -540,6 +540,10 @@ reserving the pod's resources for the lifetime of the pod. By default container
 engines run a built-in container using the pause executable. If you want override
 specify an image to pull.
 
+**kube_generate_type**="pod"
+
+Default Kubernetes kind/specification of the kubernetes yaml generated with the `podman kube generate` command. The possible options are `pod` and `deployment`.
+
 **lock_type**="shm"
 
 Specify the locking mechanism to use; valid values are "shm" and "file".

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -337,6 +337,10 @@ type EngineConfig struct {
 	// InitPath is the path to the container-init binary.
 	InitPath string `toml:"init_path,omitempty"`
 
+	// KubeGenerateType sets the Kubernetes kind/specification to generate by default
+	// with the podman kube generate command
+	KubeGenerateType string `toml:"kube_generate_type,omitempty"`
+
 	// LockType is the type of locking to use.
 	LockType string `toml:"lock_type,omitempty"`
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -444,6 +444,7 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(dbBackend).To(gomega.BeEquivalentTo(DBBackendSQLite))
 			gomega.Expect(config.Containers.CgroupConf).To(gomega.Equal(cgroupConf))
 			gomega.Expect(*config.Containers.OOMScoreAdj).To(gomega.Equal(int(750)))
+			gomega.Expect(config.Engine.KubeGenerateType).To(gomega.Equal("pod"))
 		})
 
 		It("contents of passed-in file should override others", func() {

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -480,6 +480,10 @@ default_sysctls = [
 #
 #infra_image = ""
 
+# Default Kubernetes kind/specification of the kubernetes yaml generated with the `podman kube generate` command.
+# The possible options are `pod` and `deployment`.
+#kube_generate_type = "pod"
+
 # Specify the locking mechanism to use; valid values are "shm" and "file".
 # Change the default only if you are sure of what you are doing, in general
 # "file" is useful only on platforms where cgo is not available for using the

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -202,6 +202,9 @@ infra_image = "k8s.gcr.io/pause:3.4.1"
 # Default command to run the infra container
 infra_command = "/pause"
 
+# Default k8s kind/type to generate with `podman kube generate`
+kube_generate_type = "pod"
+
 # Number of seconds to wait without a connection
 # before the `podman system service` times out and exits
 #


### PR DESCRIPTION
The kube_generate_type field can be used to set what kind of k8s object, i.e pod or deployment, that the podman kube generate command should generate by default.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
