### PR TITLE
GHA: Use version numbers instead of digests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,7 +17,7 @@ jobs:
   codespell:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3
+    - uses: actions/checkout@v3
     - name: install deps
       # Version of codespell bundled with Ubuntu is way old, so use pip.
       run: pip install codespell
@@ -26,10 +26,10 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
-    - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v3
+    - uses: actions/setup-go@v3
       with:
         go-version: 1.19
     - name: install deps
@@ -37,7 +37,7 @@ jobs:
         sudo apt-get -qq update
         sudo apt-get -qq install libseccomp-dev libdevmapper-dev
     - name: lint
-      uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc # v3
+      uses: golangci/golangci-lint-action@v3
       with:
         version: "${{ env.LINT_VERSION }}"
         only-new-issues: true
@@ -46,7 +46,7 @@ jobs:
     - name: Extra golangci-lint config. switcharoo
       run: mv .golangci-extra.yml golangci.yml
     - name: lint-extra
-      uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc # v3
+      uses: golangci/golangci-lint-action@v3
       with:
         version: "${{ env.LINT_VERSION }}"
         only-new-issues: true


### PR DESCRIPTION
Digest-based references are technically safer, however they're more difficult to manage and harder on the eyes.  The safety-benefits for high-traffic actions is also likely overstated.  Switch back to using simple version numbers.

Fixes: #1407 