### PR TITLE
pkg/auth: fix nil deref

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -242,14 +242,19 @@ func replaceURLByHostPort(repository string) (string, error) {
 // using the -u and -p flags.  If the username prompt is left empty, the
 // displayed userFromAuthFile will be used instead.
 func getUserAndPass(opts *LoginOptions, password, userFromAuthFile string) (user, pass string, err error) {
-	reader := bufio.NewReader(opts.Stdin)
 	username := opts.Username
 	if username == "" {
+		if opts.Stdin == nil {
+			return "", "", fmt.Errorf("cannot prompt for username without stdin")
+		}
+
 		if userFromAuthFile != "" {
 			fmt.Fprintf(opts.Stdout, "Username (%s): ", userFromAuthFile)
 		} else {
 			fmt.Fprint(opts.Stdout, "Username: ")
 		}
+
+		reader := bufio.NewReader(opts.Stdin)
 		username, err = reader.ReadString('\n')
 		if err != nil {
 			return "", "", fmt.Errorf("reading username: %w", err)


### PR DESCRIPTION
```
github.com/containers/podman/pkg/api/server.panicHandler.func1.1.1()
        /builddir/build/BUILD/containers-podman-05037d3/_build/src/github.com/containers/podman/pkg/api/server/handler_panic.go:22 +0x85
panic({0x55b681f5a640, 0x55b682d5e370})
        /usr/lib/golang/src/runtime/panic.go:884 +0x212
bufio.(*Reader).fill(0xc00075cd98)
        /usr/lib/golang/src/bufio/bufio.go:106 +0xd8
bufio.(*Reader).ReadSlice(0xc00075cd98, 0xc8?)
        /usr/lib/golang/src/bufio/bufio.go:372 +0x2f
bufio.(*Reader).collectFragments(0x55b6807917e9?, 0xa0?)
        /usr/lib/golang/src/bufio/bufio.go:447 +0x71
bufio.(*Reader).ReadString(0x55b682188240?, 0x80?)
        /usr/lib/golang/src/bufio/bufio.go:495 +0x2b
github.com/containers/podman/vendor/github.com/containers/common/pkg/auth.getUserAndPass(0xc00075d110, {0xc00084e370, 0x3}, {0x0, 0x0})
        /builddir/build/BUILD/containers-podman-05037d3/_build/src/github.com/containers/podman/vendor/github.com/containers/common/pkg/auth/auth.go:253 +0x29d
```

Reported-by: Alex Jia <ajia@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

@mtrmac @rhatdan PTAL