### PR TITLE
[CI:DOCS] containers.conf: database_backend

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -430,6 +430,12 @@ conmon_path=[
 ]
 ```
 
+**database_backend**="boltdb"
+
+The database backend of Podman.  Supported values are "boltdb" (default) and
+"sqlite". Please run `podman-system-reset` prior to changing the database
+backend of an existing deployment, to make sure Podman can operate correctly.
+
 **detach_keys**="ctrl-p,ctrl-q"
 
 Keys sequence used for detaching a container.

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -392,6 +392,11 @@ default_sysctls = [
 # short-name aliases defined in containers-registries.conf(5).
 #compat_api_enforce_docker_hub = true
 
+# The database backend of Podman.  Supported values are "boltdb" (default) and
+# "sqlite". Please run `podman-system-reset` prior to changing the database
+# backend of an existing deployment, to make sure Podman can operate correctly.
+#database_backend="boltdb"
+
 # Specify the keys sequence used to detach a container.
 # Format is a single character [a-Z] or a comma separated sequence of
 # `ctrl-<value>`, where `<value>` is one of:

--- a/pkg/config/containers.conf-freebsd
+++ b/pkg/config/containers.conf-freebsd
@@ -29,6 +29,11 @@
 #
 #base_hosts_file = ""
 
+# The database backend of Podman.  Supported values are "boltdb" (default) and
+# "sqlite". Please run `podman-system-reset` prior to changing the database
+# backend of an existing deployment, to make sure Podman can operate correctly.
+#database_backend="boltdb"
+
 # List of default capabilities for containers. If it is empty or commented out,
 # the default capabilities defined in the container engine will be added.
 #


### PR DESCRIPTION
Document the `database_backend` option which has been added earlier but intentionally left undocumented to avoid the impression sqlite would be ready for prime-time.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

@mheon @baude @giuseppe PTAL