### PR TITLE
pkg/sysinfo: unify NumCPU implementations

### DIFF
--- a/pkg/sysinfo/numcpu.go
+++ b/pkg/sysinfo/numcpu.go
@@ -1,13 +1,13 @@
-//go:build !linux && !windows
-// +build !linux,!windows
-
 package sysinfo
 
-import (
-	"runtime"
-)
+import "runtime"
 
-// NumCPU returns the number of CPUs
+// NumCPU returns the number of CPUs. On Linux and Windows, it returns
+// the number of CPUs which are currently online. On other platforms,
+// it returns [runtime.NumCPU].
 func NumCPU() int {
+	if ncpu := numCPU(); ncpu > 0 {
+		return ncpu
+	}
 	return runtime.NumCPU()
 }

--- a/pkg/sysinfo/numcpu_linux.go
+++ b/pkg/sysinfo/numcpu_linux.go
@@ -4,7 +4,6 @@
 package sysinfo
 
 import (
-	"runtime"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -33,12 +32,4 @@ func numCPU() int {
 		ncpu += int(popcnt(uint64(e)))
 	}
 	return ncpu
-}
-
-// NumCPU returns the number of CPUs which are currently online
-func NumCPU() int {
-	if ncpu := numCPU(); ncpu > 0 {
-		return ncpu
-	}
-	return runtime.NumCPU()
 }

--- a/pkg/sysinfo/numcpu_other.go
+++ b/pkg/sysinfo/numcpu_other.go
@@ -1,0 +1,10 @@
+//go:build !linux && !windows
+// +build !linux,!windows
+
+package sysinfo
+
+import "runtime"
+
+func numCPU() int {
+	return runtime.NumCPU()
+}

--- a/pkg/sysinfo/numcpu_windows.go
+++ b/pkg/sysinfo/numcpu_windows.go
@@ -4,7 +4,6 @@
 package sysinfo
 
 import (
-	"runtime"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -27,12 +26,4 @@ func numCPU() int {
 	// For every available thread a bit is set in the mask.
 	ncpu := int(popcnt(uint64(mask)))
 	return ncpu
-}
-
-// NumCPU returns the number of CPUs which are currently online
-func NumCPU() int {
-	if ncpu := numCPU(); ncpu > 0 {
-		return ncpu
-	}
-	return runtime.NumCPU()
 }


### PR DESCRIPTION
Use a single `NumCPU` implementation, so that the godoc string and the fallback to `runtime.NumCPU` can be maintained in one place.
