### PR TITLE
Use functions from x/sys/unix in numCPU on Linux

### DIFF
--- a/pkg/sysinfo/numcpu_linux.go
+++ b/pkg/sysinfo/numcpu_linux.go
@@ -3,11 +3,7 @@
 
 package sysinfo
 
-import (
-	"unsafe"
-
-	"golang.org/x/sys/unix"
-)
+import "golang.org/x/sys/unix"
 
 // numCPU queries the system for the count of threads available
 // for use to this process.
@@ -16,20 +12,12 @@ import (
 // Returns 0 on errors. Use |runtime.NumCPU| in that case.
 func numCPU() int {
 	// Gets the affinity mask for a process: The very one invoking this function.
-	pid, _, _ := unix.RawSyscall(unix.SYS_GETPID, 0, 0, 0)
+	pid := unix.Getpid()
 
-	var mask [1024 / 64]uintptr
-	_, _, err := unix.RawSyscall(unix.SYS_SCHED_GETAFFINITY, pid, uintptr(len(mask)*8), uintptr(unsafe.Pointer(&mask[0])))
-	if err != 0 {
+	var mask unix.CPUSet
+	err := unix.SchedGetaffinity(pid, &mask)
+	if err != nil {
 		return 0
 	}
-	// For every available thread a bit is set in the mask.
-	ncpu := 0
-	for _, e := range mask {
-		if e == 0 {
-			continue
-		}
-		ncpu += int(popcnt(uint64(e)))
-	}
-	return ncpu
+	return mask.Count()
 }


### PR DESCRIPTION
Use `Getpid` and `SchedGetaffinity` from `golang.org/x/sys/unix` to get the number of CPUs in `numCPU` on Linux.

