### PR TITLE
Bump v0.53.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.53.0"
+const Version = "0.54.0-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.53.0-dev"
+const Version = "0.53.0"


### PR DESCRIPTION
We require a new version to be able to use the new umask API. Therefore I'm proposing to bump to v0.53.0 (and v0.54.0-dev) in a second commit.