### PR TITLE
pkg/sysinfo: omit Getpid call in numCPU

### DIFF
--- a/pkg/sysinfo/numcpu_linux.go
+++ b/pkg/sysinfo/numcpu_linux.go
@@ -8,14 +8,11 @@ import "golang.org/x/sys/unix"
 // numCPU queries the system for the count of threads available
 // for use to this process.
 //
-// Issues two syscalls.
 // Returns 0 on errors. Use |runtime.NumCPU| in that case.
 func numCPU() int {
 	// Gets the affinity mask for a process: The very one invoking this function.
-	pid := unix.Getpid()
-
 	var mask unix.CPUSet
-	err := unix.SchedGetaffinity(pid, &mask)
+	err := unix.SchedGetaffinity(0, &mask)
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
The man page for sched_setaffinity(2) states the following about the pid argument [1]:

> If pid is zero, then the mask of the calling thread is returned.

Thus the additional call to unix.Getpid can be omitted and pid = 0 passed to unix.SchedGetaffinity.

[1] https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html#DESCRIPTION
