### PR TITLE
pkg/subscription: fix regression in saveTo()

### DIFF
--- a/pkg/subscriptions/subscriptions_test.go
+++ b/pkg/subscriptions/subscriptions_test.go
@@ -1,0 +1,32 @@
+package subscriptions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadAllAndSaveTo(t *testing.T) {
+	const testMode = os.FileMode(0o700)
+
+	rootDir := t.TempDir()
+	childDir := filepath.Join(rootDir, "child")
+	err := os.Mkdir(childDir, testMode)
+	assert.NoError(t, err, "mkdir child")
+
+	filePath := "child/file"
+	err = os.WriteFile(filepath.Join(rootDir, filePath), []byte("test"), testMode)
+	assert.NoError(t, err, "write file")
+
+	data, err := readAll(rootDir, "", testMode)
+	assert.NoError(t, err, "readAll")
+	assert.Len(t, data, 1, "readAll should return one result")
+
+	tmpDir := t.TempDir()
+	err = data[0].saveTo(tmpDir)
+	assert.NoError(t, err, "saveTo()")
+
+	assert.FileExists(t, filepath.Join(tmpDir, filePath), "file exists at correct location")
+}


### PR DESCRIPTION
The name is actually a relative path, so rename the field to make it clear add add comments + test to prevent future people from making the same mistake.

Regression was caught in podman CI:
https://github.com/containers/podman/pull/18350

Fixes d4a3de3a ("Don't call `umask` in subscriptions")

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
