### PR TITLE
Add support for confined SELinux users

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -208,6 +208,13 @@ the container.
 
 Indicates whether the container engine uses MAC(SELinux) container separation via labeling. This option is ignored on disabled systems.
 
+label_users=false
+
+label_users indicates whether to enforce confined users in containers on
+SELinux systems. This option causes containers to maintain the current user
+and role field of the calling process. By default SELinux containers run with
+the user system_u, and the role system_r.
+
 **log_driver**=""
 
 Logging driver for the container. Currently available options are k8s-file, journald, none and passthrough, with json-file aliased to k8s-file for scripting compatibility.  The journald driver is used by default if the systemd journal is readable and writable.  Otherwise, the k8s-file driver is used.

--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -208,7 +208,7 @@ the container.
 
 Indicates whether the container engine uses MAC(SELinux) container separation via labeling. This option is ignored on disabled systems.
 
-label_users=false
+**label_users**=false
 
 label_users indicates whether to enforce confined users in containers on
 SELinux systems. This option causes containers to maintain the current user

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -143,6 +143,12 @@ type ContainersConfig struct {
 	// Labeling to separate containers (SELinux)
 	EnableLabeling bool `toml:"label,omitempty"`
 
+	// EnableLabeledUsers indicates whether to enforce confined users with
+	// containers on SELinux systems. This option causes containers to
+	// maintain the current user and role field of the calling process.
+	// Otherwise containers run with user system_u, and the role system_r.
+	EnableLabeledUsers bool `toml:"label_users,omitempty"`
+
 	// Env is the environment variable list for container process.
 	Env []string `toml:"env,omitempty"`
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -109,6 +109,7 @@ var _ = Describe("Config", func() {
 			defaultConfig, _ := NewConfig("")
 			// EnableLabeling should match whether or not SELinux is enabled on the host
 			gomega.Expect(defaultConfig.Containers.EnableLabeling).To(gomega.Equal(selinux.GetEnabled()))
+			gomega.Expect(defaultConfig.Containers.EnableLabeledUsers).To(gomega.BeFalse())
 		})
 	})
 
@@ -932,5 +933,6 @@ env=["foo=bar"]`
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal("overridden-default"))
 		gomega.Expect(config.Containers.BaseHostsFile).To(gomega.Equal("/etc/hosts2"))
+		gomega.Expect(config.Containers.EnableLabeledUsers).To(gomega.BeTrue())
 	})
 })

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -173,6 +173,12 @@ default_sysctls = [
 #
 #label = true
 
+# label_users indicates whether to enforce confined users in containers on
+# SELinux systems. This option causes containers to maintain the current user
+# and role field of the calling process. By default SELinux containers run with
+# the user system_u, and the role system_r.
+#label_users = false
+
 # Logging driver for the container. Available options: k8s-file and journald.
 #
 #log_driver = "k8s-file"

--- a/pkg/config/testdata/containers_override.conf
+++ b/pkg/config/testdata/containers_override.conf
@@ -5,6 +5,7 @@ log_driver = "journald"
 log_tag="{{.Name}}|{{.ID}}"
 log_size_max = 100000
 read_only=true
+label_users=true
 
 [engine]
 image_parallel_copies=10


### PR DESCRIPTION
The original SELinux support in Docker and Podman does not follow the default SELinux rules for how label transitions are supposed to be handled. Containers always switch their user and role to system_u:system_r, rather then maintain the collers user and role. For example
unconfined_u:unconfined_r:container_t:s0:c1,c2

Advanced SELinux administrators want to confine users but still allow them to create containers from their role, but not allow them to launch a privileged container like spc_t.

This means if a user running as
container_user_u:container_user_r:container_user_t:s0

Ran a container they would get

container_user_u:container_user_r:container_t:s0:c1,c2

If they run a privileged container they would run it with:

container_user_u:container_user_r:container_user_t:s0

If they want to force the label they would get an error

podman run --security-opt label=type:spc_t ...

Should fail. Because the container_user_r can not run with the spc_t.

SELinux rules would also prevent the user from forcing system_u user and the sytem_r role.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
