### PR TITLE
docs: containers.conf: CHROOT

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -111,8 +111,7 @@ default_capabilities = [
 ```
 
 Note, by default container engines using containers.conf, run with less
-capabilities than Docker. Docker runs additionally with "AUDIT_WRITE", "MKNOD",
-"NET_RAW", "CHROOT". If you need to add one of these capabilities for a
+capabilities than Docker. Docker runs additionally with "AUDIT_WRITE", "MKNOD" and "NET_RAW". If you need to add one of these capabilities for a
 particular container, you can use the --cap-add option or edit your system's containers.conf.
 
 **default_sysctls**=[]


### PR DESCRIPTION
Correct a sentence stating that Podman would not run with CHROOT. It only did for a short period of time but CHROOT had to be added back since many uses (e.g., in-container builds) depend on it.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

PTAL @Luap99 @giuseppe @flouthoc 