### PR TITLE
libnetwork: add NetworkInfo() for get network information

### DIFF
--- a/libnetwork/netavark/network.go
+++ b/libnetwork/netavark/network.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containers/common/libnetwork/internal/util"
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/pkg/config"
+	cutil "github.com/containers/common/pkg/util"
 	"github.com/containers/storage/pkg/lockfile"
 	"github.com/containers/storage/pkg/unshare"
 	"github.com/sirupsen/logrus"
@@ -334,6 +335,37 @@ func (n *netavarkNetwork) Len() int {
 // DefaultInterfaceName return the default cni bridge name, must be suffixed with a number.
 func (n *netavarkNetwork) DefaultInterfaceName() string {
 	return defaultBridgeName
+}
+
+// NetworkInfo return the network information about binary path,
+// package version and program version.
+func (n *netavarkNetwork) NetworkInfo() types.NetworkInfo {
+	path := n.netavarkBinary
+	packageVersion := cutil.PackageVersion(path)
+	programVersion, err := cutil.ProgramVersion(path)
+	if err != nil {
+		logrus.Infof("Failed to get the netavark version: %v", err)
+	}
+	info := types.NetworkInfo{
+		Backend: types.Netavark,
+		Version: programVersion,
+		Package: packageVersion,
+		Path:    path,
+	}
+
+	dnsPath := n.aardvarkBinary
+	dnsPackage := cutil.PackageVersion(dnsPath)
+	dnsProgram, err := cutil.ProgramVersion(dnsPath)
+	if err != nil {
+		logrus.Infof("Failed to get the aardvark version: %v", err)
+	}
+	info.DNS = types.DNSNetworkInfo{
+		Package: dnsPackage,
+		Path:    dnsPath,
+		Version: dnsProgram,
+	}
+
+	return info
 }
 
 func (n *netavarkNetwork) Network(nameOrID string) (*types.Network, error) {

--- a/libnetwork/types/network.go
+++ b/libnetwork/types/network.go
@@ -34,6 +34,10 @@ type ContainerNetwork interface {
 	// DefaultNetworkName will return the default network name
 	// for this interface.
 	DefaultNetworkName() string
+
+	// NetworkInfo return the network information about backend type,
+	// binary path, package version and so on.
+	NetworkInfo() NetworkInfo
 }
 
 // Network describes the Network attributes.
@@ -78,6 +82,22 @@ type NetworkUpdateOptions struct {
 	// Priority order will be kept as defined by user in the configuration.
 	AddDNSServers    []string `json:"add_dns_servers,omitempty"`
 	RemoveDNSServers []string `json:"remove_dns_servers,omitempty"`
+}
+
+// NetworkInfo contains the network information.
+type NetworkInfo struct {
+	Backend NetworkBackend `json:"backend"`
+	Version string         `json:"version,omitempty"`
+	Package string         `json:"package,omitempty"`
+	Path    string         `json:"path,omitempty"`
+	DNS     DNSNetworkInfo `json:"dns,omitempty"`
+}
+
+// NetworkInfo contains the DNS information.
+type DNSNetworkInfo struct {
+	Version string `json:"version,omitempty"`
+	Package string `json:"package,omitempty"`
+	Path    string `json:"path,omitempty"`
 }
 
 // IPNet is used as custom net.IPNet type to add Marshal/Unmarshal methods.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,6 +1,94 @@
 package util
 
-import "regexp"
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+const (
+	UnknownPackage = "Unknown"
+)
+
+// Note: This function is copied from containers/podman libpod/util.go
+// Please see https://github.com/containers/common/pull/1460
+func queryPackageVersion(cmdArg ...string) string {
+	output := UnknownPackage
+	if 1 < len(cmdArg) {
+		cmd := exec.Command(cmdArg[0], cmdArg[1:]...)
+		if outp, err := cmd.Output(); err == nil {
+			output = string(outp)
+			if cmdArg[0] == "/usr/bin/dpkg" {
+				r := strings.Split(output, ": ")
+				queryFormat := `${Package}_${Version}_${Architecture}`
+				cmd = exec.Command("/usr/bin/dpkg-query", "-f", queryFormat, "-W", r[0])
+				if outp, err := cmd.Output(); err == nil {
+					output = string(outp)
+				}
+			}
+		}
+		if cmdArg[0] == "/sbin/apk" {
+			prefix := cmdArg[len(cmdArg)-1] + " is owned by "
+			output = strings.Replace(output, prefix, "", 1)
+		}
+	}
+	return strings.Trim(output, "\n")
+}
+
+// Note: This function is copied from containers/podman libpod/util.go
+// Please see https://github.com/containers/common/pull/1460
+func PackageVersion(program string) string { // program is full path
+	packagers := [][]string{
+		{"/usr/bin/rpm", "-q", "-f"},
+		{"/usr/bin/dpkg", "-S"},                // Debian, Ubuntu
+		{"/usr/bin/pacman", "-Qo"},             // Arch
+		{"/usr/bin/qfile", "-qv"},              // Gentoo (quick)
+		{"/usr/bin/equery", "b"},               // Gentoo (slow)
+		{"/sbin/apk", "info", "-W"},            // Alpine
+		{"/usr/local/sbin/pkg", "which", "-q"}, // FreeBSD
+	}
+
+	for _, cmd := range packagers {
+		cmd = append(cmd, program)
+		if out := queryPackageVersion(cmd...); out != UnknownPackage {
+			return out
+		}
+	}
+	return UnknownPackage
+}
+
+// Note: This function is copied from containers/podman libpod/util.go
+// Please see https://github.com/containers/common/pull/1460
+func ProgramVersion(program string) (string, error) {
+	return programVersion(program, false)
+}
+
+func ProgramVersionDnsname(program string) (string, error) {
+	return programVersion(program, true)
+}
+
+func programVersion(program string, dnsname bool) (string, error) {
+	cmd := exec.Command(program, "--version")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("`%v --version` failed: %v %v (%v)", program, stderr.String(), stdout.String(), err)
+	}
+
+	output := strings.TrimSuffix(stdout.String(), "\n")
+	// dnsname --version returns the information to stderr
+	if dnsname {
+		output = strings.TrimSuffix(stderr.String(), "\n")
+	}
+
+	return output, nil
+}
 
 // StringInSlice determines if a string is in a string slice, returns bool
 func StringInSlice(s string, sl []string) bool {


### PR DESCRIPTION
`NetworkInfo()` return the network binary path,
package version and program version.


Related to https://github.com/containers/podman/pull/18383
<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
