### PR TITLE
Fix indentation for the containers.conf

### DIFF
--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -314,9 +314,9 @@ default_sysctls = [
 #
 #netavark_plugin_dirs = [
 #  "/usr/local/libexec/netavark",
-#	 "/usr/libexec/netavark",
-#	 "/usr/local/lib/netavark",
-#	 "/usr/lib/netavark",
+#  "/usr/libexec/netavark",
+#  "/usr/local/lib/netavark",
+#  "/usr/lib/netavark",
 #]
 
 # The network name of the default network to attach pods to.


### PR DESCRIPTION
Fix the indentation of netavark_plugin_dirs
in the containers.conf

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
