### PR TITLE
netavark: add bclim option for macvlan

### DIFF
--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -337,6 +337,17 @@ func createIpvlanOrMacvlan(network *types.Network) error {
 			}
 			// rust only support "true" or "false" while go can parse 1 and 0 as well so we need to change it
 			network.Options[types.NoDefaultRoute] = strconv.FormatBool(val)
+		case types.BclimOption:
+			if isMacVlan {
+				_, err := strconv.ParseInt(value, 10, 32)
+				if err != nil {
+					return fmt.Errorf("failed to parse %q option: %w", key, err)
+				}
+				// do not fallthrough for macvlan
+				break
+			}
+			// bclim is only valid for macvlan not ipvlan so fallthrough to error case
+			fallthrough
 		default:
 			return fmt.Errorf("unsupported %s network option %s", driver, key)
 		}

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -1102,6 +1102,68 @@ var _ = Describe("Config", func() {
 			Expect(network1.IPAMOptions).To(HaveKeyWithValue("driver", "host-local"))
 		})
 
+		It("create macvlan config with bclim", func() {
+			subnet := "10.1.0.0/24"
+			n, _ := types.ParseCIDR(subnet)
+			network := types.Network{
+				Driver: "macvlan",
+				Subnets: []types.Subnet{
+					{Subnet: n},
+				},
+				Options: map[string]string{
+					types.BclimOption: "-1",
+				},
+			}
+			network1, err := libpodNet.NetworkCreate(network, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(network1.Name).ToNot(BeEmpty())
+			Expect(network1.Options).To(HaveKeyWithValue("bclim", "-1"))
+
+			network = types.Network{
+				Driver: "macvlan",
+				Subnets: []types.Subnet{
+					{Subnet: n},
+				},
+				Options: map[string]string{
+					types.BclimOption: "1000",
+				},
+			}
+			network1, err = libpodNet.NetworkCreate(network, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(network1.Name).ToNot(BeEmpty())
+			Expect(network1.Options).To(HaveKeyWithValue("bclim", "1000"))
+
+			network = types.Network{
+				Driver: "macvlan",
+				Subnets: []types.Subnet{
+					{Subnet: n},
+				},
+				Options: map[string]string{
+					types.BclimOption: "abc",
+				},
+			}
+			_, err = libpodNet.NetworkCreate(network, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("failed to parse \"bclim\" option: strconv.ParseInt: parsing \"abc\": invalid syntax"))
+		})
+
+		It("create ipvlan config with bclim should fail", func() {
+			subnet := "10.1.0.0/24"
+			n, _ := types.ParseCIDR(subnet)
+			network := types.Network{
+				Driver: "ipvlan",
+				Subnets: []types.Subnet{
+					{Subnet: n},
+				},
+				Options: map[string]string{
+					types.BclimOption: "-1",
+				},
+			}
+			_, err := libpodNet.NetworkCreate(network, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unsupported ipvlan network option bclim"))
+		})
+
 		It("create macvlan config with mode", func() {
 			subnet := "10.1.0.0/24"
 			n, _ := types.ParseCIDR(subnet)

--- a/libnetwork/types/const.go
+++ b/libnetwork/types/const.go
@@ -36,12 +36,13 @@ const (
 	IPVLANModeL3s = "l3s"
 
 	// valid network options
-	VLANOption    = "vlan"
-	MTUOption     = "mtu"
-	ModeOption    = "mode"
-	IsolateOption = "isolate"
-	MetricOption  = "metric"
+	VLANOption     = "vlan"
+	MTUOption      = "mtu"
+	ModeOption     = "mode"
+	IsolateOption  = "isolate"
+	MetricOption   = "metric"
 	NoDefaultRoute = "no_default_route"
+	BclimOption    = "bclim"
 )
 
 type NetworkBackend string


### PR DESCRIPTION
see https://github.com/containers/netavark/pull/698

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
