### PR TITLE
[CI:DOCS] Document disabling detach-keys

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -459,6 +459,7 @@ Specify the keys sequence used to detach a container.
 Format is a single character `[a-Z]` or a comma separated sequence of
 `ctrl-<value>`, where `<value>` is one of:
 `a-z`, `@`, `^`, `[`, `\`, `]`, `^` or `_`
+Specifying "" disables this feature.
 
 **enable_port_reservation**=true
 

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -419,7 +419,7 @@ default_sysctls = [
 # Format is a single character [a-Z] or a comma separated sequence of
 # `ctrl-<value>`, where `<value>` is one of:
 # `a-z`, `@`, `^`, `[`, `\`, `]`, `^` or `_`
-#
+# Specifying "" disables this feature.
 #detach_keys = "ctrl-p,ctrl-q"
 
 # Determines whether engine will reserve ports on the host when they are


### PR DESCRIPTION
https://github.com/containers/podman/issues/18708 points out that user did not understand how to disable detach-keys in containers.conf.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
