### PR TITLE
Relax name length restriction for Secrets/ConfigMaps.

### DIFF
--- a/pkg/configmaps/configmaps.go
+++ b/pkg/configmaps/configmaps.go
@@ -48,7 +48,7 @@ var errDataSize = errors.New("configmap data must be larger than 0 and less than
 var configMapsFile = "configmaps.json"
 
 // configMapNameRegexp matches valid configMap names
-// Allowed: 64 [a-zA-Z0-9-_.] characters, and the start and end character must be [a-zA-Z0-9]
+// Allowed: 253 [a-zA-Z0-9-_.] characters, and the start and end character must be [a-zA-Z0-9]
 var configMapNameRegexp = regexp.Delayed(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`)
 
 // ConfigMapManager holds information on handling configmaps
@@ -266,8 +266,8 @@ func (s *ConfigMapManager) LookupConfigMapData(nameOrID string) (*ConfigMap, []b
 
 // validateConfigMapName checks if the configMap name is valid.
 func validateConfigMapName(name string) error {
-	if !configMapNameRegexp.MatchString(name) || len(name) > 64 || strings.HasSuffix(name, "-") || strings.HasSuffix(name, ".") {
-		return fmt.Errorf("only 64 [a-zA-Z0-9-_.] characters allowed, and the start and end character must be [a-zA-Z0-9]: %s: %w", name, errInvalidConfigMapName)
+	if !configMapNameRegexp.MatchString(name) || len(name) > 253 || strings.HasSuffix(name, "-") || strings.HasSuffix(name, ".") {
+		return fmt.Errorf("only 253 [a-zA-Z0-9-_.] characters allowed, and the start and end character must be [a-zA-Z0-9]: %s: %w", name, errInvalidConfigMapName)
 	}
 	return nil
 }

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -50,7 +50,7 @@ var errDataSize = errors.New("secret data must be larger than 0 and less than 51
 var secretsFile = "secrets.json"
 
 // secretNameRegexp matches valid secret names
-// Allowed: 64 [a-zA-Z0-9-_.] characters, and the start and end character must be [a-zA-Z0-9]
+// Allowed: 253 [a-zA-Z0-9-_.] characters, and the start and end character must be [a-zA-Z0-9]
 var secretNameRegexp = regexp.Delayed(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`)
 
 // SecretsManager holds information on handling secrets
@@ -296,8 +296,8 @@ func (s *SecretsManager) LookupSecretData(nameOrID string) (*Secret, []byte, err
 
 // validateSecretName checks if the secret name is valid.
 func validateSecretName(name string) error {
-	if !secretNameRegexp.MatchString(name) || len(name) > 64 || strings.HasSuffix(name, "-") || strings.HasSuffix(name, ".") {
-		return fmt.Errorf("only 64 [a-zA-Z0-9-_.] characters allowed, and the start and end character must be [a-zA-Z0-9]: %s: %w", name, errInvalidSecretName)
+	if !secretNameRegexp.MatchString(name) || len(name) > 253 || strings.HasSuffix(name, "-") || strings.HasSuffix(name, ".") {
+		return fmt.Errorf("only 253 [a-zA-Z0-9-_.] characters allowed, and the start and end character must be [a-zA-Z0-9]: %s: %w", name, errInvalidSecretName)
 	}
 	return nil
 }


### PR DESCRIPTION
The Kubernetes documentation states that the name of these resources much be a DNS subdomain name, [which it defines](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names) as being up to 253 characters.

Following the referenced RFC it does appear that the name should be further restricted to require the 253 characters be made up of multiple of multiple 63-character labels separated by dots. The [Kubernetes validation code](https://github.com/kubernetes/apimachinery/blob/6b1428efc73348cc1c33935f3a39ab0f2f01d23d/pkg/util/validation/validation.go#L215
) does not apply this label restriction though, and will accept names longer than 63 characters.

This commit adjusts the length limits to match.