### PR TITLE
libimage: fix reference filters

### DIFF
--- a/libimage/filters_test.go
+++ b/libimage/filters_test.go
@@ -62,6 +62,7 @@ func TestFilterReference(t *testing.T) {
 		{"quay.io/libpod/*", 2},
 		{"busybox", 1},
 		{"alpine", 1},
+		{"alpine@" + alpine.Digest().String(), 1},
 	} {
 		listOptions := &ListImagesOptions{
 			Filters: []string{"reference=" + test.filter},


### PR DESCRIPTION
Make sure that reference filters properly work on digests as well. To keep things simple, try to lookup an image for the user-specified value and compare IDs.  This will implicitly fix #containers/podman/issues/18445 and probably more (unknown) issues.

Fixes: #containers/podman/issues/18445

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
