### PR TITLE
libnetwork: add pasta package to start pasta

### DIFF
--- a/libnetwork/pasta/pasta.go
+++ b/libnetwork/pasta/pasta.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	BinaryName = "passt"
+	BinaryName = "pasta"
 )
 
 type SetupOptions struct {
@@ -48,7 +48,7 @@ func Setup(opts *SetupOptions) error {
 	NoUDPNamespacePorts := true
 	NoMapGW := true
 
-	path, err := opts.Config.FindHelperBinary("pasta", true)
+	path, err := opts.Config.FindHelperBinary(BinaryName, true)
 	if err != nil {
 		return fmt.Errorf("could not find pasta, the network namespace can't be configured: %w", err)
 	}

--- a/libnetwork/pasta/pasta.go
+++ b/libnetwork/pasta/pasta.go
@@ -83,6 +83,9 @@ func Setup(opts *SetupOptions) error {
 		}
 	}
 
+	// first append options set in the config
+	cmdArgs = append(cmdArgs, opts.Config.Network.PastaOptions...)
+	// then append the ones that were set on the cli
 	cmdArgs = append(cmdArgs, opts.ExtraOptions...)
 
 	for i, opt := range cmdArgs {

--- a/libnetwork/pasta/pasta.go
+++ b/libnetwork/pasta/pasta.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// pasta.go - Start pasta(1) for user-mode connectivity
+//
+// Copyright (c) 2022 Red Hat GmbH
+// Author: Stefano Brivio <sbrivio@redhat.com>
+
+// This file has been imported from the podman repository
+// (libpod/networking_pasta_linux.go), for the full history see there.
+
+package pasta
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/containers/common/libnetwork/types"
+	"github.com/containers/common/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	BinaryName = "passt"
+)
+
+type SetupOptions struct {
+	// Config used to get pasta options and binary path via HelperBinariesDir
+	Config *config.Config
+	// Netns is the path to the container Netns
+	Netns string
+	// Ports that should be forwarded in the container
+	Ports []types.PortMapping
+	// ExtraOptions are pasta(1) cli options, these will be appended after the
+	// pasta options from containers.conf to allow some form of overwrite.
+	ExtraOptions []string
+}
+
+// Setup start the pasta process for the given netns.
+// The pasta binary is looked up in the HelperBinariesDir and $PATH.
+// Note that there is no need any special cleanup logic, the pasta process will
+// automatically exit when the netns path is deleted.
+func Setup(opts *SetupOptions) error {
+	NoTCPInitPorts := true
+	NoUDPInitPorts := true
+	NoTCPNamespacePorts := true
+	NoUDPNamespacePorts := true
+	NoMapGW := true
+
+	path, err := opts.Config.FindHelperBinary("pasta", true)
+	if err != nil {
+		return fmt.Errorf("could not find pasta, the network namespace can't be configured: %w", err)
+	}
+
+	cmdArgs := []string{}
+	cmdArgs = append(cmdArgs, "--config-net")
+
+	for _, i := range opts.Ports {
+		protocols := strings.Split(i.Protocol, ",")
+		for _, protocol := range protocols {
+			var addr string
+
+			if i.HostIP != "" {
+				addr = fmt.Sprintf("%s/", i.HostIP)
+			}
+
+			switch protocol {
+			case "tcp":
+				cmdArgs = append(cmdArgs, "-t")
+			case "udp":
+				cmdArgs = append(cmdArgs, "-u")
+			default:
+				return fmt.Errorf("can't forward protocol: %s", protocol)
+			}
+
+			arg := fmt.Sprintf("%s%d-%d:%d-%d", addr,
+				i.HostPort,
+				i.HostPort+i.Range-1,
+				i.ContainerPort,
+				i.ContainerPort+i.Range-1)
+			cmdArgs = append(cmdArgs, arg)
+		}
+	}
+
+	cmdArgs = append(cmdArgs, opts.ExtraOptions...)
+
+	for i, opt := range cmdArgs {
+		switch opt {
+		case "-t", "--tcp-ports":
+			NoTCPInitPorts = false
+		case "-u", "--udp-ports":
+			NoUDPInitPorts = false
+		case "-T", "--tcp-ns":
+			NoTCPNamespacePorts = false
+		case "-U", "--udp-ns":
+			NoUDPNamespacePorts = false
+		case "--map-gw":
+			NoMapGW = false
+			// not an actual pasta(1) option
+			cmdArgs = append(cmdArgs[:i], cmdArgs[i+1:]...)
+		}
+	}
+
+	if NoTCPInitPorts {
+		cmdArgs = append(cmdArgs, "-t", "none")
+	}
+	if NoUDPInitPorts {
+		cmdArgs = append(cmdArgs, "-u", "none")
+	}
+	if NoTCPNamespacePorts {
+		cmdArgs = append(cmdArgs, "-T", "none")
+	}
+	if NoUDPNamespacePorts {
+		cmdArgs = append(cmdArgs, "-U", "none")
+	}
+	if NoMapGW {
+		cmdArgs = append(cmdArgs, "--no-map-gw")
+	}
+
+	cmdArgs = append(cmdArgs, "--netns", opts.Netns)
+
+	logrus.Debugf("pasta arguments: %s", strings.Join(cmdArgs, " "))
+
+	// pasta forks once ready, and quits once we delete the target namespace
+	_, err = exec.Command(path, cmdArgs...).Output()
+	if err != nil {
+		return fmt.Errorf("failed to start pasta:\n%s",
+			err.(*exec.ExitError).Stderr)
+	}
+
+	return nil
+}

--- a/libnetwork/pasta/pasta.go
+++ b/libnetwork/pasta/pasta.go
@@ -11,6 +11,7 @@
 package pasta
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -124,8 +125,12 @@ func Setup(opts *SetupOptions) error {
 	// pasta forks once ready, and quits once we delete the target namespace
 	_, err = exec.Command(path, cmdArgs...).Output()
 	if err != nil {
-		return fmt.Errorf("failed to start pasta:\n%s",
-			err.(*exec.ExitError).Stderr)
+		exitErr := &exec.ExitError{}
+		if errors.As(err, &exitErr) {
+			return fmt.Errorf("pasta failed with exit code %d:\n%s",
+				exitErr.ExitCode(), exitErr.Stderr)
+		}
+		return fmt.Errorf("failed to start pasta: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Mostly copied from podman/libpod/networking_pasta_linux.go, this should
be moved to common so that we can use it in buildah as well.

I changed the function parameter to accept a single struct with all
options so that we can extend it when needed without breaking the API
The Container type is libpod/podman specific and not available here so
we only use the values we really need here.
Also I removed "pasta" from the function and constant name as this will
now be used as pasta.Setup() so it would be redundant.
