### PR TITLE
Add cwd argument for hooks exec Run func (API break-free version)

### DIFF
--- a/pkg/hooks/exec/exec.go
+++ b/pkg/hooks/exec/exec.go
@@ -16,16 +16,50 @@ import (
 // DefaultPostKillTimeout is the recommended default post-kill timeout.
 const DefaultPostKillTimeout = time.Duration(10) * time.Second
 
+type RunOptions struct {
+	// The hook to run
+	Hook *rspec.Hook
+	// The workdir to change when invoking the hook
+	Dir string
+	// The container state data to pass into the hook process
+	State []byte
+	// Stdout from the hook process
+	Stdout io.Writer
+	// Stderr from the hook process
+	Stderr io.Writer
+	// Timeout for waiting process killed
+	PostKillTimeout time.Duration
+}
+
 // Run executes the hook and waits for it to complete or for the
 // context or hook-specified timeout to expire.
+//
+// Deprecated: Too many arguments, has been refactored and replaced by RunWithOptions instead
 func Run(ctx context.Context, hook *rspec.Hook, state []byte, stdout io.Writer, stderr io.Writer, postKillTimeout time.Duration) (hookErr, err error) {
+	return RunWithOptions(
+		ctx,
+		RunOptions{
+			Hook:            hook,
+			State:           state,
+			Stdout:          stdout,
+			Stderr:          stderr,
+			PostKillTimeout: postKillTimeout,
+		},
+	)
+}
+
+// RunWithOptions executes the hook and waits for it to complete or for the
+// context or hook-specified timeout to expire.
+func RunWithOptions(ctx context.Context, options RunOptions) (hookErr, err error) {
+	hook := options.Hook
 	cmd := osexec.Cmd{
 		Path:   hook.Path,
 		Args:   hook.Args,
 		Env:    hook.Env,
-		Stdin:  bytes.NewReader(state),
-		Stdout: stdout,
-		Stderr: stderr,
+		Dir:    options.Dir,
+		Stdin:  bytes.NewReader(options.State),
+		Stdout: options.Stdout,
+		Stderr: options.Stderr,
 	}
 	if cmd.Env == nil {
 		cmd.Env = []string{}
@@ -57,11 +91,11 @@ func Run(ctx context.Context, hook *rspec.Hook, state []byte, stdout io.Writer, 
 		if err := cmd.Process.Kill(); err != nil {
 			logrus.Errorf("Failed to kill pid %v", cmd.Process)
 		}
-		timer := time.NewTimer(postKillTimeout)
+		timer := time.NewTimer(options.PostKillTimeout)
 		defer timer.Stop()
 		select {
 		case <-timer.C:
-			err = fmt.Errorf("failed to reap process within %s of the kill signal", postKillTimeout)
+			err = fmt.Errorf("failed to reap process within %s of the kill signal", options.PostKillTimeout)
 		case err = <-exit:
 		}
 		return err, ctx.Err()

--- a/pkg/hooks/exec/runtimeconfigfilter_test.go
+++ b/pkg/hooks/exec/runtimeconfigfilter_test.go
@@ -243,7 +243,7 @@ func TestRuntimeConfigFilter(t *testing.T) {
 				ctx, cancel = context.WithTimeout(ctx, test.contextTimeout)
 				defer cancel()
 			}
-			hookErr, err := RuntimeConfigFilter(ctx, test.hooks, test.input, DefaultPostKillTimeout)
+			hookErr, err := RuntimeConfigFilterWithOptions(ctx, RuntimeConfigFilterOptions{Hooks: test.hooks, Config: test.input, PostKillTimeout: DefaultPostKillTimeout})
 			if test.expectedRunErrorString != "" {
 				// We have to compare the error strings in that case because
 				// errors.Is works differently.


### PR DESCRIPTION
For fixing the wrong cwd bug in podman:

https://github.com/containers/podman/issues/18907

Basically this is the same as #1514, but instead of changing the signature of function, we create a new one with options struct and mark the old one as deprecated