### PR TITLE
layer tree: handle more errors

### DIFF
--- a/libimage/image.go
+++ b/libimage/image.go
@@ -402,7 +402,7 @@ func (i *Image) removeRecursive(ctx context.Context, rmMap map[string]*RemoveIma
 	// have a closer look at the errors.  On top, image removal should be
 	// tolerant toward corrupted images.
 	handleError := func(err error) error {
-		if errors.Is(err, storage.ErrImageUnknown) || errors.Is(err, storage.ErrNotAnImage) || errors.Is(err, storage.ErrLayerUnknown) {
+		if ErrorIsImageUnknown(err) {
 			// The image or layers of the image may already have been removed
 			// in which case we consider the image to be removed.
 			return nil


### PR DESCRIPTION
Commit 97961a6ad1df took a first stab at making operating on the layer
tree more resilient by detecting unknown-image errors.  Testing in
containers/podman/pull/18980 revealed that we also need to detect
unknown-layer and -size errors as well.

Move the errors checks into a convenience function and update the
relevant call sites to facilitate future changes.  Export the
function since Podman needs the very same checks when operating
on images, for instance, when looking up image labels.

