### PR TITLE
Change secrets Replace to modify the ID

### DIFF
--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -74,8 +74,8 @@ func TestAddSecretAndLookupData(t *testing.T) {
 	storeOpts.Replace = true
 	id2, err := manager.Store("mysecret", []byte("mydata"), drivertype, storeOpts)
 	require.NoError(t, err)
-	if id1 != id2 {
-		t.Errorf("error: secret id after Replace should be same")
+	if id1 == id2 {
+		t.Errorf("error: secret id after Replace should be different")
 	}
 
 	s, _, err = manager.LookupSecretData("mysecret")


### PR DESCRIPTION
We decided that podman secret create --replace should match behaviour of podman container create --replace, so the ID should change.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
