### PR TITLE
[v0.55] libimage: HasDifferentDigest: add InsecureSkipTLSVerify option

### DIFF
--- a/libimage/image.go
+++ b/libimage/image.go
@@ -806,6 +806,9 @@ type HasDifferentDigestOptions struct {
 	// containers-auth.json(5) file to use when authenticating against
 	// container registries.
 	AuthFilePath string
+	// Allow contacting registries over HTTP, or HTTPS with failed TLS
+	// verification. Note that this does not affect other TLS connections.
+	InsecureSkipTLSVerify types.OptionalBool
 }
 
 // HasDifferentDigest returns true if the image specified by `remoteRef` has a
@@ -831,8 +834,15 @@ func (i *Image) HasDifferentDigest(ctx context.Context, remoteRef types.ImageRef
 		sys.VariantChoice = inspectInfo.Variant
 	}
 
-	if options != nil && options.AuthFilePath != "" {
-		sys.AuthFilePath = options.AuthFilePath
+	if options != nil {
+		if options.AuthFilePath != "" {
+			sys.AuthFilePath = options.AuthFilePath
+		}
+		if options.InsecureSkipTLSVerify != types.OptionalBoolUndefined {
+			sys.DockerInsecureSkipTLSVerify = options.InsecureSkipTLSVerify
+			sys.OCIInsecureSkipTLSVerify = options.InsecureSkipTLSVerify == types.OptionalBoolTrue
+			sys.DockerDaemonInsecureSkipTLSVerify = options.InsecureSkipTLSVerify == types.OptionalBoolTrue
+		}
 	}
 
 	return i.hasDifferentDigestWithSystemContext(ctx, remoteRef, sys)


### PR DESCRIPTION
To fix a BZ on auto-updates, we need to improve the system tests. To improve the system tests, we need to use the existing test infrastructure.  To use the existing test infrastructure, we need to be able to skip TLS verification in tests.  To be able to skip TLS verification in the tests, we need a new --tls-verify flag for podman-auto-update.  And for that to work, we need a way to pass that down to libimage when checking if there's a new image on the registry.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2218315

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

@TomSweeneyRedHat @Luap99 PTAL
Needed to backport https://github.com/containers/podman/pull/19092 to Podman v4.6.  I did not bump the version as I also want to backport https://github.com/containers/common/pull/1505 (not yet merged) to the v0.55 branch.
