### PR TITLE
libnetwork: Add support for host-gatway

### DIFF
--- a/libnetwork/etchosts/hosts.go
+++ b/libnetwork/etchosts/hosts.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	HostContainersInternal = "host.containers.internal"
+	HostGateway            = "host-gateway"
 	localhost              = "localhost"
 )
 
@@ -244,7 +245,7 @@ func parseExtraHosts(extraHosts []string, hostContainersInternalIP string) (Host
 			return nil, fmt.Errorf("IP address in host entry %q is empty", entry)
 		}
 		ip := values[1]
-		if values[1] == "host-gateway" {
+		if values[1] == HostGateway {
 			ip = hostContainersInternalIP
 		}
 		e := HostEntry{IP: ip, Names: []string{values[0]}}

--- a/libnetwork/etchosts/hosts.go
+++ b/libnetwork/etchosts/hosts.go
@@ -246,6 +246,9 @@ func parseExtraHosts(extraHosts []string, hostContainersInternalIP string) (Host
 		}
 		ip := values[1]
 		if values[1] == HostGateway {
+			if hostContainersInternalIP == "" {
+				return nil, fmt.Errorf("unable to replace %q of host entry %q: host containers internal IP address is empty", HostGateway, entry)
+			}
 			ip = hostContainersInternalIP
 		}
 		e := HostEntry{IP: ip, Names: []string{values[0]}}

--- a/libnetwork/etchosts/hosts_test.go
+++ b/libnetwork/etchosts/hosts_test.go
@@ -274,6 +274,12 @@ func TestNew(t *testing.T) {
 			extraHosts:      []string{"name"},
 			wantErrString:   "unable to parse host entry \"name\": incorrect format",
 		},
+		{
+			name:            "invalid host-gateway",
+			baseFileContent: baseFileContent1Spaces,
+			extraHosts:      []string{"gatewayname:host-gateway"},
+			wantErrString:   "host containers internal IP address is empty",
+		},
 	}
 
 	for _, tt := range tests {

--- a/libnetwork/etchosts/hosts_test.go
+++ b/libnetwork/etchosts/hosts_test.go
@@ -219,6 +219,13 @@ func TestNew(t *testing.T) {
 			expectedTargetFileContent: targetFileContent1 + "10.0.0.1\thost.containers.internal\n",
 		},
 		{
+			name:                      "with host.containers.internal ip and host-gateway",
+			baseFileContent:           baseFileContent1Spaces,
+			extraHosts:                []string{"gatewayname:host-gateway"},
+			hostContainersInternal:    "10.0.0.1",
+			expectedTargetFileContent: "10.0.0.1\tgatewayname\n" + targetFileContent1 + "10.0.0.1\thost.containers.internal\n",
+		},
+		{
 			name:                      "host.containers.internal not added when already present in extra hosts",
 			baseFileContent:           baseFileContent1Spaces,
 			extraHosts:                []string{"host.containers.internal:1.1.1.1"},


### PR DESCRIPTION
This change adds support for the special IP designator `host-gateway` to the etchosts package.

The first part of fixing https://github.com/containers/podman/issues/14390 as mentioned in https://github.com/containers/podman/pull/14392#pullrequestreview-988593151
