### PR TITLE
pkg/ssh: simplify ssh.Validate

### DIFF
--- a/pkg/ssh/utils.go
+++ b/pkg/ssh/utils.go
@@ -16,10 +16,6 @@ import (
 )
 
 func Validate(user *url.Userinfo, path string, port int, identity string) (*config.Destination, *url.URL, error) {
-	sock := ""
-	if strings.Contains(path, "/run") {
-		sock = strings.Split(path, "/run")[1]
-	}
 	// url.Parse NEEDS ssh://, if this ever fails or returns some nonsense, that is why.
 	uri, err := url.Parse(path)
 	if err != nil {
@@ -43,15 +39,8 @@ func Validate(user *url.Userinfo, path string, port int, identity string) (*conf
 		uri.User = user
 	}
 
-	uriStr := ""
-	if len(sock) > 0 {
-		uriStr = "ssh://" + uri.User.Username() + "@" + uri.Host + "/run" + sock
-	} else {
-		uriStr = "ssh://" + uri.User.Username() + "@" + uri.Host
-	}
-
 	dst := config.Destination{
-		URI: uriStr,
+		URI: uri.String(),
 	}
 
 	if len(identity) > 0 {

--- a/pkg/ssh/utils_test.go
+++ b/pkg/ssh/utils_test.go
@@ -1,0 +1,37 @@
+package ssh
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	// Test adding ssh port
+	dst, uri, err := Validate(nil, "ssh://testhost", 0, "")
+	require.Nil(t, err)
+	require.Equal(t, dst.URI, "ssh://testhost:22")
+	require.Equal(t, dst.URI, uri.String())
+	dst, _, err = Validate(nil, "ssh://testhost", 22022, "")
+	require.Nil(t, err)
+	require.Equal(t, dst.URI, "ssh://testhost:22022")
+
+	// Test adding user
+	dst, _, err = Validate(url.User("root"), "ssh://testhost", 0, "")
+	require.Nil(t, err)
+	require.Equal(t, dst.URI, "ssh://root@testhost:22")
+
+	// Test adding identity
+	dst, _, err = Validate(nil, "ssh://testhost", 0, "/path/to/sshkey")
+	require.Nil(t, err)
+	require.Equal(t, dst.Identity, "/path/to/sshkey")
+
+	// Test that the URI path is preserved (#1551)
+	dst, _, err = Validate(nil, "ssh://testhost/run/podman/podman.sock", 0, "")
+	require.Nil(t, err)
+	require.Equal(t, dst.URI, "ssh://testhost:22/run/podman/podman.sock")
+	dst, _, err = Validate(nil, "ssh://testhost/var/run/podman/podman.sock", 0, "")
+	require.Nil(t, err)
+	require.Equal(t, dst.URI, "ssh://testhost:22/var/run/podman/podman.sock")
+}


### PR DESCRIPTION
This removes logic which forces the socket path (if present) to start with "/run" and uses (*URL).String to reconstruct the URI after applying port and user policy. Fixes #1551.
