### PR TITLE
Beautify lookup after #1505

### DIFF
--- a/libimage/filters.go
+++ b/libimage/filters.go
@@ -406,7 +406,7 @@ func filterDigest(value string) (filterFunc, error) {
 		return nil, fmt.Errorf("invalid value %q for digest filter: %w", value, err)
 	}
 	return func(img *Image) (bool, error) {
-		return img.hasDigest(d.String()), nil
+		return img.hasDigest(d), nil
 	}, nil
 }
 

--- a/libimage/filters.go
+++ b/libimage/filters.go
@@ -11,6 +11,7 @@ import (
 	filtersPkg "github.com/containers/common/pkg/filters"
 	"github.com/containers/common/pkg/timetype"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
 )
 
@@ -147,7 +148,11 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 			filter = filterID(value)
 
 		case "digest":
-			filter = filterDigest(value)
+			f, err := filterDigest(value)
+			if err != nil {
+				return nil, err
+			}
+			filter = f
 
 		case "intermediate":
 			intermediate, err := r.bool(duplicate, key, value)
@@ -395,12 +400,14 @@ func filterID(value string) filterFunc {
 }
 
 // filterDigest creates a digest filter for matching the specified value.
-func filterDigest(value string) filterFunc {
-	// TODO: return an error if value is not a digest
-	// if _, err := digest.Parse(value); err != nil {...}
-	return func(img *Image) (bool, error) {
-		return img.hasDigest(value), nil
+func filterDigest(value string) (filterFunc, error) {
+	d, err := digest.Parse(value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid value %q for digest filter: %w", value, err)
 	}
+	return func(img *Image) (bool, error) {
+		return img.hasDigest(d.String()), nil
+	}, nil
 }
 
 // filterIntermediate creates an intermediate filter for images.  An image is

--- a/libimage/filters_test.go
+++ b/libimage/filters_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/containers/common/pkg/config"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -123,6 +124,10 @@ func TestFilterDigest(t *testing.T) {
 		require.Len(t, listedImages, test.matches, "%s -> %v", test.filter, listedImages)
 		require.Equal(t, listedImages[0].ID(), test.id)
 	}
+	_, err = runtime.ListImages(ctx, nil, &ListImagesOptions{
+		Filters: []string{"digest=this-is-not-a-digest"},
+	})
+	assert.Error(t, err)
 }
 
 func TestFilterManifest(t *testing.T) {

--- a/libimage/image.go
+++ b/libimage/image.go
@@ -685,9 +685,13 @@ func (i *Image) NamedRepoTags() ([]reference.Named, error) {
 	return repoTags, nil
 }
 
-// inRepoTags looks for the specified name/tag in the image's repo tags.  If
-// `ignoreTag` is set, only the repo must match and the tag is ignored.
-func (i *Image) inRepoTags(namedTagged reference.NamedTagged, ignoreTag bool) (reference.Named, error) {
+// referenceFuzzilyMatchingRepoAndTag checks if the image’s repo (and optionally tag) matches a fuzzy short input,
+// and if so, returns the matching reference.
+// If `ignoreTag` is set, only the repo must match and the tag is ignored.
+//
+// DO NOT ADD ANY NEW USERS OF THIS SEMANTICS. Rely on existing libimage calls like LookupImage instead,
+// and handle unqualified the way it does (c/image/pkg/shortnames).
+func (i *Image) referenceFuzzilyMatchingRepoAndTag(namedTagged reference.NamedTagged, ignoreTag bool) (reference.Named, error) {
 	repoTags, err := i.NamedRepoTags()
 	if err != nil {
 		return nil, err

--- a/libimage/image.go
+++ b/libimage/image.go
@@ -690,13 +690,13 @@ func (i *Image) NamedRepoTags() ([]reference.Named, error) {
 //
 // DO NOT ADD ANY NEW USERS OF THIS SEMANTICS. Rely on existing libimage calls like LookupImage instead,
 // and handle unqualified the way it does (c/image/pkg/shortnames).
-func (i *Image) referenceFuzzilyMatchingRepoAndTag(namedTagged reference.NamedTagged, requiredTag string) (reference.Named, error) {
+func (i *Image) referenceFuzzilyMatchingRepoAndTag(requiredRepo reference.Named, requiredTag string) (reference.Named, error) {
 	repoTags, err := i.NamedRepoTags()
 	if err != nil {
 		return nil, err
 	}
 
-	name := namedTagged.Name()
+	name := requiredRepo.Name()
 	for _, r := range repoTags {
 		if requiredTag != "" {
 			tagged, isTagged := r.(reference.NamedTagged)

--- a/libimage/image.go
+++ b/libimage/image.go
@@ -159,10 +159,9 @@ func (i *Image) Digests() []digest.Digest {
 
 // hasDigest returns whether the specified value matches any digest of the
 // image.
-func (i *Image) hasDigest(value string) bool {
-	// TODO: change the argument to a typed digest.Digest
+func (i *Image) hasDigest(wantedDigest digest.Digest) bool {
 	for _, d := range i.Digests() {
-		if string(d) == value {
+		if d == wantedDigest {
 			return true
 		}
 	}

--- a/libimage/image.go
+++ b/libimage/image.go
@@ -685,24 +685,22 @@ func (i *Image) NamedRepoTags() ([]reference.Named, error) {
 	return repoTags, nil
 }
 
-// referenceFuzzilyMatchingRepoAndTag checks if the image’s repo (and optionally tag) matches a fuzzy short input,
+// referenceFuzzilyMatchingRepoAndTag checks if the image’s repo (and tag if requiredTag != "") matches a fuzzy short input,
 // and if so, returns the matching reference.
-// If `ignoreTag` is set, only the repo must match and the tag is ignored.
 //
 // DO NOT ADD ANY NEW USERS OF THIS SEMANTICS. Rely on existing libimage calls like LookupImage instead,
 // and handle unqualified the way it does (c/image/pkg/shortnames).
-func (i *Image) referenceFuzzilyMatchingRepoAndTag(namedTagged reference.NamedTagged, ignoreTag bool) (reference.Named, error) {
+func (i *Image) referenceFuzzilyMatchingRepoAndTag(namedTagged reference.NamedTagged, requiredTag string) (reference.Named, error) {
 	repoTags, err := i.NamedRepoTags()
 	if err != nil {
 		return nil, err
 	}
 
 	name := namedTagged.Name()
-	tag := namedTagged.Tag()
 	for _, r := range repoTags {
-		if !ignoreTag {
+		if requiredTag != "" {
 			tagged, isTagged := r.(reference.NamedTagged)
-			if !isTagged || tag != tagged.Tag() {
+			if !isTagged || tagged.Tag() != requiredTag {
 				continue
 			}
 		}

--- a/libimage/image.go
+++ b/libimage/image.go
@@ -701,12 +701,8 @@ func (i *Image) referenceFuzzilyMatchingRepoAndTag(namedTagged reference.NamedTa
 	tag := namedTagged.Tag()
 	for _, r := range repoTags {
 		if !ignoreTag {
-			var repoTag string
 			tagged, isTagged := r.(reference.NamedTagged)
-			if isTagged {
-				repoTag = tagged.Tag()
-			}
-			if !isTagged || tag != repoTag {
+			if !isTagged || tag != tagged.Tag() {
 				continue
 			}
 		}

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -487,7 +487,7 @@ func (r *Runtime) lookupImageInDigestsAndRepoTags(name string, possiblyUnqualifi
 	}
 
 	for _, image := range allImages {
-		named, err := image.referenceFuzzilyMatchingRepoAndTag(namedTagged, requiredTag)
+		named, err := image.referenceFuzzilyMatchingRepoAndTag(possiblyUnqualifiedNamedReference, requiredTag)
 		if err != nil {
 			return nil, "", err
 		}

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -498,7 +498,7 @@ func (r *Runtime) lookupImageInDigestsAndRepoTags(name string, possiblyUnqualifi
 		}
 		if img != nil {
 			if isDigested {
-				if !img.hasDigest(requiredDigest.String()) {
+				if !img.hasDigest(requiredDigest) {
 					continue
 				}
 				named = reference.TrimNamed(named)

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -485,7 +485,7 @@ func (r *Runtime) lookupImageInDigestsAndRepoTags(name string, possiblyUnqualifi
 	}
 
 	for _, image := range allImages {
-		named, err := image.inRepoTags(namedTagged, isDigested)
+		named, err := image.referenceFuzzilyMatchingRepoAndTag(namedTagged, isDigested)
 		if err != nil {
 			return nil, "", err
 		}

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -454,6 +454,9 @@ func (r *Runtime) lookupImageInDigestsAndRepoTags(name string, possiblyUnqualifi
 	if possiblyUnqualifiedNamedReference == nil {
 		return nil, "", fmt.Errorf("%s: %w", originalName, storage.ErrImageUnknown)
 	}
+	if !shortnames.IsShortName(name) {
+		return nil, "", fmt.Errorf("%s: %w", originalName, storage.ErrImageUnknown)
+	}
 
 	// In case of a digested reference, we strip off the digest and require
 	// any image matching the repo/tag to also match the specified digest.
@@ -463,10 +466,6 @@ func (r *Runtime) lookupImageInDigestsAndRepoTags(name string, possiblyUnqualifi
 		requiredDigest = digested.Digest()
 		possiblyUnqualifiedNamedReference = reference.TrimNamed(possiblyUnqualifiedNamedReference)
 		name = possiblyUnqualifiedNamedReference.String()
-	}
-
-	if !shortnames.IsShortName(name) {
-		return nil, "", fmt.Errorf("%s: %w", originalName, storage.ErrImageUnknown)
 	}
 
 	// Docker compat: make sure to add the "latest" tag if needed.  The tag


### PR DESCRIPTION
This is a set of small cleanups on top of #1505. Apart from the first commit, they should not change behavior, and are not worth backporting.

See individual commit messages for details.