### PR TITLE
libnetwork: correctly assign free names

### DIFF
--- a/libnetwork/internal/util/util.go
+++ b/libnetwork/internal/util/util.go
@@ -28,9 +28,7 @@ func GetBridgeInterfaceNames(n NetUtil) []string {
 func GetUsedNetworkNames(n NetUtil) []string {
 	names := make([]string, 0, n.Len())
 	n.ForEach(func(net types.Network) {
-		if net.Driver == types.BridgeNetworkDriver {
-			names = append(names, net.NetworkInterface)
-		}
+		names = append(names, net.Name)
 	})
 	return names
 }

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -1001,6 +1001,19 @@ var _ = Describe("Config", func() {
 			Expect(network1.IPAMOptions[types.Driver]).To(Equal(types.DHCPIPAMDriver))
 		})
 
+		It("create two macvlan networks without name", func() {
+			network := types.Network{Driver: "macvlan"}
+			network1, err := libpodNet.NetworkCreate(network, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(network1.IPAMOptions[types.Driver]).To(Equal(types.DHCPIPAMDriver))
+			Expect(network1.Name).To(Equal("podman1"))
+
+			network2, err := libpodNet.NetworkCreate(network, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(network2.IPAMOptions[types.Driver]).To(Equal(types.DHCPIPAMDriver))
+			Expect(network2.Name).To(Equal("podman2"), "second name should be different then first")
+		})
+
 		It("create macvlan config without subnet and host-local", func() {
 			network := types.Network{
 				Driver:      "macvlan",


### PR DESCRIPTION
If no name is given we have to set a free one, however the logic was
broken since the beginning due some copy paste. This function as the
name suggests must return all network names so we know to not reuse an
existing one.

I just found this by accident no user ever reported this in almost two
years. This likely means no one uses the automatic names and everybody
set's their own name on the cli instead.