### PR TITLE
Change default image volume mode to "nullfs" on FreeBSD

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,7 +51,7 @@ const (
 	BoltDBStateStore RuntimeStateStore = iota
 )
 
-var validImageVolumeModes = []string{"bind", "tmpfs", "ignore"}
+var validImageVolumeModes = []string{_typeBind, "tmpfs", "ignore"}
 
 // ProxyEnv is a list of Proxy Environment variables
 var ProxyEnv = []string{

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -14,6 +14,9 @@ const (
 	// DefaultSignaturePolicyPath is the default value for the
 	// policy.json file.
 	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
+
+	// Mount type for mounting host dir
+	_typeBind = "bind"
 )
 
 // podman remote clients on darwin cannot use unshare.isRootless() to determine the configuration file locations.

--- a/pkg/config/config_freebsd.go
+++ b/pkg/config/config_freebsd.go
@@ -14,6 +14,9 @@ const (
 	// DefaultSignaturePolicyPath is the default value for the
 	// policy.json file.
 	DefaultSignaturePolicyPath = "/usr/local/etc/containers/policy.json"
+
+	// Mount type for mounting host dir
+	_typeBind = "nullfs"
 )
 
 // podman remote clients on freebsd cannot use unshare.isRootless() to determine the configuration file locations.

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -17,6 +17,9 @@ const (
 	// DefaultSignaturePolicyPath is the default value for the
 	// policy.json file.
 	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
+
+	// Mount type for mounting host dir
+	_typeBind = "bind"
 )
 
 func selinuxEnabled() bool {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -38,7 +38,11 @@ var _ = Describe("Config", func() {
 			gomega.Expect(defaultConfig.NetNS()).To(gomega.BeEquivalentTo("private"))
 			gomega.Expect(defaultConfig.IPCNS()).To(gomega.BeEquivalentTo("shareable"))
 			gomega.Expect(defaultConfig.Engine.InfraImage).To(gomega.BeEquivalentTo(""))
-			gomega.Expect(defaultConfig.Engine.ImageVolumeMode).To(gomega.BeEquivalentTo("bind"))
+			if runtime.GOOS == "freebsd" {
+				gomega.Expect(defaultConfig.Engine.ImageVolumeMode).To(gomega.BeEquivalentTo("nullfs"))
+			} else {
+				gomega.Expect(defaultConfig.Engine.ImageVolumeMode).To(gomega.BeEquivalentTo("bind"))
+			}
 			gomega.Expect(defaultConfig.Engine.SSHConfig).To(gomega.ContainSubstring("/.ssh/config"))
 			gomega.Expect(defaultConfig.Engine.EventsContainerCreateInspectData).To(gomega.BeFalse())
 			gomega.Expect(defaultConfig.Engine.DBBackend).To(gomega.BeEquivalentTo(stringBoltDB))

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -12,6 +12,9 @@ const (
 	// DefaultSignaturePolicyPath is the default value for the
 	// policy.json file.
 	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
+
+	// Mount type for mounting host dir
+	_typeBind = "bind"
 )
 
 // podman remote clients on windows cannot use unshare.isRootless() to determine the configuration file locations.

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -28,7 +28,7 @@ const (
 	_defaultTransport = "docker://"
 
 	// _defaultImageVolumeMode is a mode to handle built-in image volumes.
-	_defaultImageVolumeMode = "bind"
+	_defaultImageVolumeMode = _typeBind
 )
 
 var (


### PR DESCRIPTION
This fixes a regression in
https://github.com/containers/podman/pull/19241 which quite reasonably assumed that the default image volume mode from pkg/config was correct.
