### PR TITLE
Allow rootless AppArmor

### DIFF
--- a/pkg/apparmor/apparmor.go
+++ b/pkg/apparmor/apparmor.go
@@ -2,16 +2,19 @@ package apparmor
 
 import (
 	"errors"
-
-	"github.com/containers/common/version"
 )
 
 const (
 	// ProfilePrefix is used for version-independent presence checks.
 	ProfilePrefix = "containers-default-"
 
-	// Profile default name
-	Profile = ProfilePrefix + version.Version
+	// Default AppArmor profile used by containers; by default this is set to unconfined.
+	// To override this, distros should supply their own profile and specify it in a default
+	// containers.conf.
+	// See the following issues for more information:
+	// - https://github.com/containers/common/issues/958
+	// - https://github.com/containers/podman/issues/15874
+	Profile = "unconfined"
 )
 
 var (

--- a/pkg/apparmor/apparmor.go
+++ b/pkg/apparmor/apparmor.go
@@ -17,6 +17,4 @@ const (
 var (
 	// ErrApparmorUnsupported indicates that AppArmor support is not supported.
 	ErrApparmorUnsupported = errors.New("AppArmor is not supported")
-	// ErrApparmorRootless indicates that AppArmor support is not supported in rootless mode.
-	ErrApparmorRootless = errors.New("AppArmor is not supported in rootless mode")
 )

--- a/pkg/apparmor/internal/supported/supported.go
+++ b/pkg/apparmor/internal/supported/supported.go
@@ -41,9 +41,6 @@ func NewAppArmorVerifier() *ApparmorVerifier {
 // - AppArmor is disabled by the host system
 // - the `apparmor_parser` binary is not discoverable
 func (a *ApparmorVerifier) IsSupported() error {
-	if a.impl.UnshareIsRootless() {
-		return errors.New("AppAmor is not supported on rootless containers")
-	}
 	if !a.impl.RuncIsEnabled() {
 		return errors.New("AppArmor not supported by the host system")
 	}


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
Related issues:
- https://github.com/containers/common/issues/958 (closed in https://github.com/containers/common/pull/960, reverted by https://github.com/containers/common/pull/969)
- https://github.com/containers/podman/issues/15874

This PR re-implements https://github.com/containers/common/pull/960, allowing containers to execute under a specified AppArmor profile when run rootlessly. In addition, it changes the default AppArmor profile used by containers to `unconfined`.

The current implementation of Podman compiles and loads the default AppArmor profile at runtime. However, this is incompatible with providing rootless AppArmor compatibility, as loading an AppArmor profile requires root privileges. As discussed in https://github.com/containers/podman/issues/15874, the ideal mechanism by which a default profile should be loaded is to add a profile to `/etc/apparmor.d` at installation time, by individual distributions. This profile should then be specified in a default `containers.conf` provided by the distribution.