### PR TITLE
Use dlocate where available, instead of dpkg search

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -27,7 +27,16 @@ func queryPackageVersion(cmdArg ...string) string {
 		cmd := exec.Command(cmdArg[0], cmdArg[1:]...)
 		if outp, err := cmd.Output(); err == nil {
 			output = string(outp)
-			if cmdArg[0] == "/usr/bin/dpkg" {
+			deb := false
+			if cmdArg[0] == "/usr/bin/dlocate" {
+				// can return multiple matches
+				l := strings.Split(output, "\n")
+				output = l[0]
+				deb = true
+			} else if cmdArg[0] == "/usr/bin/dpkg" {
+				deb = true
+			}
+			if deb {
 				r := strings.Split(output, ": ")
 				queryFormat := `${Package}_${Version}_${Architecture}`
 				cmd = exec.Command("/usr/bin/dpkg-query", "-f", queryFormat, "-W", r[0])
@@ -49,7 +58,8 @@ func queryPackageVersion(cmdArg ...string) string {
 func PackageVersion(program string) string { // program is full path
 	packagers := [][]string{
 		{"/usr/bin/rpm", "-q", "-f"},
-		{"/usr/bin/dpkg", "-S"},                // Debian, Ubuntu
+		{"/usr/bin/dlocate", "-F"},             // Debian, Ubuntu (quick)
+		{"/usr/bin/dpkg", "-S"},                // Debian, Ubuntu (slow)
 		{"/usr/bin/pacman", "-Qo"},             // Arch
 		{"/usr/bin/qfile", "-qv"},              // Gentoo (quick)
 		{"/usr/bin/equery", "b"},               // Gentoo (slow)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -56,6 +56,10 @@ func queryPackageVersion(cmdArg ...string) string {
 // Note: This function is copied from containers/podman libpod/util.go
 // Please see https://github.com/containers/common/pull/1460
 func PackageVersion(program string) string { // program is full path
+	_, err := os.Stat(program)
+	if err != nil {
+		return UnknownPackage
+	}
 	packagers := [][]string{
 		{"/usr/bin/rpm", "-q", "-f"},
 		{"/usr/bin/dlocate", "-F"},             // Debian, Ubuntu (quick)


### PR DESCRIPTION
The `dpkg -S` call is _really_ slow, taking some 500ms per call.

```console
$ time dpkg -S /usr/bin/podman
podman: /usr/bin/podman

real	0m0,583s
user	0m0,481s
sys	0m0,100s
```

Using `dlocate -F` is better, still not fast but tolerable (grep)

```console
$ time dlocate -F /usr/bin/podman
podman: /usr/bin/podman
podman: /usr/bin/podman-remote

real	0m0,099s
user	0m0,072s
sys	0m0,034s
```

This a problem for podman version and info, which calls PackageVersion a lot (more than 10 times)

When using a database, like rpm, there is no particular overhead. But when using files: 5 seconds
