### PR TITLE
pkg/config: Add ocijail to the RuntimeSupportsJSON list

### DIFF
--- a/pkg/config/containers.conf-freebsd
+++ b/pkg/config/containers.conf-freebsd
@@ -500,7 +500,7 @@ default_sysctls = [
 # List of the OCI runtimes that support --format=json. When json is supported
 # engine will use it for reporting nicer errors.
 #
-#runtime_supports_json = ["crun", "runc", "kata", "runsc", "youki", "krun"]
+#runtime_supports_json = ["crun", "runc", "kata", "runsc", "youki", "krun", "ocijail"]
 
 # List of the OCI runtimes that supports running containers with KVM Separation.
 #

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -406,6 +406,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 		"runsc",
 		"youki",
 		"krun",
+		"ocijail",
 	}
 	c.RuntimeSupportsNoCgroups = []string{"crun", "krun"}
 	c.RuntimeSupportsKVM = []string{"kata", "kata-runtime", "kata-qemu", "kata-fc", "krun"}


### PR DESCRIPTION
I added this support to ocijail a while ago but forgot to change the compiled-in default since I was overriding the value in my containers.conf.
