### PR TITLE
config: rm cni plugins dir check

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1021,17 +1021,7 @@ func (c *NetworkConfig) Validate() error {
 		}
 	}
 
-	if stringsEq(c.CNIPluginDirs, DefaultCNIPluginDirs) {
-		return nil
-	}
-
-	for _, pluginDir := range c.CNIPluginDirs {
-		if err := isDirectory(pluginDir); err == nil {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("invalid cni_plugin_dirs: %s", strings.Join(c.CNIPluginDirs, ","))
+	return nil
 }
 
 // FindConmon iterates over (*Config).ConmonPath and returns the path

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("Config Local", func() {
 	BeforeEach(beforeEach)
 
-	It("should fail on invalid NetworkConfigDir", func() {
+	It("should not fail on invalid NetworkConfigDir", func() {
 		// Given
 		tmpfile := path.Join(os.TempDir(), "wrong-file")
 		file, err := os.Create(tmpfile)
@@ -32,10 +32,10 @@ var _ = Describe("Config Local", func() {
 		err = sut.Network.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		gomega.Expect(err).To(gomega.BeNil())
 	})
 
-	It("should fail on invalid CNIPluginDirs", func() {
+	It("should not fail on invalid CNIPluginDirs", func() {
 		validDirPath, err := os.MkdirTemp("", "config-empty")
 		if err != nil {
 			panic(err)
@@ -49,41 +49,7 @@ var _ = Describe("Config Local", func() {
 		err = sut.Network.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
-	})
-
-	It("should fail in validating invalid PluginDir", func() {
-		validDirPath, err := os.MkdirTemp("", "config-empty")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(validDirPath)
-		// Given
-		sut.Network.NetworkConfigDir = validDirPath
-		sut.Network.CNIPluginDirs = []string{invalidPath}
-
-		// When
-		err = sut.Network.Validate()
-
-		// Then
-		gomega.Expect(err).ToNot(gomega.BeNil())
-	})
-
-	It("should fail on invalid CNIPluginDirs", func() {
-		validDirPath, err := os.MkdirTemp("", "config-empty")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(validDirPath)
-		// Given
-		sut.Network.NetworkConfigDir = validDirPath
-		sut.Network.CNIPluginDirs = []string{invalidPath}
-
-		// When
-		err = sut.Network.Validate()
-
-		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		gomega.Expect(err).To(gomega.BeNil())
 	})
 
 	It("should fail on invalid subnet pool", func() {
@@ -169,25 +135,6 @@ var _ = Describe("Config Local", func() {
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config2.Network.DefaultRootlessNetworkCmd).To(gomega.Equal("pasta"))
-	})
-
-	It("should fail during runtime", func() {
-		validDirPath, err := os.MkdirTemp("", "config-empty")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(validDirPath)
-		// Given
-		sut.Network.NetworkConfigDir = validDirPath
-		tmpDir := path.Join(os.TempDir(), "cni-test")
-		sut.Network.CNIPluginDirs = []string{tmpDir}
-		defer os.RemoveAll(tmpDir)
-
-		// When
-		err = sut.Network.Validate()
-
-		// Then
-		gomega.Expect(err).ToNot(gomega.BeNil())
 	})
 
 	It("should fail on invalid device mode", func() {


### PR DESCRIPTION
This check as part of validation errors out in conditions where Netavark is used instead of CNI which is rather misleading. Removing this check from Validation (early on) and expecting it to fail closer to time-of-use.

Closes https://github.com/containers/podman/issues/19327