### PR TITLE
Allow mounts to be specified in containers.conf

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -229,6 +229,13 @@ limit is never exceeded.
 
 Default format tag for container log messages. This is useful for creating a specific tag for container log messages. Container log messages default to using the truncated container ID as a tag.
 
+**mounts**=[]
+
+List of mounts.
+Specified as "type=TYPE,source=<directory-on-host>,destination=<directory-in-container>,<options>"
+
+Example:  [ "type=bind,source=/var/lib/foobar,destination=/var/lib/foobar,ro", ]
+
 **netns**="private"
 
 Default way to to create a NET namespace for the container.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -185,6 +185,9 @@ type ContainersConfig struct {
 	// Containers logs default to truncated container ID as a tag.
 	LogTag string `toml:"log_tag,omitempty"`
 
+	// Mount to add to all containers
+	Mounts []string `toml:"mounts,omitempty"`
+
 	// NetNS indicates how to create a network namespace for the container
 	NetNS string `toml:"netns,omitempty"`
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -249,6 +249,11 @@ image_copy_tmp_dir="storage"`
 				"TERM=xterm",
 			}
 
+			mounts := []string{
+				"type=glob,source=/tmp/test2*,ro=true",
+				"type=bind,source=/etc/services,destination=/etc/services,ro",
+			}
+
 			volumes := []string{
 				"$HOME:$HOME",
 			}
@@ -265,6 +270,7 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(defaultConfig.Engine.CgroupManager).To(gomega.Equal("systemd"))
 			gomega.Expect(defaultConfig.Containers.Env).To(gomega.BeEquivalentTo(envs))
+			gomega.Expect(defaultConfig.Containers.Mounts).To(gomega.BeEquivalentTo(mounts))
 			gomega.Expect(defaultConfig.Containers.PidsLimit).To(gomega.BeEquivalentTo(2048))
 			gomega.Expect(defaultConfig.Network.CNIPluginDirs).To(gomega.Equal(pluginDirs))
 			gomega.Expect(defaultConfig.Network.NetavarkPluginDirs).To(gomega.Equal([]string{"/usr/netavark"}))

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -196,6 +196,13 @@ default_sysctls = [
 #
 #log_tag = ""
 
+# List of mounts. Specified as
+# "type=TYPE,source=<directory-on-host>,destination=<directory-in-container>,<options>", for example:
+# "type=bind,source=/var/lib/foobar,destination=/var/lib/foobar,ro".
+# If it is empty or commented out, no mounts will be added
+#
+#mounts = []
+
 # Default way to to create a Network namespace for the container
 # Options are:
 # `private` Create private Network Namespace for the container.
@@ -276,7 +283,7 @@ default_sysctls = [
 # If it is empty or commented out, no volumes will be added
 #
 #volumes = []
-#
+
 #[engine.platform_to_oci_runtime]
 #"wasi/wasm" = ["crun-wasm"]
 #"wasi/wasm32" = ["crun-wasm"]

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -186,19 +186,18 @@ func DefaultConfig() (*Config, error) {
 
 	return &Config{
 		Containers: ContainersConfig{
-			Devices:             []string{},
-			Volumes:             []string{},
 			Annotations:         []string{},
 			ApparmorProfile:     DefaultApparmorProfile,
 			BaseHostsFile:       "",
 			CgroupNS:            cgroupNS,
 			Cgroups:             getDefaultCgroupsMode(),
+			DNSOptions:          []string{},
+			DNSSearches:         []string{},
+			DNSServers:          []string{},
 			DefaultCapabilities: DefaultCapabilities,
 			DefaultSysctls:      []string{},
 			DefaultUlimits:      getDefaultProcessLimits(),
-			DNSServers:          []string{},
-			DNSOptions:          []string{},
-			DNSSearches:         []string{},
+			Devices:             []string{},
 			EnableKeyring:       true,
 			EnableLabeling:      selinuxEnabled(),
 			Env: []string{
@@ -207,20 +206,22 @@ func DefaultConfig() (*Config, error) {
 			},
 			EnvHost:    false,
 			HTTPProxy:  true,
+			IPCNS:      "shareable",
 			Init:       false,
 			InitPath:   "",
-			IPCNS:      "shareable",
 			LogDriver:  defaultLogDriver(),
 			LogSizeMax: DefaultLogSizeMax,
+			Mounts:     []string{},
 			NetNS:      "private",
 			NoHosts:    false,
-			PidsLimit:  DefaultPidsLimit,
 			PidNS:      "private",
+			PidsLimit:  DefaultPidsLimit,
 			ShmSize:    DefaultShmSize,
 			TZ:         "",
-			Umask:      "0022",
 			UTSNS:      "private",
+			Umask:      "0022",
 			UserNSSize: DefaultUserNSSize, // Deprecated
+			Volumes:    []string{},
 		},
 		Network: NetworkConfig{
 			DefaultNetwork:            "podman",
@@ -498,6 +499,11 @@ func (c *Config) Sysctls() []string {
 // Volumes returns the default set of volumes that should be mounted in containers.
 func (c *Config) Volumes() []string {
 	return c.Containers.Volumes
+}
+
+// Mounts returns the default set of mounts that should be mounted in containers.
+func (c *Config) Mounts() []string {
+	return c.Containers.Mounts
 }
 
 // Devices returns the default additional devices for containers.

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -81,6 +81,11 @@ label = true
 # limit is never exceeded.
 log_size_max = -1
 
+mounts= [
+	"type=glob,source=/tmp/test2*,ro=true",
+	"type=bind,source=/etc/services,destination=/etc/services,ro",
+]
+
 oom_score_adj = 750
 
 # Maximum number of processes allowed in a container.


### PR DESCRIPTION
We want to allow HPC Customers and others to specify mounts inside of containers.conf, so that they can have a default list of mounts into all of thier containers.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
