### PR TITLE
Add Farms to config

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -848,6 +848,17 @@ Virtualization provider to be used for running a podman-machine VM. Empty value
 is interpreted as the default provider for the current host OS. On Linux/Mac
 default is `QEMU` and on Windows it is `WSL`.
 
+## FARMS TABLE
+The `farms` table contains configuration options used to group up remote connections into farms that will be used when sending out builds to different machines in a farm via `podman buildfarm`.
+
+**default**=""
+
+The default farm to use when farming out builds.
+
+**[farms.list]**
+
+Map of farms created where the key is the farm name and the value is the list of system connections.
+
 # FILES
 
 **containers.conf**

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -79,6 +79,8 @@ type Config struct {
 	Secrets SecretConfig `toml:"secrets"`
 	// ConfigMap section defines configurations for the configmaps management
 	ConfigMaps ConfigMapConfig `toml:"configmaps"`
+	// Farms defines configurations for the buildfarm farms
+	Farms FarmConfig `toml:"farms"`
 }
 
 // ContainersConfig represents the "containers" TOML config table
@@ -674,6 +676,14 @@ type MachineConfig struct {
 	Volumes []string `toml:"volumes"`
 	// Provider is the virtualization provider used to run podman-machine VM
 	Provider string `toml:"provider,omitempty"`
+}
+
+// FarmConfig represents the "farm" TOML config tabls
+type FarmConfig struct {
+	// Default is the default farm to be used when farming out builds
+	Default string `toml:"default,omitempty"`
+	// List is a map of farms created where key=farm-name and value=list of connections
+	List map[string][]string `toml:"list,omitempty"`
 }
 
 // Destination represents destination for remote service
@@ -1275,6 +1285,10 @@ func ReadCustomConfig() (*Config, error) {
 		if !errors.Is(err, os.ErrNotExist) {
 			return nil, err
 		}
+	}
+	// Let's always initialize the farm list so it is never nil
+	if newConfig.Farms.List == nil {
+		newConfig.Farms.List = make(map[string][]string)
 	}
 	return newConfig, nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -867,6 +867,67 @@ image_copy_tmp_dir="storage"`
 		})
 	})
 
+	Describe("Farms", func() {
+		ConfPath := struct {
+			Value string
+			IsSet bool
+		}{}
+
+		BeforeEach(func() {
+			ConfPath.Value, ConfPath.IsSet = os.LookupEnv("CONTAINERS_CONF")
+			conf, _ := os.CreateTemp("", "containersconf")
+			os.Setenv("CONTAINERS_CONF", conf.Name())
+		})
+
+		AfterEach(func() {
+			os.Remove(os.Getenv("CONTAINERS_CONF"))
+			if ConfPath.IsSet {
+				os.Setenv("CONTAINERS_CONF", ConfPath.Value)
+			} else {
+				os.Unsetenv("CONTAINERS_CONF")
+			}
+		})
+
+		It("succeed to set and read", func() {
+			cfg, err := ReadCustomConfig()
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			cfg.Engine.ActiveService = "QA"
+			cfg.Engine.ServiceDestinations = map[string]Destination{
+				"QA": {
+					URI:      "https://qa/run/podman/podman.sock",
+					Identity: "/.ssh/id_rsa",
+				},
+			}
+			err = cfg.Write()
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			// test that connections were written correctly
+			cfg, err = ReadCustomConfig()
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Expect(cfg.Engine.ActiveService, "QA")
+			gomega.Expect(cfg.Engine.ServiceDestinations["QA"].URI,
+				"https://qa/run/podman/podman.sock")
+			gomega.Expect(cfg.Engine.ServiceDestinations["QA"].Identity,
+				"/.ssh/id_rsa")
+
+			// Create farm
+			cfg.Farms.Default = "Farm-1"
+			cfg.Farms.List = map[string][]string{
+				"Farm-1": {"QA"},
+			}
+			err = cfg.Write()
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			cfg, err = ReadCustomConfig()
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			gomega.Expect(cfg.Farms.Default, "Farm-1")
+			gomega.Expect(cfg.Farms.List["Farm-1"],
+				"QA")
+		})
+	})
+
 	Describe("Reload", func() {
 		It("test new config from reload", func() {
 			// Default configuration

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -988,7 +988,7 @@ env=["foo=bar"]`
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		// config should only contain empty stanzas
 		gomega.Expect(string(b)).To(gomega.
-			Equal("[containers]\n\n[engine]\n\n[machine]\n\n[network]\n\n[secrets]\n\n[configmaps]\n"))
+			Equal("[containers]\n\n[engine]\n\n[machine]\n\n[network]\n\n[secrets]\n\n[configmaps]\n\n[farms]\n"))
 	})
 
 	It("validate ImageVolumeMode", func() {

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -799,3 +799,11 @@ default_sysctls = [
 # TOML does not provide a way to end a table other than a further table being
 # defined, so every key hereafter will be part of [machine] and not the
 # main config.
+
+[farms]
+#
+# the default farm to use when farming out builds
+# default = ""
+#
+# map of existing farms
+#[farms.list]

--- a/pkg/config/containers.conf-freebsd
+++ b/pkg/config/containers.conf-freebsd
@@ -661,3 +661,11 @@ default_sysctls = [
 # TOML does not provide a way to end a table other than a further table being
 # defined, so every key hereafter will be part of [machine] and not the
 # main config.
+
+[farms]
+#
+# the default farm to use when farming out builds
+# default = ""
+#
+# map of existing farms
+#[farms.list]

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -235,6 +235,7 @@ func DefaultConfig() (*Config, error) {
 		Engine:  *defaultEngineConfig,
 		Secrets: defaultSecretConfig(),
 		Machine: defaultMachineConfig(),
+		Farms:   defaultFarmConfig(),
 	}, nil
 }
 
@@ -255,6 +256,14 @@ func defaultMachineConfig() MachineConfig {
 		Memory:   2048,
 		User:     getDefaultMachineUser(),
 		Volumes:  getDefaultMachineVolumes(),
+	}
+}
+
+// defaultFarmConfig returns the default farms configuration.
+func defaultFarmConfig() FarmConfig {
+	emptyList := make(map[string][]string)
+	return FarmConfig{
+		List: emptyList,
 	}
 }
 

--- a/pkg/ssh/connection_golang.go
+++ b/pkg/ssh/connection_golang.go
@@ -64,6 +64,19 @@ func golangConnectionCreate(options ConnectionCreateOptions) error {
 	} else {
 		cfg.Engine.ServiceDestinations[options.Name] = *dst
 	}
+
+	// Create or update an existing farm with the connection being added
+	if options.Farm != "" {
+		if len(cfg.Farms.List) == 0 {
+			cfg.Farms.Default = options.Farm
+		}
+		if val, ok := cfg.Farms.List[options.Farm]; ok {
+			cfg.Farms.List[options.Farm] = append(val, options.Name)
+		} else {
+			cfg.Farms.List[options.Farm] = []string{options.Name}
+		}
+	}
+
 	return cfg.Write()
 }
 

--- a/pkg/ssh/types.go
+++ b/pkg/ssh/types.go
@@ -24,6 +24,7 @@ type ConnectionCreateOptions struct {
 	Identity string
 	Socket   string
 	Default  bool
+	Farm     string
 }
 
 type ConnectionDialOptions struct {


### PR DESCRIPTION
Add 2 new fields to EngineConfig `Farms` and `DefaultFarm` for the podman buildfarm feature work.
Also update the ssh connection code to be able to add a new connection to a new or existing farm when the `--farm` is set in `podman system connection add`.

PR https://github.com/containers/podman/pull/19358 will vendor this in.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
