### PR TITLE
We don't want TERM environment turned on by default

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -151,7 +151,7 @@ A list of dns servers to override the DNS configuration passed to the
 container. The special value “none” can be specified to disable creation of
 /etc/resolv.conf in the container.
 
-**env**=["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "TERM=xterm"]
+**env**=["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]
 
 Environment variable list for the container process, used for passing
 environment variables to the container.

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -260,7 +260,6 @@ var _ = Describe("Config Local", func() {
 	It("verify getDefaultEnv", func() {
 		envs := []string{
 			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-			"TERM=xterm",
 		}
 		// Given we do
 		oldContainersConf, envSet := os.LookupEnv("CONTAINERS_CONF")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -246,7 +246,6 @@ image_copy_tmp_dir="storage"`
 
 			envs := []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-				"TERM=xterm",
 			}
 
 			mounts := []string{
@@ -297,7 +296,6 @@ image_copy_tmp_dir="storage"`
 		It("test GetDefaultEnvEx", func() {
 			envs := []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-				"TERM=xterm",
 			}
 			httpEnvs := append([]string{"HTTP_PROXY=1.2.3.4"}, envs...)
 			oldProxy, proxyEnvSet := os.LookupEnv("HTTP_PROXY")
@@ -395,7 +393,6 @@ image_copy_tmp_dir="storage"`
 
 			envs := []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-				"TERM=xterm",
 			}
 
 			// Given we do
@@ -900,7 +897,7 @@ env=["foo=bar"]`
 				os.Unsetenv("CONTAINERS_CONF")
 			}
 
-			expectOldEnv := []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "TERM=xterm"}
+			expectOldEnv := []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
 			expectNewEnv := []string{"foo=bar"}
 			gomega.Expect(cfg.Containers.Env).To(gomega.Equal(expectOldEnv))
 			gomega.Expect(newCfg.Containers.Env).To(gomega.Equal(expectNewEnv))

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -119,7 +119,6 @@ default_sysctls = [
 #
 #env = [
 #  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-#  "TERM=xterm",
 #]
 
 # Pass all host environment variables into the container.

--- a/pkg/config/containers.conf-freebsd
+++ b/pkg/config/containers.conf-freebsd
@@ -99,7 +99,6 @@ default_sysctls = [
 #
 #env = [
 #  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-#  "TERM=xterm",
 #]
 
 # Pass all host environment variables into the container.

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -202,7 +202,6 @@ func DefaultConfig() (*Config, error) {
 			EnableLabeling:      selinuxEnabled(),
 			Env: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-				"TERM=xterm",
 			},
 			EnvHost:    false,
 			HTTPProxy:  true,

--- a/pkg/config/testdata/containers_comment.conf
+++ b/pkg/config/testdata/containers_comment.conf
@@ -18,7 +18,6 @@
 # environment variables to conmon or the runtime.
 # env = [
 #     "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-#     "TERM=xterm",
 # ]
 
 # proxy environment variables are passed into the container

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -61,7 +61,6 @@ default_sysctls = [
 # environment variables to conmon or the runtime.
 env = [
     "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-    "TERM=xterm",
 ]
 
 # Run an init inside the container that forwards signals and reaps processes.

--- a/pkg/config/testdata/containers_invalid.conf
+++ b/pkg/config/testdata/containers_invalid.conf
@@ -18,7 +18,6 @@ default_ulimits = [
 # environment variables to conmon or the runtime.
 env = [
     "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-    "TERM=xterm",
 ]
 
 # proxy environment variables are passed into the container

--- a/pkg/hooks/exec/exec_test.go
+++ b/pkg/hooks/exec/exec_test.go
@@ -113,11 +113,9 @@ func TestRunEnvironment(t *testing.T) {
 			name: "set",
 			env: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-				"TERM=xterm",
 			},
 			expected: map[string]string{
 				"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-				"TERM": "xterm",
 			},
 		},
 	} {


### PR DESCRIPTION
This should only be done in container-engines that are using a terminal.

Reverts: https://github.com/containers/common/pull/267

Related to : https://github.com/containers/podman/issues/19264
<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
