### PR TITLE
libimage/ManifestPushOptions: add `AddCompression` for `Manifest.PushOptions`

### DIFF
--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -415,6 +415,8 @@ type ManifestListPushOptions struct {
 	ImageListSelection imageCopy.ImageListSelection
 	// Use when selecting only specific imags.
 	Instances []digest.Digest
+	// Add existing instances with requested compression algorithms to manifest list
+	AddCompression []string
 }
 
 // Push pushes a manifest to the specified destination.
@@ -446,6 +448,7 @@ func (m *ManifestList) Push(ctx context.Context, destination string, options *Ma
 	defer copier.close()
 
 	pushOptions := manifests.PushOptions{
+		AddCompression:                   options.AddCompression,
 		Store:                            m.image.runtime.store,
 		SystemContext:                    copier.systemContext,
 		ImageListSelection:               options.ImageListSelection,


### PR DESCRIPTION
Podman uses different API for pushing manifest list than buildah, add `AddCompression` to ManifestPushOptions, which is implemented here: https://github.com/containers/common/pull/1585

[NO NEW TESTS NEEDED]
Tests are added here: https://github.com/containers/common/pull/1585

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
