### PR TITLE
libnetwork/etchosts: add docker.internal dns entries

### DIFF
--- a/libnetwork/etchosts/hosts.go
+++ b/libnetwork/etchosts/hosts.go
@@ -16,6 +16,7 @@ const (
 	HostContainersInternal = "host.containers.internal"
 	HostGateway            = "host-gateway"
 	localhost              = "localhost"
+	hostDockerInternal     = "host.docker.internal"
 )
 
 type HostEntries []HostEntry
@@ -119,7 +120,7 @@ func newHost(params *Params) error {
 	l2 := HostEntry{IP: "::1", Names: lh}
 	containerIPs = append(containerIPs, l1, l2)
 	if params.HostContainersInternalIP != "" {
-		e := HostEntry{IP: params.HostContainersInternalIP, Names: []string{HostContainersInternal}}
+		e := HostEntry{IP: params.HostContainersInternalIP, Names: []string{HostContainersInternal, hostDockerInternal}}
 		containerIPs = append(containerIPs, e)
 	}
 	containerIPs = append(containerIPs, params.ContainerIPs...)

--- a/libnetwork/etchosts/hosts_test.go
+++ b/libnetwork/etchosts/hosts_test.go
@@ -64,12 +64,12 @@ const targetFileContent5 = `1.1.1.1	name1
 
 const baseFileContent6 = `127.0.0.1	localhost
 ::1	localhost
-1.1.1.1 host.containers.internal
+1.1.1.1 host.containers.internal host.docker.internal
 `
 
 const targetFileContent6 = `127.0.0.1	localhost
 ::1	localhost
-1.1.1.1	host.containers.internal
+1.1.1.1	host.containers.internal host.docker.internal
 `
 
 const baseFileContent7 = `
@@ -216,21 +216,28 @@ func TestNew(t *testing.T) {
 			name:                      "with host.containers.internal ip",
 			baseFileContent:           baseFileContent1Spaces,
 			hostContainersInternal:    "10.0.0.1",
-			expectedTargetFileContent: targetFileContent1 + "10.0.0.1\thost.containers.internal\n",
+			expectedTargetFileContent: targetFileContent1 + "10.0.0.1\thost.containers.internal host.docker.internal\n",
 		},
 		{
 			name:                      "with host.containers.internal ip and host-gateway",
 			baseFileContent:           baseFileContent1Spaces,
 			extraHosts:                []string{"gatewayname:host-gateway"},
 			hostContainersInternal:    "10.0.0.1",
-			expectedTargetFileContent: "10.0.0.1\tgatewayname\n" + targetFileContent1 + "10.0.0.1\thost.containers.internal\n",
+			expectedTargetFileContent: "10.0.0.1\tgatewayname\n" + targetFileContent1 + "10.0.0.1\thost.containers.internal host.docker.internal\n",
 		},
 		{
 			name:                      "host.containers.internal not added when already present in extra hosts",
 			baseFileContent:           baseFileContent1Spaces,
 			extraHosts:                []string{"host.containers.internal:1.1.1.1"},
 			hostContainersInternal:    "10.0.0.1",
-			expectedTargetFileContent: "1.1.1.1\thost.containers.internal\n" + targetFileContent1,
+			expectedTargetFileContent: "1.1.1.1\thost.containers.internal\n" + targetFileContent1 + "10.0.0.1\thost.docker.internal\n",
+		},
+		{
+			name:                      "host.containers.internal and host.docker.internal not added when already present in extra hosts",
+			baseFileContent:           baseFileContent1Spaces,
+			extraHosts:                []string{"host.containers.internal:1.1.1.1", "host.docker.internal:1.1.1.1"},
+			hostContainersInternal:    "10.0.0.1",
+			expectedTargetFileContent: "1.1.1.1\thost.containers.internal\n1.1.1.1\thost.docker.internal\n" + targetFileContent1,
 		},
 		{
 			name:                      "host.containers.internal not added when already present in base hosts",


### PR DESCRIPTION
Some tools hard code the `host.docker.internal` dns name so it is not possible to run them with podman right now. Adding the entry is simple so we should support it for better compatibility.

see containers/podman#19361

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
