### PR TITLE
containers.conf: add field for `AddCompression` to Engine table

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -444,6 +444,17 @@ The `engine` table contains configuration options used to set up container engin
 
 Name of destination for accessing the Podman service. See SERVICE DESTINATION TABLE below.
 
+**add_compression**=[]
+
+List of compression algorithms. If set makes sure that requested compression variant
+for each platform is added to the manifest list keeping original instance intact in
+the same manifest list on every `manifest push`. Supported values are (`gzip`, `zstd` and `zstd:chunked`).
+
+Note: This is different from `compression_format` which allows users to select a default
+compression format for `push` and `manifest push`, while `add_compression` is limited to
+`manifest push` and allows users to append new instances to manifest list with specified compression
+algorithms in `add_compression` for each platform.
+
 **cgroup_manager**="systemd"
 
 The cgroup management implementation used for the runtime. Supports `cgroupfs`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -428,6 +428,9 @@ type EngineConfig struct {
 	// ActiveService index to Destinations added v2.0.3
 	ActiveService string `toml:"active_service,omitempty"`
 
+	// Add existing instances with requested compression algorithms to manifest list
+	AddCompression []string `toml:"add_compression,omitempty"`
+
 	// ServiceDestinations mapped by service Names
 	ServiceDestinations map[string]Destination `toml:"service_destinations,omitempty"`
 

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -485,6 +485,18 @@ var _ = Describe("Config Local", func() {
 		gomega.Expect(config2.Engine.ComposeProviders).To(gomega.Equal([]string{"/some/thing/else", "/than/before"}))
 	})
 
+	It("AddCompression", func() {
+		// Given
+		config, err := New(nil)
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config.Engine.AddCompression).To(gomega.BeNil()) // no hard-coding to work on all paltforms
+		// When
+		config2, err := NewConfig("testdata/containers_default.conf")
+		// Then
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config2.Engine.AddCompression).To(gomega.Equal([]string{"zstd", "zstd:chunked"}))
+	})
+
 	It("ComposeWarningLogs", func() {
 		// Given
 		config, err := New(nil)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Config", func() {
 			gomega.Expect(defaultConfig.Engine.EventsContainerCreateInspectData).To(gomega.BeFalse())
 			gomega.Expect(defaultConfig.Engine.DBBackend).To(gomega.BeEquivalentTo(stringBoltDB))
 			gomega.Expect(defaultConfig.Engine.PodmanshTimeout).To(gomega.BeEquivalentTo(30))
+			gomega.Expect(defaultConfig.Engine.AddCompression).To(gomega.BeNil())
 
 			dbBackend, err := defaultConfig.DBBackend()
 			gomega.Expect(dbBackend).To(gomega.BeEquivalentTo(DBBackendBoltDB))

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -382,6 +382,12 @@ default_sysctls = [
 #
 #active_service = "production"
 
+#List of compression algorithms. If set makes sure that requested compression variant
+#for each platform is added to the manifest list keeping original instance intact in
+#the same manifest list on every `manifest push`. Supported values are (`gzip`, `zstd` and `zstd:chunked`).
+#
+#add_compression = ["gzip", "zstd", "zstd:chunked"]
+
 # Enforces using docker.io for completing short names in Podman's compatibility
 # REST API. Note that this will ignore unqualified-search-registries and
 # short-name aliases defined in containers-registries.conf(5).

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -132,6 +132,8 @@ pasta_options = ["-t", "auto"]
 
 [engine]
 
+add_compression = ["zstd", "zstd:chunked"]
+
 # Cgroup management implementation used for the runtime.
 cgroup_manager = "systemd"
 


### PR DESCRIPTION
Allows users to set default value of `AddCompression` to Engine table so users of `podman` and `buildah` can use https://github.com/containers/buildah/pull/4912 by default.

Closes: https://github.com/containers/buildah/pull/4912#issuecomment-1661105029

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
