### PR TITLE
containers.conf: implement modules

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -30,6 +30,26 @@ Note, container engines also use other configuration files for configuring the e
 container images.
 * `policy.conf` for controlling which images can be pulled to the system.
 
+## ENVIRONMENT VARIABLES
+If the `CONTAINERS_CONF` environment variable is set, all system and user
+config files are ignored and only the specified config file will be loaded.
+
+If the `CONTAINERS_CONF_OVERRIDE` path environment variable is set, the config
+file will be loaded last even when `CONTAINERS_CONF` is set.
+
+The values of both environment variables may be absolute or relative paths, for
+instance, `CONTAINERS_CONF=/tmp/my_containers.conf`.
+
+## MODULES
+A module is a containers.conf file located directly in or a sub-directory of the following three directories:
+ - __$HOME/.config/containers/containers.conf.modules__
+ - __/etc/containers/containers.conf.modules__
+ - __/usr/share/containers/containers.conf.modules__
+
+Files in those locations are not loaded by default but only on-demand.  They are loaded after all system and user configuration files but before `CONTAINERS_CONF_OVERRIDE` hence allowing for overriding system and user configs.
+
+Modules are currently supported by podman(1).  The `podman --module` flag allows for loading a module and can be specified multiple times.  If the specified value is an absolute path, the config file will be loaded directly.  Relative paths are resolved relative to the three module directories mentioned above and in the specified order such that modules in `$HOME` allow for overriding those in `/etc` and `/usr/share`.  Modules in `$HOME` (or `$XDG_CONFIG_HOME` if specified) are only used for rootless users.
+
 # FORMAT
 The [TOML format][toml] is used as the encoding of the configuration file.
 Every option is nested under its table. No bare options are used. The format of
@@ -870,15 +890,6 @@ configuration. They may also drop `.conf` files in
 __/etc/containers/containers.conf.d__ which will be loaded in alphanumeric order.
 Rootless users can further override fields in the config by creating a config
 file stored in the __$HOME/.config/containers/containers.conf__ file or __.conf__ files in __$HOME/.config/containers/containers.conf.d__.
-
-If the `CONTAINERS_CONF` environment variable is set, all system and user
-config files are ignored and only the specified config file will be loaded.
-
-If the `CONTAINERS_CONF_OVERRIDE` path environment variable is set, the config
-file will be loaded last even when `CONTAINERS_CONF` is set.
-
-The values of both environment variables may be absolute or relative paths, for
-instance, `CONTAINERS_CONF=/tmp/my_containers.conf`.
 
 Fields specified in a containers.conf file override the default options, as
 well as options in previously loaded containers.conf files.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -716,8 +716,8 @@ func (c *EngineConfig) ImagePlatformToRuntime(os string, arch string) string {
 // with cgroupv2v2. Other OCI runtimes are not yet supporting cgroupv2v2. This
 // might change in the future.
 func NewConfig(userConfigPath string) (*Config, error) {
-	// Generate the default config for the system
-	config, err := DefaultConfig()
+	// Start with the built-in defaults
+	config, err := defaultConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,6 +78,8 @@ type Config struct {
 	ConfigMaps ConfigMapConfig `toml:"configmaps"`
 	// Farms defines configurations for the buildfarm farms
 	Farms FarmConfig `toml:"farms"`
+
+	loadedModules []string // only used at runtime to store which modules were loaded
 }
 
 // ContainersConfig represents the "containers" TOML config table

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -16,69 +16,80 @@ import (
 )
 
 var _ = Describe("Config Local", func() {
-	BeforeEach(beforeEach)
-
 	It("should not fail on invalid NetworkConfigDir", func() {
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 		// Given
 		tmpfile := path.Join(os.TempDir(), "wrong-file")
 		file, err := os.Create(tmpfile)
 		gomega.Expect(err).To(gomega.BeNil())
 		file.Close()
 		defer os.Remove(tmpfile)
-		sut.Network.NetworkConfigDir = tmpfile
-		sut.Network.CNIPluginDirs = []string{}
+		defConf.Network.NetworkConfigDir = tmpfile
+		defConf.Network.CNIPluginDirs = []string{}
 
 		// When
-		err = sut.Network.Validate()
+		err = defConf.Network.Validate()
 
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
 	})
 
 	It("should not fail on invalid CNIPluginDirs", func() {
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 		validDirPath, err := os.MkdirTemp("", "config-empty")
 		if err != nil {
 			panic(err)
 		}
 		defer os.RemoveAll(validDirPath)
+
 		// Given
-		sut.Network.NetworkConfigDir = validDirPath
-		sut.Network.CNIPluginDirs = []string{invalidPath}
+		defConf.Network.NetworkConfigDir = validDirPath
+		defConf.Network.CNIPluginDirs = []string{invalidPath}
 
 		// When
-		err = sut.Network.Validate()
+		err = defConf.Network.Validate()
 
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
 	})
 
 	It("should fail on invalid subnet pool", func() {
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 		validDirPath, err := os.MkdirTemp("", "config-empty")
 		if err != nil {
 			panic(err)
 		}
 		defer os.RemoveAll(validDirPath)
 		// Given
-		sut.Network.NetworkConfigDir = validDirPath
-		sut.Network.CNIPluginDirs = []string{validDirPath}
+		defConf.Network.NetworkConfigDir = validDirPath
+		defConf.Network.CNIPluginDirs = []string{validDirPath}
 
 		net, _ := types.ParseCIDR("10.0.0.0/24")
-		sut.Network.DefaultSubnetPools = []SubnetPool{
+		defConf.Network.DefaultSubnetPools = []SubnetPool{
 			{Base: &net, Size: 16},
 		}
 
 		// When
-		err = sut.Network.Validate()
+		err = defConf.Network.Validate()
 
 		// Then
 		gomega.Expect(err).NotTo(gomega.BeNil())
 
-		sut.Network.DefaultSubnetPools = []SubnetPool{
+		defConf.Network.DefaultSubnetPools = []SubnetPool{
 			{Base: &net, Size: 33},
 		}
 
 		// When
-		err = sut.Network.Validate()
+		err = defConf.Network.Validate()
 
 		// Then
 		gomega.Expect(err).NotTo(gomega.BeNil())
@@ -138,99 +149,135 @@ var _ = Describe("Config Local", func() {
 	})
 
 	It("should fail on invalid device mode", func() {
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 		// Given
-		sut.Containers.Devices = []string{"/dev/null:/dev/null:abc"}
+		defConf.Containers.Devices = []string{"/dev/null:/dev/null:abc"}
 
 		// When
-		err := sut.Containers.Validate()
+		err = defConf.Containers.Validate()
 
 		// Then
 		gomega.Expect(err).NotTo(gomega.BeNil())
 	})
 
 	It("should fail on invalid first device", func() {
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 		// Given
-		sut.Containers.Devices = []string{"wrong:/dev/null:rw"}
+		defConf.Containers.Devices = []string{"wrong:/dev/null:rw"}
 
 		// When
-		err := sut.Containers.Validate()
+		err = defConf.Containers.Validate()
 
 		// Then
 		gomega.Expect(err).NotTo(gomega.BeNil())
 	})
 
 	It("should fail on invalid second device", func() {
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 		// Given
-		sut.Containers.Devices = []string{"/dev/null:wrong:rw"}
+		defConf.Containers.Devices = []string{"/dev/null:wrong:rw"}
 
 		// When
-		err := sut.Containers.Validate()
+		err = defConf.Containers.Validate()
 
 		// Then
 		gomega.Expect(err).NotTo(gomega.BeNil())
 	})
 
 	It("should fail on invalid device", func() {
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 		// Given
-		sut.Containers.Devices = []string{invalidPath}
+		defConf.Containers.Devices = []string{invalidPath}
 
 		// When
-		err := sut.Containers.Validate()
+		err = defConf.Containers.Validate()
 
 		// Then
 		gomega.Expect(err).NotTo(gomega.BeNil())
 	})
 
 	It("should fail on wrong invalid device specification", func() {
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 		// Given
-		sut.Containers.Devices = []string{"::::"}
+		defConf.Containers.Devices = []string{"::::"}
 
 		// When
-		err := sut.Containers.Validate()
+		err = defConf.Containers.Validate()
 
 		// Then
 		gomega.Expect(err).NotTo(gomega.BeNil())
 	})
 
 	It("should fail on bad timezone", func() {
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 		// Given
-		sut.Containers.TZ = "foo"
+		defConf.Containers.TZ = "foo"
 
 		// When
-		err := sut.Containers.Validate()
+		err = defConf.Containers.Validate()
 
 		// Then
 		gomega.Expect(err).NotTo(gomega.BeNil())
 	})
 
 	It("should succeed on good timezone", func() {
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 		// Given
-		sut.Containers.TZ = "US/Eastern"
+		defConf.Containers.TZ = "US/Eastern"
 
 		// When
-		err := sut.Containers.Validate()
+		err = defConf.Containers.Validate()
 
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
 	})
 
 	It("should succeed on local timezone", func() {
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 		// Given
-		sut.Containers.TZ = "local"
+		defConf.Containers.TZ = "local"
 
 		// When
-		err := sut.Containers.Validate()
+		err = defConf.Containers.Validate()
 
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
 	})
 
 	It("should fail on wrong DefaultUlimits", func() {
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 		// Given
-		sut.Containers.DefaultUlimits = []string{invalidPath}
+		defConf.Containers.DefaultUlimits = []string{invalidPath}
 
 		// When
-		err := sut.Containers.Validate()
+		err = defConf.Containers.Validate()
 
 		// Then
 		gomega.Expect(err).NotTo(gomega.BeNil())
@@ -337,11 +384,15 @@ var _ = Describe("Config Local", func() {
 		gomega.Expect(config.Containers.Umask).To(gomega.Equal("0002"))
 	})
 	It("Should fail on bad Umask", func() {
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 		// Given
-		sut.Containers.Umask = "88888"
+		defConf.Containers.Umask = "88888"
 
 		// When
-		err := sut.Containers.Validate()
+		err = defConf.Containers.Validate()
 
 		// Then
 		gomega.Expect(err).NotTo(gomega.BeNil())

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Config Local", func() {
 
 	It("parse dns port", func() {
 		// Given
-		config, err := NewConfig("")
+		config, err := New(nil)
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config.Network.DNSBindPort).To(gomega.Equal(uint16(0)))
 		// When
@@ -126,7 +126,7 @@ var _ = Describe("Config Local", func() {
 
 	It("parse pasta_options", func() {
 		// Given
-		config, err := NewConfig("")
+		config, err := New(nil)
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config.Network.PastaOptions).To(gomega.BeNil())
 		// When
@@ -298,7 +298,7 @@ var _ = Describe("Config Local", func() {
 	It("Expect Remote to be False", func() {
 		// Given
 		// When
-		config, err := NewConfig("")
+		config, err := New(nil)
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config.Engine.Remote).To(gomega.BeFalse())
@@ -370,7 +370,7 @@ var _ = Describe("Config Local", func() {
 	It("Default Umask", func() {
 		// Given
 		// When
-		config, err := NewConfig("")
+		config, err := New(nil)
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config.Containers.Umask).To(gomega.Equal("0022"))
@@ -400,7 +400,7 @@ var _ = Describe("Config Local", func() {
 
 	It("Set Machine Enabled", func() {
 		// Given
-		config, err := NewConfig("")
+		config, err := New(nil)
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config.Engine.MachineEnabled).To(gomega.Equal(false))
 		// When
@@ -412,7 +412,7 @@ var _ = Describe("Config Local", func() {
 
 	It("default netns", func() {
 		// Given
-		config, err := NewConfig("")
+		config, err := New(nil)
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config.Containers.NetNS).To(gomega.Equal("private"))
 		// When
@@ -448,7 +448,7 @@ var _ = Describe("Config Local", func() {
 
 	It("Set machine image path", func() {
 		// Given
-		config, err := NewConfig("")
+		config, err := New(nil)
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config.Machine.Image).To(gomega.Equal("testing"))
 		// When
@@ -463,7 +463,7 @@ var _ = Describe("Config Local", func() {
 
 	It("CompatAPIEnforceDockerHub", func() {
 		// Given
-		config, err := NewConfig("")
+		config, err := New(nil)
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config.Engine.CompatAPIEnforceDockerHub).To(gomega.Equal(true))
 		// When
@@ -475,7 +475,7 @@ var _ = Describe("Config Local", func() {
 
 	It("ComposeProviders", func() {
 		// Given
-		config, err := NewConfig("")
+		config, err := New(nil)
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config.Engine.ComposeProviders).To(gomega.Equal(getDefaultComposeProviders())) // no hard-coding to work on all paltforms
 		// When
@@ -487,7 +487,7 @@ var _ = Describe("Config Local", func() {
 
 	It("ComposeWarningLogs", func() {
 		// Given
-		config, err := NewConfig("")
+		config, err := New(nil)
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config.Engine.ComposeWarningLogs).To(gomega.Equal(true))
 		// When
@@ -499,7 +499,7 @@ var _ = Describe("Config Local", func() {
 
 	It("Set machine disk", func() {
 		// Given
-		config, err := NewConfig("")
+		config, err := New(nil)
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config.Machine.DiskSize).To(gomega.Equal(uint64(100)))
 		// When
@@ -510,7 +510,7 @@ var _ = Describe("Config Local", func() {
 	})
 	It("Set machine CPUs", func() {
 		// Given
-		config, err := NewConfig("")
+		config, err := New(nil)
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config.Machine.CPUs).To(gomega.Equal(uint64(1)))
 		// When
@@ -521,7 +521,7 @@ var _ = Describe("Config Local", func() {
 	})
 	It("Set machine memory", func() {
 		// Given
-		config, err := NewConfig("")
+		config, err := New(nil)
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config.Machine.Memory).To(gomega.Equal(uint64(2048)))
 		// When

--- a/pkg/config/config_remote_test.go
+++ b/pkg/config/config_remote_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Config Remote", func() {
 	It("Expect Remote to be true", func() {
 		// Given
 		// When
-		config, err := NewConfig("")
+		config, err := New(nil)
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(config.Engine.Remote).To(gomega.BeTrue())

--- a/pkg/config/config_remote_test.go
+++ b/pkg/config/config_remote_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 var _ = Describe("Config Remote", func() {
-	BeforeEach(beforeEach)
-
 	It("should succeed on invalid CNIPluginDirs", func() {
 		validDirPath, err := os.MkdirTemp("", "config-empty")
 		if err != nil {
@@ -20,11 +18,15 @@ var _ = Describe("Config Remote", func() {
 		}
 		defer os.RemoveAll(validDirPath)
 		// Given
-		sut.Network.NetworkConfigDir = validDirPath
-		sut.Network.CNIPluginDirs = []string{invalidPath}
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+
+		defConf.Network.NetworkConfigDir = validDirPath
+		defConf.Network.CNIPluginDirs = []string{invalidPath}
 
 		// When
-		err = sut.Network.Validate()
+		err = defConf.Network.Validate()
 
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
@@ -32,10 +34,13 @@ var _ = Describe("Config Remote", func() {
 
 	It("should succeed on invalid device mode", func() {
 		// Given
-		sut.Containers.Devices = []string{"/dev/null:/dev/null:abc"}
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+		defConf.Containers.Devices = []string{"/dev/null:/dev/null:abc"}
 
 		// When
-		err := sut.Containers.Validate()
+		err = defConf.Containers.Validate()
 
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
@@ -43,10 +48,13 @@ var _ = Describe("Config Remote", func() {
 
 	It("should succeed on invalid first device", func() {
 		// Given
-		sut.Containers.Devices = []string{"wrong:/dev/null:rw"}
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+		defConf.Containers.Devices = []string{"wrong:/dev/null:rw"}
 
 		// When
-		err := sut.Containers.Validate()
+		err = defConf.Containers.Validate()
 
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
@@ -54,10 +62,13 @@ var _ = Describe("Config Remote", func() {
 
 	It("should succeed on invalid second device", func() {
 		// Given
-		sut.Containers.Devices = []string{"/dev/null:wrong:rw"}
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+		defConf.Containers.Devices = []string{"/dev/null:wrong:rw"}
 
 		// When
-		err := sut.Containers.Validate()
+		err = defConf.Containers.Validate()
 
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
@@ -65,10 +76,13 @@ var _ = Describe("Config Remote", func() {
 
 	It("should succeed on invalid device", func() {
 		// Given
-		sut.Containers.Devices = []string{invalidPath}
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+		defConf.Containers.Devices = []string{invalidPath}
 
 		// When
-		err := sut.Containers.Validate()
+		err = defConf.Containers.Validate()
 
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
@@ -76,10 +90,13 @@ var _ = Describe("Config Remote", func() {
 
 	It("should succeed on wrong invalid device specification", func() {
 		// Given
-		sut.Containers.Devices = []string{"::::"}
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+		defConf.Containers.Devices = []string{"::::"}
 
 		// When
-		err := sut.Containers.Validate()
+		err = defConf.Containers.Validate()
 
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
@@ -96,10 +113,13 @@ var _ = Describe("Config Remote", func() {
 
 	It("should succeed on wrong DefaultUlimits", func() {
 		// Given
-		sut.Containers.DefaultUlimits = []string{invalidPath}
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+		defConf.Containers.DefaultUlimits = []string{invalidPath}
 
 		// When
-		err := sut.Containers.Validate()
+		err = defConf.Containers.Validate()
 
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
@@ -112,11 +132,14 @@ var _ = Describe("Config Remote", func() {
 		}
 		defer os.RemoveAll(validDirPath)
 		// Given
-		sut.Network.NetworkConfigDir = validDirPath
-		sut.Network.CNIPluginDirs = []string{invalidPath}
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+		defConf.Network.NetworkConfigDir = validDirPath
+		defConf.Network.CNIPluginDirs = []string{invalidPath}
 
 		// When
-		err = sut.Network.Validate()
+		err = defConf.Network.Validate()
 
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
@@ -129,11 +152,14 @@ var _ = Describe("Config Remote", func() {
 		}
 		defer os.RemoveAll(validDirPath)
 		// Given
-		sut.Network.NetworkConfigDir = validDirPath
-		sut.Network.CNIPluginDirs = []string{invalidPath}
+		defConf, err := defaultConfig()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+		defConf.Network.NetworkConfigDir = validDirPath
+		defConf.Network.CNIPluginDirs = []string{invalidPath}
 
 		// When
-		err = sut.Network.Validate()
+		err = defConf.Network.Validate()
 
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())

--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -19,12 +19,8 @@ const (
 var sut *Config
 
 func beforeEach() {
-	sut = defaultConfig()
-}
-
-func defaultConfig() *Config {
-	c, err := DefaultConfig()
+	c, err := defaultConfig()
 	gomega.Expect(err).To(gomega.BeNil())
 	gomega.Expect(c).NotTo(gomega.BeNil())
-	return c
+	sut = c
 }

--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -15,12 +15,3 @@ func TestConfig(t *testing.T) {
 const (
 	invalidPath = "/wrong"
 )
-
-var sut *Config
-
-func beforeEach() {
-	c, err := defaultConfig()
-	gomega.Expect(err).To(gomega.BeNil())
-	gomega.Expect(c).NotTo(gomega.BeNil())
-	sut = c
-}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -166,7 +166,7 @@ image_copy_tmp_dir="storage"`
 		It("should succeed with default config", func() {
 			// Given
 			// When
-			defaultConfig, _ := DefaultConfig()
+			defaultConfig, _ := defaultConfig()
 			// prior to reading local config, shows hard coded defaults
 			gomega.Expect(defaultConfig.Containers.HTTPProxy).To(gomega.Equal(true))
 
@@ -303,7 +303,7 @@ image_copy_tmp_dir="storage"`
 			oldFoo, fooEnvSet := os.LookupEnv("foo")
 			os.Setenv("foo", "bar")
 
-			defaultConfig, _ := DefaultConfig()
+			defaultConfig, _ := defaultConfig()
 			gomega.Expect(defaultConfig.GetDefaultEnvEx(false, false)).To(gomega.BeEquivalentTo(envs))
 			gomega.Expect(defaultConfig.GetDefaultEnvEx(false, true)).To(gomega.BeEquivalentTo(httpEnvs))
 			gomega.Expect(strings.Join(defaultConfig.GetDefaultEnvEx(true, true), ",")).To(gomega.ContainSubstring("HTTP_PROXY"))

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,8 +18,6 @@ import (
 )
 
 var _ = Describe("Config", func() {
-	BeforeEach(beforeEach)
-
 	Describe("ValidateConfig", func() {
 		It("should succeed with default config", func() {
 			// Given
@@ -57,8 +55,12 @@ var _ = Describe("Config", func() {
 		})
 
 		It("should succeed with devices", func() {
+			defConf, err := defaultConfig()
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 			// Given
-			sut.Containers.Devices = []string{
+			defConf.Containers.Devices = []string{
 				"/dev/null:/dev/null:rw",
 				"/dev/sdc/",
 				"/dev/sdc:/dev/xvdc",
@@ -66,49 +68,61 @@ var _ = Describe("Config", func() {
 			}
 
 			// When
-			err := sut.Containers.Validate()
+			err = defConf.Containers.Validate()
 
 			// Then
 			gomega.Expect(err).To(gomega.BeNil())
 		})
 
 		It("should fail wrong max log size", func() {
+			defConf, err := defaultConfig()
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 			// Given
-			sut.Containers.LogSizeMax = 1
+			defConf.Containers.LogSizeMax = 1
 
 			// When
-			err := sut.Validate()
+			err = defConf.Validate()
 
 			// Then
 			gomega.Expect(err).NotTo(gomega.BeNil())
 		})
 
 		It("should succeed with valid shm size", func() {
+			defConf, err := defaultConfig()
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 			// Given
-			sut.Containers.ShmSize = "1024"
+			defConf.Containers.ShmSize = "1024"
 
 			// When
-			err := sut.Validate()
+			err = defConf.Validate()
 
 			// Then
 			gomega.Expect(err).To(gomega.BeNil())
 
 			// Given
-			sut.Containers.ShmSize = "64m"
+			defConf.Containers.ShmSize = "64m"
 
 			// When
-			err = sut.Validate()
+			err = defConf.Validate()
 
 			// Then
 			gomega.Expect(err).To(gomega.BeNil())
 		})
 
 		It("should fail wrong shm size", func() {
+			defConf, err := defaultConfig()
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 			// Given
-			sut.Containers.ShmSize = "-2"
+			defConf.Containers.ShmSize = "-2"
 
 			// When
-			err := sut.Validate()
+			err = defConf.Validate()
 
 			// Then
 			gomega.Expect(err).NotTo(gomega.BeNil())
@@ -124,9 +138,13 @@ var _ = Describe("Config", func() {
 
 	Describe("ValidateNetworkConfig", func() {
 		It("should succeed with default config", func() {
+			defConf, err := defaultConfig()
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(defConf).NotTo(gomega.BeNil())
+
 			// Given
 			// When
-			err := sut.Network.Validate()
+			err = defConf.Network.Validate()
 
 			// Then
 			gomega.Expect(err).To(gomega.BeNil())
@@ -589,30 +607,46 @@ image_copy_tmp_dir="storage"`
 		})
 
 		It("should succeed with default pull_policy", func() {
-			err := sut.Engine.Validate()
+			defConf, err := defaultConfig()
 			gomega.Expect(err).To(gomega.BeNil())
-			gomega.Expect(sut.Engine.PullPolicy).To(gomega.Equal("missing"))
+			gomega.Expect(defConf).NotTo(gomega.BeNil())
 
-			sut.Engine.PullPolicy = DefaultPullPolicy
-			err = sut.Engine.Validate()
+			err = defConf.Engine.Validate()
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(defConf.Engine.PullPolicy).To(gomega.Equal("missing"))
+
+			defConf.Engine.PullPolicy = DefaultPullPolicy
+			err = defConf.Engine.Validate()
 			gomega.Expect(err).To(gomega.BeNil())
 		})
 
 		It("should succeed case-insensitive", func() {
-			sut.Engine.PullPolicy = "NeVer"
-			err := sut.Engine.Validate()
+			defConf, err := defaultConfig()
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(defConf).NotTo(gomega.BeNil())
+
+			defConf.Engine.PullPolicy = "NeVer"
+			err = defConf.Engine.Validate()
 			gomega.Expect(err).To(gomega.BeNil())
 		})
 
 		It("should fail with invalid pull_policy", func() {
-			sut.Engine.PullPolicy = "invalidPullPolicy"
-			err := sut.Engine.Validate()
+			defConf, err := defaultConfig()
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(defConf).NotTo(gomega.BeNil())
+
+			defConf.Engine.PullPolicy = "invalidPullPolicy"
+			err = defConf.Engine.Validate()
 			gomega.Expect(err).ToNot(gomega.BeNil())
 		})
 
 		It("should fail with invalid database_backend", func() {
-			sut.Engine.DBBackend = ""
-			err := sut.Engine.Validate()
+			defConf, err := defaultConfig()
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(defConf).NotTo(gomega.BeNil())
+
+			defConf.Engine.DBBackend = ""
+			err = defConf.Engine.Validate()
 			gomega.Expect(err).ToNot(gomega.BeNil())
 		})
 	})

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -159,7 +159,7 @@ const (
 
 // DefaultConfig defines the default values from containers.conf.
 func DefaultConfig() (*Config, error) {
-	defaultEngineConfig, err := defaultConfigFromMemory()
+	defaultEngineConfig, err := defaultEngineConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -266,9 +266,9 @@ func defaultFarmConfig() FarmConfig {
 	}
 }
 
-// defaultConfigFromMemory returns a default engine configuration. Note that the
+// defaultEngineConfig eturns a default engine configuration. Note that the
 // config is different for root and rootless. It also parses the storage.conf.
-func defaultConfigFromMemory() (*EngineConfig, error) {
+func defaultEngineConfig() (*EngineConfig, error) {
 	c := new(EngineConfig)
 	tmp, err := defaultTmpDir()
 	if err != nil {

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -157,8 +157,10 @@ const (
 	DefaultVolumePluginTimeout = 5
 )
 
-// DefaultConfig defines the default values from containers.conf.
-func DefaultConfig() (*Config, error) {
+// defaultConfig returns Config with builtin defaults and minimal adjustments
+// to the current host only. It does not read any config files from the host or
+// the environment.
+func defaultConfig() (*Config, error) {
 	defaultEngineConfig, err := defaultEngineConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/config/modules.go
+++ b/pkg/config/modules.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/containers/storage/pkg/homedir"
+	"github.com/containers/storage/pkg/unshare"
+	"github.com/hashicorp/go-multierror"
+)
+
+// The subdirectory for looking up containers.conf modules.
+const moduleSubdir = "containers/containers.conf.modules"
+
+// Moving the base paths into variables allows for overriding them in units
+// tests.
+var (
+	moduleBaseEtc = "/etc/"
+	moduleBaseUsr = "/usr/share"
+)
+
+// Find the specified modules in the options.  Return an error if a specific
+// module cannot be located on the host.
+func (o *Options) modules() ([]string, error) {
+	if len(o.Modules) == 0 {
+		return nil, nil
+	}
+
+	dirs, err := ModuleDirectories()
+	if err != nil {
+		return nil, err
+	}
+
+	configs := make([]string, 0, len(o.Modules))
+	for _, path := range o.Modules {
+		resolved, err := resolveModule(path, dirs)
+		if err != nil {
+			return nil, fmt.Errorf("could not resolve module %q: %w", path, err)
+		}
+		configs = append(configs, resolved)
+	}
+
+	return configs, nil
+}
+
+// ModuleDirectories return the directories to load modules from:
+// 1) XDG_CONFIG_HOME/HOME if rootless
+// 2) /etc/
+// 3) /usr/share
+func ModuleDirectories() ([]string, error) { // Public API for shell completions in Podman
+	modules := []string{
+		filepath.Join(moduleBaseEtc, moduleSubdir),
+		filepath.Join(moduleBaseUsr, moduleSubdir),
+	}
+
+	if !unshare.IsRootless() {
+		return modules, nil
+	}
+
+	// Prepend the user modules dir.
+	configHome, err := homedir.GetConfigHome()
+	if err != nil {
+		return nil, err
+	}
+	return append([]string{filepath.Join(configHome, moduleSubdir)}, modules...), nil
+}
+
+// Resolve the specified path to a module.
+func resolveModule(path string, dirs []string) (string, error) {
+	if filepath.IsAbs(path) {
+		_, err := os.Stat(path)
+		return path, err
+	}
+
+	// Collect all errors to avoid suppressing important errors (e.g.,
+	// permission errors).
+	var multiErr error
+	for _, d := range dirs {
+		candidate := filepath.Join(d, path)
+		_, err := os.Stat(candidate)
+		if err == nil {
+			return candidate, nil
+		}
+		multiErr = multierror.Append(multiErr, err)
+	}
+	return "", multiErr
+}

--- a/pkg/config/modules.go
+++ b/pkg/config/modules.go
@@ -20,6 +20,13 @@ var (
 	moduleBaseUsr = "/usr/share"
 )
 
+// LoadedModules returns absolute paths to loaded containers.conf modules.
+func (c *Config) LoadedModules() []string {
+	// Required for conmon's callback to Podman's cleanup.
+	// Absolute paths make loading the modules a bit faster.
+	return c.loadedModules
+}
+
 // Find the specified modules in the options.  Return an error if a specific
 // module cannot be located on the host.
 func (o *Options) modules() ([]string, error) {

--- a/pkg/config/modules_test.go
+++ b/pkg/config/modules_test.go
@@ -1,0 +1,180 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/containers/storage/pkg/unshare"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+const (
+	testBaseHome = "testdata/modules/home/.config"
+	testBaseEtc  = "testdata/modules/etc"
+	testBaseUsr  = "testdata/modules/usr/share"
+)
+
+func testSetModulePaths() (func(), error) {
+	oldXDG := os.Getenv("XDG_CONFIG_HOME")
+	oldEtc := moduleBaseEtc
+	oldUsr := moduleBaseUsr
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.Setenv("XDG_CONFIG_HOME", filepath.Join(wd, testBaseHome)); err != nil {
+		return nil, err
+	}
+
+	moduleBaseEtc = filepath.Join(wd, testBaseEtc)
+	moduleBaseUsr = filepath.Join(wd, testBaseUsr)
+
+	return func() {
+		os.Setenv("XDG_CONFIG_HOME", oldXDG)
+		moduleBaseEtc = oldEtc
+		moduleBaseUsr = oldUsr
+	}, nil
+}
+
+var _ = Describe("Config Modules", func() {
+	It("module directories", func() {
+		dirs, err := ModuleDirectories()
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(dirs).NotTo(gomega.BeNil())
+
+		if unshare.IsRootless() {
+			gomega.Expect(dirs).To(gomega.HaveLen(3))
+		} else {
+			gomega.Expect(dirs).To(gomega.HaveLen(2))
+		}
+	})
+
+	It("resolve modules", func() {
+		// This test makes sure that the correct module is being
+		// returned.
+		cleanUp, err := testSetModulePaths()
+		gomega.Expect(err).To(gomega.BeNil())
+		defer cleanUp()
+
+		dirs, err := ModuleDirectories()
+		gomega.Expect(err).To(gomega.BeNil())
+
+		if unshare.IsRootless() {
+			gomega.Expect(dirs).To(gomega.HaveLen(3))
+			gomega.Expect(dirs[0]).To(gomega.ContainSubstring(testBaseHome))
+			gomega.Expect(dirs[1]).To(gomega.ContainSubstring(testBaseEtc))
+			gomega.Expect(dirs[2]).To(gomega.ContainSubstring(testBaseUsr))
+		} else {
+			gomega.Expect(dirs).To(gomega.HaveLen(2))
+			gomega.Expect(dirs[0]).To(gomega.ContainSubstring(testBaseEtc))
+			gomega.Expect(dirs[1]).To(gomega.ContainSubstring(testBaseUsr))
+		}
+
+		for _, test := range []struct {
+			input       string
+			expectedDir string
+			mustFail    bool
+			rootless    bool
+		}{
+			// Rootless
+			{"first.conf", testBaseHome, false, true},
+			{"second.conf", testBaseHome, false, true},
+			{"third.conf", testBaseHome, false, true},
+			{"sub/first.conf", testBaseHome, false, true},
+
+			// Root + Rootless
+			{"fourth.conf", testBaseEtc, false, false},
+			{"sub/etc-only.conf", testBaseEtc, false, false},
+			{"fifth.conf", testBaseUsr, false, false},
+			{"sub/share-only.conf", testBaseUsr, false, false},
+			{"none.conf", "", true, false},
+		} {
+			if test.rootless && !unshare.IsRootless() {
+				continue
+			}
+			result, err := resolveModule(test.input, dirs)
+			if test.mustFail {
+				gomega.Expect(err).NotTo(gomega.BeNil())
+				continue
+			}
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(result).To(gomega.HaveSuffix(filepath.Join(test.expectedDir, moduleSubdir, test.input)))
+		}
+	})
+
+	It("new config with modules", func() {
+		cleanUp, err := testSetModulePaths()
+		gomega.Expect(err).To(gomega.BeNil())
+		defer cleanUp()
+
+		options := &Options{Modules: []string{"none.conf"}}
+		_, err = New(options)
+		gomega.Expect(err).NotTo(gomega.BeNil()) // must error out
+
+		options = &Options{}
+		c, err := New(options)
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(options.additionalConfigs).To(gomega.HaveLen(0)) // no module is getting loaded!
+		gomega.Expect(c).NotTo(gomega.BeNil())
+
+		options = &Options{Modules: []string{"fourth.conf"}}
+		c, err = New(options)
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(options.additionalConfigs).To(gomega.HaveLen(1)) // 1 module is getting loaded!
+		gomega.Expect(c.Containers.InitPath).To(gomega.Equal("etc four"))
+
+		options = &Options{Modules: []string{"fourth.conf"}}
+		c, err = New(options)
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(options.additionalConfigs).To(gomega.HaveLen(1)) // 1 module is getting loaded!
+		gomega.Expect(c.Containers.InitPath).To(gomega.Equal("etc four"))
+
+		options = &Options{Modules: []string{"fourth.conf", "sub/share-only.conf", "sub/etc-only.conf"}}
+		c, err = New(options)
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(options.additionalConfigs).To(gomega.HaveLen(3)) // 3 modules are getting loaded!
+		gomega.Expect(c.Containers.InitPath).To(gomega.Equal("etc four"))
+		gomega.Expect(c.Containers.Env).To(gomega.Equal([]string{"usr share only"}))
+		gomega.Expect(c.Network.DefaultNetwork).To(gomega.Equal("etc only conf"))
+
+		options = &Options{Modules: []string{"third.conf"}}
+		c, err = New(options)
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(options.additionalConfigs).To(gomega.HaveLen(1)) // 1 module is getting loaded!
+		if unshare.IsRootless() {
+			gomega.Expect(c.Network.DefaultNetwork).To(gomega.Equal("home third"))
+		} else {
+			gomega.Expect(c.Network.DefaultNetwork).To(gomega.Equal("etc third"))
+		}
+	})
+
+	It("new config with modules and env variables", func() {
+		cleanUp, err := testSetModulePaths()
+		gomega.Expect(err).To(gomega.BeNil())
+		defer cleanUp()
+
+		oldOverride := os.Getenv(containersConfOverrideEnv)
+		defer func() {
+			os.Setenv(containersConfOverrideEnv, oldOverride)
+		}()
+
+		err = os.Setenv(containersConfOverrideEnv, "testdata/modules/override.conf")
+		gomega.Expect(err).To(gomega.BeNil())
+
+		// Also make sure that absolute paths are loaded as is.
+		wd, err := os.Getwd()
+		gomega.Expect(err).To(gomega.BeNil())
+		absConf := filepath.Join(wd, "testdata/modules/home/.config/containers/containers.conf.modules/second.conf")
+
+		options := &Options{Modules: []string{"fourth.conf", "sub/share-only.conf", absConf}}
+		c, err := New(options)
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(options.additionalConfigs).To(gomega.HaveLen(4)) // 2 modules + abs path + override conf are getting loaded!
+		gomega.Expect(c.Containers.InitPath).To(gomega.Equal("etc four"))
+		gomega.Expect(c.Containers.Env).To(gomega.Equal([]string{"override conf always wins"}))
+		gomega.Expect(c.Containers.Volumes).To(gomega.Equal([]string{"home second"}))
+	})
+})

--- a/pkg/config/new.go
+++ b/pkg/config/new.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	cachedConfigError error
+	cachedConfigMutex sync.Mutex
+	cachedConfig      *Config
+)
+
+// Options to use when loading a Config via New().
+type Options struct {
+	// Set the loaded config as the default one which can later on be
+	// accessed via Default().
+	SetDefault bool
+
+	// Additional configs that will be loaded after all system/user configs
+	// and environment variables but the _OVERRIDE one.
+	additionalConfigs []string
+}
+
+// New returns a Config as described in the containers.conf(5) man page.
+func New(options *Options) (*Config, error) {
+	if options == nil {
+		options = &Options{}
+	}
+	cachedConfigMutex.Lock()
+	defer cachedConfigMutex.Unlock()
+	return newLocked(options)
+}
+
+// A helper function for New() expecting the caller to hold the
+// cachedConfigMutex.
+func newLocked(options *Options) (*Config, error) {
+	// The _OVERRIDE variable _must_ always win.  That's a contract we need
+	// to honor (for the Podman CI).
+	if path := os.Getenv("CONTAINERS_CONF_OVERRIDE"); path != "" {
+		if _, err := os.Stat(path); err != nil {
+			return nil, fmt.Errorf("CONTAINERS_CONF_OVERRIDE file: %w", err)
+		}
+		options.additionalConfigs = append(options.additionalConfigs, path)
+	}
+
+	// Start with the built-in defaults
+	config, err := defaultConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// Now, gather the system configs and merge them as needed.
+	configs, err := systemConfigs()
+	if err != nil {
+		return nil, fmt.Errorf("finding config on system: %w", err)
+	}
+	for _, path := range configs {
+		// Merge changes in later configs with the previous configs.
+		// Each config file that specified fields, will override the
+		// previous fields.
+		if err = readConfigFromFile(path, config); err != nil {
+			return nil, fmt.Errorf("reading system config %q: %w", path, err)
+		}
+		logrus.Debugf("Merged system config %q", path)
+		logrus.Tracef("%+v", config)
+	}
+
+	// If the caller specified a config path to use, then we read it to
+	// override the system defaults.
+	for _, add := range options.additionalConfigs {
+		if add == "" {
+			continue
+		}
+		// readConfigFromFile reads in container config in the specified
+		// file and then merge changes with the current default.
+		if err := readConfigFromFile(add, config); err != nil {
+			return nil, fmt.Errorf("reading additional config %q: %w", add, err)
+		}
+		logrus.Debugf("Merged additional config %q", add)
+		logrus.Tracef("%+v", config)
+	}
+	config.addCAPPrefix()
+
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	if err := config.setupEnv(); err != nil {
+		return nil, err
+	}
+
+	if options.SetDefault {
+		cachedConfig = config
+		cachedConfigError = nil
+	}
+
+	return config, nil
+}
+
+// NewConfig creates a new Config. It starts with an empty config and, if
+// specified, merges the config at `userConfigPath` path.
+//
+// Deprecated: use new instead.
+func NewConfig(userConfigPath string) (*Config, error) {
+	return New(&Options{additionalConfigs: []string{userConfigPath}})
+}
+
+// Default returns the default container config.  If no default config has been
+// set yet, a new config will be loaded by New() and set as the default one.
+// All callers are expected to use the returned Config read only.  Changing
+// data may impact other call sites.
+func Default() (*Config, error) {
+	cachedConfigMutex.Lock()
+	defer cachedConfigMutex.Unlock()
+	if cachedConfig != nil || cachedConfigError != nil {
+		return cachedConfig, cachedConfigError
+	}
+	cachedConfig, cachedConfigError = newLocked(&Options{SetDefault: true})
+	return cachedConfig, cachedConfigError
+}

--- a/pkg/config/new.go
+++ b/pkg/config/new.go
@@ -56,12 +56,6 @@ func New(options *Options) (*Config, error) {
 // All callers are expected to use the returned Config read only.  Changing
 // data may impact other call sites.
 func Default() (*Config, error) {
-	if cachedConfig != nil || cachedConfigError != nil {
-		return cachedConfig, cachedConfigError
-	}
-	// Lock and check again.  This has a minimal performance penalty for
-	// the single writer but prevents taking the lock for all readers (once
-	// the config is written).
 	cachedConfigMutex.Lock()
 	defer cachedConfigMutex.Unlock()
 	if cachedConfig != nil || cachedConfigError != nil {
@@ -100,6 +94,7 @@ func newLocked(options *Options) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	config.loadedModules = modules
 
 	options.additionalConfigs = append(options.additionalConfigs, modules...)
 

--- a/pkg/config/testdata/modules/etc/containers/containers.conf.modules/first.conf
+++ b/pkg/config/testdata/modules/etc/containers/containers.conf.modules/first.conf
@@ -1,0 +1,2 @@
+[containers]
+annotations=["etc first"]

--- a/pkg/config/testdata/modules/etc/containers/containers.conf.modules/fourth.conf
+++ b/pkg/config/testdata/modules/etc/containers/containers.conf.modules/fourth.conf
@@ -1,0 +1,2 @@
+[containers]
+init_path="etc four"

--- a/pkg/config/testdata/modules/etc/containers/containers.conf.modules/second.conf
+++ b/pkg/config/testdata/modules/etc/containers/containers.conf.modules/second.conf
@@ -1,0 +1,2 @@
+[containers]
+volumes=["etc second"]

--- a/pkg/config/testdata/modules/etc/containers/containers.conf.modules/sub/etc-only.conf
+++ b/pkg/config/testdata/modules/etc/containers/containers.conf.modules/sub/etc-only.conf
@@ -1,0 +1,2 @@
+[network]
+default_network="etc only conf"

--- a/pkg/config/testdata/modules/etc/containers/containers.conf.modules/third.conf
+++ b/pkg/config/testdata/modules/etc/containers/containers.conf.modules/third.conf
@@ -1,0 +1,2 @@
+[network]
+default_network="etc third"

--- a/pkg/config/testdata/modules/home/.config/containers/containers.conf.modules/first.conf
+++ b/pkg/config/testdata/modules/home/.config/containers/containers.conf.modules/first.conf
@@ -1,0 +1,2 @@
+[containers]
+annotations=["home first"]

--- a/pkg/config/testdata/modules/home/.config/containers/containers.conf.modules/second.conf
+++ b/pkg/config/testdata/modules/home/.config/containers/containers.conf.modules/second.conf
@@ -1,0 +1,2 @@
+[containers]
+volumes=["home second"]

--- a/pkg/config/testdata/modules/home/.config/containers/containers.conf.modules/sub/first.conf
+++ b/pkg/config/testdata/modules/home/.config/containers/containers.conf.modules/sub/first.conf
@@ -1,0 +1,2 @@
+[containers]
+annotations=["home sub first"]

--- a/pkg/config/testdata/modules/home/.config/containers/containers.conf.modules/third.conf
+++ b/pkg/config/testdata/modules/home/.config/containers/containers.conf.modules/third.conf
@@ -1,0 +1,2 @@
+[network]
+default_network="home third"

--- a/pkg/config/testdata/modules/override.conf
+++ b/pkg/config/testdata/modules/override.conf
@@ -1,0 +1,2 @@
+[containers]
+env=["override conf always wins"]

--- a/pkg/config/testdata/modules/usr/share/containers/containers.conf.modules/fifth.conf
+++ b/pkg/config/testdata/modules/usr/share/containers/containers.conf.modules/fifth.conf
@@ -1,0 +1,2 @@
+[containers]
+env=["usr five"]

--- a/pkg/config/testdata/modules/usr/share/containers/containers.conf.modules/first.conf
+++ b/pkg/config/testdata/modules/usr/share/containers/containers.conf.modules/first.conf
@@ -1,0 +1,2 @@
+[containers]
+annotations=["usr first"]

--- a/pkg/config/testdata/modules/usr/share/containers/containers.conf.modules/second.conf
+++ b/pkg/config/testdata/modules/usr/share/containers/containers.conf.modules/second.conf
@@ -1,0 +1,2 @@
+[containers]
+volumes=["usr second"]

--- a/pkg/config/testdata/modules/usr/share/containers/containers.conf.modules/sub/first.conf
+++ b/pkg/config/testdata/modules/usr/share/containers/containers.conf.modules/sub/first.conf
@@ -1,0 +1,2 @@
+[containers]
+annotations=["usr sub first"]

--- a/pkg/config/testdata/modules/usr/share/containers/containers.conf.modules/sub/share-only.conf
+++ b/pkg/config/testdata/modules/usr/share/containers/containers.conf.modules/sub/share-only.conf
@@ -1,0 +1,2 @@
+[containers]
+env=["usr share only"]

--- a/pkg/config/testdata/modules/usr/share/containers/containers.conf.modules/third.conf
+++ b/pkg/config/testdata/modules/usr/share/containers/containers.conf.modules/third.conf
@@ -1,0 +1,2 @@
+[network]
+default_network="usr third"


### PR DESCRIPTION
Add a new concept to containers.conf called "modules".  A "module" is
a containers.conf file located at a specific directory.  More than one
modules can be loaded in the specified order, following existing
override semantics.

There are three directories to load modules from:
 - $CONFIG_HOME/containers/containers.conf.modules
 - /etc/containers/containers.conf.modules
 - /usr/share/containers/containers.conf.modules

With CONFIG_HOME pointing to $HOME/.config or, if set, $XDG_CONFIG_HOME.
Absolute paths will be loaded as is, relative paths will be resolved
relative to the three directories above allowing for admin configs
(/etc/) to override system configs (/usr/share/) and user configs
($CONFIG_HOME) to override admin configs.

Also move some functions from config.go for locality.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

---

Still a draft but there are fairly comprehensive tests.

@rhatdan @Luap99 @giuseppe @containers/podman-maintainers PTAL.  I've received contradicting feedback with respect to the "modules" name.  So far, it's my favorite but I am not married to it.

Please also take a look at the initial refactoring.  I found it important to first clean up the API a bit to make sure it remains maintainable.
