### PR TITLE
change default machine image for windows

### DIFF
--- a/pkg/config/default_windows.go
+++ b/pkg/config/default_windows.go
@@ -5,7 +5,7 @@ import "os"
 // getDefaultImage returns the default machine image stream
 // On Windows this refers to the Fedora major release number
 func getDefaultMachineImage() string {
-	return "35"
+	return "testing"
 }
 
 // getDefaultMachineUser returns the user to use for rootless podman


### PR DESCRIPTION
wsl no longer uses this field and for windows using hyperv, it should be set to "testing" like all other providers that use fcos as a base machine image.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
