### PR TITLE
[v0.55][CI-DOCS] remove zstd:chunked from docs

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -721,7 +721,7 @@ the primary uid/gid of the container.
 
 **compression_format**="gzip"
 
-Specifies the compression format to use when pushing an image. Supported values are: `gzip`, `zstd` and `zstd:chunked`.
+Specifies the compression format to use when pushing an image. Supported values are: `gzip` and `zstd`.
 
 **compression_level**="5"
 

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -377,7 +377,7 @@ default_sysctls = [
 #active_service = "production"
 
 # The compression format to use when pushing an image.
-# Valid options are: `gzip`, `zstd` and `zstd:chunked`.
+# Valid options are: `gzip` and `zstd`.
 #
 #compression_format = "gzip"
 

--- a/pkg/config/containers.conf-freebsd
+++ b/pkg/config/containers.conf-freebsd
@@ -307,7 +307,7 @@ default_sysctls = [
 #active_service = production
 
 # The compression format to use when pushing an image.
-# Valid options are: `gzip`, `zstd` and `zstd:chunked`.
+# Valid options are: `gzip` and `zstd`.
 #
 #compression_format = "gzip"
 


### PR DESCRIPTION
Remove the zstd:chunked encryption algorithm from the docs and the containers.conf file.  This is aimed for RHEL 8.9/9.3 and it will not be supported there.

[NO NEW TESTS NEEDED]

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
