### PR TITLE
default windows machine user change

### DIFF
--- a/pkg/config/default_windows.go
+++ b/pkg/config/default_windows.go
@@ -9,8 +9,10 @@ func getDefaultMachineImage() string {
 }
 
 // getDefaultMachineUser returns the user to use for rootless podman
+// This is only for the hyperv and qemu implementations.  WSL's user
+// will be hardcoded in podman to "user"
 func getDefaultMachineUser() string {
-	return "user"
+	return "core"
 }
 
 // isCgroup2UnifiedMode returns whether we are running in cgroup2 mode.


### PR DESCRIPTION
change the default windows user to core instead of user; which is what WSL uses.  WSL will need to hardcode the its value in podman

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
