### PR TITLE
Introduce (global) default config file locking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,15 @@ endif
 bin/netavark-testplugin:
 	$(GO_BUILD) -o $@ ./libnetwork/netavark/testplugin/
 
+.PHONY: bin/flocksim
+bin/flocksim:
+	$(GO_BUILD) -o $@ ./cmd/flocksim/
+
 .PHONY: netavark-testplugin
 netavark-testplugin: bin/netavark-testplugin
+
+.PHONY: flocksim
+flocksim: bin/flocksim
 
 .PHONY: docs
 docs:
@@ -97,7 +104,7 @@ install:
 test: test-unit
 
 .PHONY: test-unit
-test-unit: netavark-testplugin
+test-unit: netavark-testplugin flocksim
 	go test --tags $(BUILDTAGS) -v ./libimage
 	go test --tags $(BUILDTAGS) -v ./libnetwork/...
 	go test --tags $(BUILDTAGS) -v ./pkg/...
@@ -111,6 +118,7 @@ clean: ## Clean artifacts
 	$(MAKE) -C docs clean
 	find . -name \*~ -delete
 	find . -name \#\* -delete
+	rm -rf bin
 
 .PHONY: seccomp.json
 seccomp.json: $(sources)

--- a/cmd/flocksim/main.go
+++ b/cmd/flocksim/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/containers/storage/pkg/lockfile"
+)
+
+// flocksim is a testing tool used by the config lock tests
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Printf("Usage: %s <path to lock>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	lock, err := lockfile.GetLockFile(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	lock.Lock()
+	fmt.Println("acquired lock, hit enter to release")
+
+	reader := bufio.NewReader(os.Stdin)
+	_, _ = reader.ReadString('\n')
+	lock.Unlock()
+}

--- a/pkg/util/util_darwin.go
+++ b/pkg/util/util_darwin.go
@@ -1,0 +1,12 @@
+package util
+
+import "os"
+
+// getRuntimeDir returns the runtime directory
+func GetRuntimeDir() (string, error) {
+	tmpDir, ok := os.LookupEnv("TMPDIR")
+	if !ok {
+		tmpDir = "/tmp"
+	}
+	return tmpDir, nil
+}

--- a/pkg/util/util_supported.go
+++ b/pkg/util/util_supported.go
@@ -1,5 +1,5 @@
-//go:build linux || darwin || freebsd
-// +build linux darwin freebsd
+//go:build linux || freebsd
+// +build linux freebsd
 
 package util
 

--- a/pkg/util/util_windows.go
+++ b/pkg/util/util_windows.go
@@ -4,10 +4,37 @@
 package util
 
 import (
-	"errors"
+	"os"
 )
 
 // getRuntimeDir returns the runtime directory
 func GetRuntimeDir() (string, error) {
-	return "", errors.New("this function is not implemented for windows")
+	tmpDir, ok := os.LookupEnv("TEMP")
+	if ok {
+		return tmpDir, nil
+	}
+
+	tmpDir, ok = os.LookupEnv("LOCALAPPDATA")
+	if ok {
+		tmpDir += `\Temp`
+	}
+
+	if !ok {
+		tmpDir, ok = os.LookupEnv("USERPROFILE")
+		if !ok {
+			tmpDir, ok = os.LookupEnv("HOME")
+		}
+		// Append to either match
+		if ok {
+			tmpDir += `\AppData\Local\Temp`
+		}
+	}
+
+	if !ok {
+		// Hope for the best
+		return `C:\Temp`, nil
+	}
+	_ = os.MkdirAll(tmpDir, 0o700)
+
+	return tmpDir, nil
 }


### PR DESCRIPTION
This PR is a follow on to containers/podman#19557

It adds a shared locking facility for containers.conf, notably to ensure concurrent connection definition updates are safely performed. It is intended to replace the backend-specific approach used in containers/podman#19557, as well as support other future usage patterns.

This PR also introduces a unit test that relies on a helper executable. Unfortunately, this is necessary since Linux/POSIX fcntl record locking behavior forcefully shares locks at the process level, so different file descriptors can not be used to simulate multi-process locking. Technically storage's impl of LockFile could be refactored to utilize Linux-specific open fd locks, but this would only address one platform (although Windows behaved similarly - locks are exclusive to a handle). Ultimately, I concluded consistency is better, plus "if it ain't broke, don't fix it".

Adds LockDefault() and UnlockDefault(), which lock an associate file mapping to the same default containers file that Write() selects. This functionality allows for multiple read-and-write operations to be atomically executed by serializing access from multiple updaters.

As an example, if two parallel updaters are inserting a different entry into a map, one will likely be omitted from being overwritten with data from a stale read. Instead, using these functions, callers can coordinate, ensuring writes are never interposed between another caller's read-update pattern.

