### PR TITLE
cgroups_linux: use SessionBusPrivateNoAutoStartup

### DIFF
--- a/pkg/cgroups/cgroups_linux.go
+++ b/pkg/cgroups/cgroups_linux.go
@@ -394,7 +394,7 @@ func (c *CgroupControl) CreateSystemdUnit(path string) error {
 // GetUserConnection returns an user connection to D-BUS
 func GetUserConnection(uid int) (*systemdDbus.Conn, error) {
 	return systemdDbus.NewConnection(func() (*dbus.Conn, error) {
-		return dbusAuthConnection(uid, dbus.SessionBusPrivate)
+		return dbusAuthConnection(uid, dbus.SessionBusPrivateNoAutoStartup)
 	})
 }
 


### PR DESCRIPTION
port Commit 12a939e1048a (cgroups: use SessionBusPrivateNoAutoStartup) from cgroups.go to cgroups_linux.go

do not start up a dbus daemon if it is not already running.

[NO NEW TESTS NEEDED] the fix is in a dependency.
