### PR TITLE
[WIP] Add append lists

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -176,6 +176,11 @@ container. The special value “none” can be specified to disable creation of
 Environment variable list for the container process, used for passing
 environment variables to the container.
 
+**env_append**=[]
+
+Append env variables list to list of env. env_append allows users to append to
+env variables provided via other containers.conf files.
+
 **env_host**=false
 
 Pass all host environment variables into the container.
@@ -255,6 +260,11 @@ List of mounts.
 Specified as "type=TYPE,source=<directory-on-host>,destination=<directory-in-container>,<options>"
 
 Example:  [ "type=bind,source=/var/lib/foobar,destination=/var/lib/foobar,ro", ]
+
+**mounts_append**=[]
+
+Append mounts list to list of mounts. mounts_append allows users to append to
+mounts provided via other containers.conf files.
 
 **netns**="private"
 
@@ -340,6 +350,11 @@ List of volumes.
 Specified as "directory-on-host:directory-in-container:options".
 
 Example:  "/db:/var/lib/db:ro".
+
+**volumes_append**=[]
+
+Append volume list to list of volumes. volumes_append allows users to append to
+volumes provided via other containers.conf files.
 
 ## NETWORK TABLE
 The `network` table contains settings pertaining to the management of CNI

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,6 +91,9 @@ type ContainersConfig struct {
 	// Volumes to add to all containers
 	Volumes []string `toml:"volumes,omitempty"`
 
+	// VolumesAppend appends to existing Volumes fields
+	VolumesAppend []string `toml:"volumes_append,omitempty"`
+
 	// ApparmorProfile is the apparmor profile name which is used as the
 	// default for the runtime.
 	ApparmorProfile string `toml:"apparmor_profile,omitempty"`
@@ -153,6 +156,9 @@ type ContainersConfig struct {
 	// Env is the environment variable list for container process.
 	Env []string `toml:"env,omitempty"`
 
+	// Append to existing Env fields
+	EnvAppend []string `toml:"env_append,omitempty"`
+
 	// EnvHost Pass all host environment variables into the container.
 	EnvHost bool `toml:"env_host,omitempty"`
 
@@ -188,6 +194,9 @@ type ContainersConfig struct {
 
 	// Mount to add to all containers
 	Mounts []string `toml:"mounts,omitempty"`
+
+	// MountsAppend appends to existing Mounts fields
+	MountsAppend []string `toml:"mounts_append,omitempty"`
 
 	// NetNS indicates how to create a network namespace for the container
 	NetNS string `toml:"netns,omitempty"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -976,7 +976,8 @@ image_copy_tmp_dir="storage"`
 			// Reload from new configuration file
 			testFile := "testdata/temp.conf"
 			content := `[containers]
-env=["foo=bar"]`
+env=["foo=bar"]
+env_append=["bax=baz"]`
 			err = os.WriteFile(testFile, []byte(content), os.ModePerm)
 			defer os.Remove(testFile)
 			gomega.Expect(err).To(gomega.BeNil())
@@ -994,8 +995,10 @@ env=["foo=bar"]`
 
 			expectOldEnv := []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
 			expectNewEnv := []string{"foo=bar"}
+			allEnv := []string{"foo=bar", "bax=baz"}
 			gomega.Expect(cfg.Containers.Env).To(gomega.Equal(expectOldEnv))
 			gomega.Expect(newCfg.Containers.Env).To(gomega.Equal(expectNewEnv))
+			gomega.Expect(newCfg.Env()).To(gomega.Equal(allEnv))
 			// Reload change back to default global configuration
 			_, err = Reload()
 			gomega.Expect(err).To(gomega.BeNil())
@@ -1046,5 +1049,7 @@ env=["foo=bar"]`
 		gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal("overridden-default"))
 		gomega.Expect(config.Containers.BaseHostsFile).To(gomega.Equal("/etc/hosts2"))
 		gomega.Expect(config.Containers.EnableLabeledUsers).To(gomega.BeTrue())
+		env := []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "bax=baz"}
+		gomega.Expect(config.Env()).To(gomega.Equal(env))
 	})
 })

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -202,6 +202,12 @@ default_sysctls = [
 #
 #mounts = []
 
+# Append list of mounts to mounts.
+# mounts_append allows users to append to mounts provided via other
+# containers.conf files.
+#
+#mounts_append = []
+
 # Default way to to create a Network namespace for the container
 # Options are:
 # `private` Create private Network Namespace for the container.
@@ -282,6 +288,11 @@ default_sysctls = [
 # If it is empty or commented out, no volumes will be added
 #
 #volumes = []
+
+# Append volume list to list of volumes.
+# volumes_append allows users to append to Volumes provided via other
+# containers.conf files.
+#volumes_append = []
 
 #[engine.platform_to_oci_runtime]
 #"wasi/wasm" = ["crun-wasm"]
@@ -463,6 +474,12 @@ default_sysctls = [
 # Set the env section under [containers] table, if you want to set environment variables for the container.
 #
 #env = []
+
+# Append environment variables to env list
+# env_append allows users to append to env variables provided via other
+# containers.conf files.
+#
+#env_append = []
 
 # Define where event logs will be stored, when events_logger is "file".
 #events_logfile_path=""

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -508,12 +508,12 @@ func (c *Config) Sysctls() []string {
 
 // Volumes returns the default set of volumes that should be mounted in containers.
 func (c *Config) Volumes() []string {
-	return c.Containers.Volumes
+	return append(c.Containers.Volumes, c.Containers.VolumesAppend...)
 }
 
 // Mounts returns the default set of mounts that should be mounted in containers.
 func (c *Config) Mounts() []string {
-	return c.Containers.Mounts
+	return append(c.Containers.Mounts, c.Containers.MountsAppend...)
 }
 
 // Devices returns the default additional devices for containers.
@@ -538,7 +538,7 @@ func (c *Config) DNSOptions() []string {
 
 // Env returns the default additional environment variables to add to containers.
 func (c *Config) Env() []string {
-	return c.Containers.Env
+	return append(c.Containers.Env, c.Containers.EnvAppend...)
 }
 
 // InitPath returns location where init program added to containers when users specify the --init flag.

--- a/pkg/config/testdata/containers_override.conf
+++ b/pkg/config/testdata/containers_override.conf
@@ -6,6 +6,7 @@ log_tag="{{.Name}}|{{.ID}}"
 log_size_max = 100000
 read_only=true
 label_users=true
+env_append=["bax=baz",]
 
 [engine]
 image_parallel_copies=10


### PR DESCRIPTION
With the addition of modules, we need a way to append to lists of volumes, environment variables and mounts rather then replace existing variables.

HPC Community has requested this feature.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
