### PR TITLE
libnetwork/cni: use 'ifconfig -j' on FreeBSD if it is supported

### DIFF
--- a/libnetwork/cni/run_freebsd.go
+++ b/libnetwork/cni/run_freebsd.go
@@ -8,6 +8,12 @@ import (
 // add the default address. Note: this will also add ::1 as a side
 // effect.
 func setupLoopback(namespacePath string) error {
-	// The jexec wrapper runs the ifconfig command inside the jail.
+	// Try to run the command using ifconfig's -j flag (supported in 13.3 and later)
+	if err := exec.Command("ifconfig", "-j", namespacePath, "lo0", "inet", "127.0.0.1").Run(); err == nil {
+		return nil
+	}
+
+	// Fall back to using the jexec wrapper to run the ifconfig command
+	// inside the jail.
 	return exec.Command("jexec", namespacePath, "ifconfig", "lo0", "inet", "127.0.0.1").Run()
 }


### PR DESCRIPTION
This allows us to use a single jail for containers with networking since CNI can initialise the network without needing a separate jail to own the network namespace.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
