### PR TITLE
Move libimage.ManifestList{Descriptor,Data} to libimage/define

### DIFF
--- a/libimage/define/manifests.go
+++ b/libimage/define/manifests.go
@@ -1,0 +1,27 @@
+package define
+
+import (
+	"github.com/containers/image/v5/manifest"
+)
+
+// ManifestListDescriptor references a platform-specific manifest.
+// Contains exclusive field like `annotations` which is only present in
+// OCI spec and not in docker image spec.
+type ManifestListDescriptor struct {
+	manifest.Schema2Descriptor
+	Platform manifest.Schema2PlatformSpec `json:"platform"`
+	// Annotations contains arbitrary metadata for the image index.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// ManifestListData is a list of platform-specific manifests, specifically used to
+// generate output struct for `podman manifest inspect`. Reason for maintaining and
+// having this type is to ensure we can have a common type which contains exclusive
+// fields from both Docker manifest format and OCI manifest format.
+type ManifestListData struct {
+	SchemaVersion int                      `json:"schemaVersion"`
+	MediaType     string                   `json:"mediaType"`
+	Manifests     []ManifestListDescriptor `json:"manifests"`
+	// Annotations contains arbitrary metadata for the image index.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/containers/common/libimage/define"
 	"github.com/containers/common/libimage/manifests"
 	imageCopy "github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/docker"
@@ -38,28 +39,6 @@ type ManifestList struct {
 
 	// The underlying manifest list.
 	list manifests.List
-}
-
-// ManifestListDescriptor references a platform-specific manifest.
-// Contains exclusive field like `annotations` which is only present in
-// OCI spec and not in docker image spec.
-type ManifestListDescriptor struct {
-	manifest.Schema2Descriptor
-	Platform manifest.Schema2PlatformSpec `json:"platform"`
-	// Annotations contains arbitrary metadata for the image index.
-	Annotations map[string]string `json:"annotations,omitempty"`
-}
-
-// ManifestListData is a list of platform-specific manifests, specifically used to
-// generate output struct for `podman manifest inspect`. Reason for maintaining and
-// having this type is to ensure we can have a common type which contains exclusive
-// fields from both Docker manifest format and OCI manifest format.
-type ManifestListData struct {
-	SchemaVersion int                      `json:"schemaVersion"`
-	MediaType     string                   `json:"mediaType"`
-	Manifests     []ManifestListDescriptor `json:"manifests"`
-	// Annotations contains arbitrary metadata for the image index.
-	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // ID returns the ID of the manifest list.
@@ -238,8 +217,8 @@ func (i *Image) IsManifestList(ctx context.Context) (bool, error) {
 }
 
 // Inspect returns a dockerized version of the manifest list.
-func (m *ManifestList) Inspect() (*ManifestListData, error) {
-	inspectList := ManifestListData{}
+func (m *ManifestList) Inspect() (*define.ManifestListData, error) {
+	inspectList := define.ManifestListData{}
 	dockerFormat := m.list.Docker()
 	err := structcopier.Copy(&inspectList, &dockerFormat)
 	if err != nil {


### PR DESCRIPTION
These structs are (for better or worse) a part of Podman's API, so `podman-remote` needs to include the subpackage that defines them - which is all of `libimage` (and `c/image/v5/copy`) right now.

Instead, move them to `libimage/define`.

Alternatively, maybe Podman's API should not directly depend on (unstable) c/common types?!

Only moves unchanged code, should not change behavior.
