### PR TITLE
libimage: preserve optional name when pulling from OCI transport

### DIFF
--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -230,8 +230,18 @@ func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference,
 
 	case ociTransport.Transport.Name():
 		split := strings.SplitN(ref.StringWithinTransport(), ":", 2)
-		storageName = toLocalImageName(split[0])
-		imageName = storageName
+		if len(split) == 1 || split[1] == "" {
+			// Same trick as for the dir transport: we cannot use
+			// the path to a directory as the name.
+			storageName, err = getImageID(ctx, ref, nil)
+			if err != nil {
+				return nil, err
+			}
+			imageName = "sha256:" + storageName[1:]
+		} else { // If the OCI-reference includes an image reference, use it
+			storageName = split[1]
+			imageName = storageName
+		}
 
 	case ociArchiveTransport.Transport.Name():
 		manifestDescriptor, err := ociArchiveTransport.LoadManifestDescriptorWithContext(r.SystemContext(), ref)


### PR DESCRIPTION
When pulling from an OCI source, make sure to preseve the optional name. For instance, a `podman pull oci:/tmp/foo:quay.io/foo/bar:latest` should pull the image and name it `quay.io/foo/bar:latest`.

While at it, also fix a bug when pulling an OCI without the optional name.  Previously, we used the path to name the image which will error in most cases due to invalid characters (e.g., capital ones).  Hence, apply the same trick as for the `dir` transport and generate a sha.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
