### PR TITLE
golangci.yml: enable all, disable failing linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,15 +10,77 @@ run:
   concurrency: 6
   deadline: 5m
 linters:
-  enable:
-    - dupl
-    - gocritic
-    - unparam
-    - exportloopref
-    - revive
-    - prealloc
-    - makezero
-    - gofumpt
+  enable-all: true
+  disable:
+    # linters deprecated by upstreams ...
+    - interfacer
+    - varcheck
+    - deadcode
+    - scopelint
+    - maligned
+    - nosnakecase
+    - exhaustivestruct
+    - structcheck
+    - ifshort
+    - golint
+    # others to be re-enabled one-by-one ...
+    - forbidigo
+    - funlen
+    - gci
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - godox
+    - golint
+    - lll
+    - maligned
+    - mirror
+    - misspell
+    - nestif
+    - unconvert
+    - whitespace
+    - wsl
+    - contextcheck
+    - cyclop
+    - depguard
+    - dupword
+    - errchkjson
+    - errname
+    - errorlint
+    - exhaustive
+    - exhaustivestruct
+    - ginkgolinter
+    - gochecknoglobals
+    - goerr113
+    - gomnd
+    - nolintlint
+    - wrapcheck
+    - wastedassign
+    - varnamelen
+    - testpackage
+    - tenv
+    - tagliatelle
+    - stylecheck
+    - paralleltest
+    - nonamedreturns
+    - nlreturn
+    - nakedret
+    - musttag
+    - maintidx
+    - ireturn
+    - exhaustruct
+    - gosec
+    - godot
+    - gocyclo
+    - dogsled
+    - tparallel
+    - thelper
+    - nilnil
+    - nilerr
+    - interfacebloat
+    - forcetypeassert
+    - gomoddirectives
+    - predeclared
 linters-settings:
   errcheck:
     check-type-assertions: true


### PR DESCRIPTION
golangci-lint has a number of helpful linters and new ones are being continuously added.  Instead of enabling only a minimal subset of these linters, enable all by default and - for now - disable failing ones. This allows us to make use of new linters on updates and to selectively enable those we deem useful.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
