### PR TITLE
cgroups: fix memory usage on cgroup v1

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -582,7 +582,7 @@ func (c *CgroupControl) Stat() (*Metrics, error) {
 	return &m, nil
 }
 
-func readCgroup2MapPath(path string) (map[string][]string, error) {
+func readCgroupMapPath(path string) (map[string][]string, error) {
 	ret := map[string][]string{}
 	f, err := os.Open(path)
 	if err != nil {
@@ -610,5 +610,5 @@ func readCgroup2MapPath(path string) (map[string][]string, error) {
 func readCgroup2MapFile(ctr *CgroupControl, name string) (map[string][]string, error) {
 	p := filepath.Join(cgroupRoot, ctr.path, name)
 
-	return readCgroup2MapPath(p)
+	return readCgroupMapPath(p)
 }

--- a/pkg/cgroups/cgroups_linux.go
+++ b/pkg/cgroups/cgroups_linux.go
@@ -542,7 +542,7 @@ func (c *CgroupControl) Stat() (*cgroups.Stats, error) {
 	return &m, nil
 }
 
-func readCgroup2MapPath(path string) (map[string][]string, error) {
+func readCgroupMapPath(path string) (map[string][]string, error) {
 	ret := map[string][]string{}
 	f, err := os.Open(path)
 	if err != nil {
@@ -570,5 +570,5 @@ func readCgroup2MapPath(path string) (map[string][]string, error) {
 func readCgroup2MapFile(ctr *CgroupControl, name string) (map[string][]string, error) {
 	p := filepath.Join(cgroupRoot, ctr.config.Path, name)
 
-	return readCgroup2MapPath(p)
+	return readCgroupMapPath(p)
 }

--- a/pkg/cgroups/utils.go
+++ b/pkg/cgroups/utils.go
@@ -64,7 +64,7 @@ func GetSystemCPUUsage() (uint64, error) {
 		}
 		p := filepath.Join(cgroupRoot, file.Name(), "cpu.stat")
 
-		values, err := readCgroup2MapPath(p)
+		values, err := readCgroupMapPath(p)
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
calculate the memory usage on cgroup v1 using the same logic as cgroup v2.

Since there is no single "anon" field, calculate the memory usage by summing the two fields "total_active_anon" and "total_inactive_anon".

Closes: https://github.com/containers/common/issues/1642
