### PR TITLE
libimage/layer_tree: if parent is empty and a manifest list then ignore check.

### DIFF
--- a/libimage/layer_tree.go
+++ b/libimage/layer_tree.go
@@ -199,6 +199,17 @@ func (t *layerTree) children(ctx context.Context, parent *Image, all bool) ([]*I
 	if parent.TopLayer() == "" {
 		for i := range t.emptyImages {
 			empty := t.emptyImages[i]
+			isManifest, err := empty.IsManifestList(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if isManifest {
+				// If this is a manifest list and is already
+				// marked as empty then no instance can be
+				// selected from this list therefore its
+				// better to skip this.
+				continue
+			}
 			isParent, err := checkParent(empty)
 			if err != nil {
 				return nil, err
@@ -287,6 +298,17 @@ func (t *layerTree) parent(ctx context.Context, child *Image) (*Image, error) {
 	if child.TopLayer() == "" {
 		for _, empty := range t.emptyImages {
 			if childID == empty.ID() {
+				continue
+			}
+			isManifest, err := empty.IsManifestList(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if isManifest {
+				// If this is a manifest list and is already
+				// marked as empty then no instance can be
+				// selected from this list therefore its
+				// better to skip this.
 				continue
 			}
 			emptyOCI, err := t.toOCI(ctx, empty)


### PR DESCRIPTION
Layer tree expectes to form a relation between child and parent instances, however it expects an instance from manifest list which is empty, following expectation is not possible and will always resuilt in error.

Closes: https://github.com/containers/podman/issues/19860

[NO NEW TESTS NEEDED]
Image without layer cant be built in libimage, and `podman save` automatically malforms such image so no such external image can be loaded.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
