### PR TITLE
Default machine CPUs to Cores/2

### DIFF
--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -522,14 +522,19 @@ var _ = Describe("Config Local", func() {
 	})
 	It("Set machine CPUs", func() {
 		// Given
+		cpus := runtime.NumCPU() / 2
+		if cpus == 0 {
+			cpus = 1
+		}
+
 		config, err := New(nil)
 		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config.Machine.CPUs).To(gomega.Equal(uint64(1)))
+		gomega.Expect(config.Machine.CPUs).To(gomega.Equal(uint64(cpus)))
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config2.Machine.CPUs).To(gomega.Equal(uint64(2)))
+		gomega.Expect(config2.Machine.CPUs).To(gomega.Equal(uint64(1)))
 	})
 	It("Set machine memory", func() {
 		// Given

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	nettypes "github.com/containers/common/libnetwork/types"
@@ -250,8 +251,12 @@ func defaultSecretConfig() SecretConfig {
 
 // defaultMachineConfig returns the default machine configuration.
 func defaultMachineConfig() MachineConfig {
+	cpus := runtime.NumCPU() / 2
+	if cpus == 0 {
+		cpus = 1
+	}
 	return MachineConfig{
-		CPUs:     1,
+		CPUs:     uint64(cpus),
 		DiskSize: 100,
 		Image:    getDefaultMachineImage(),
 		Memory:   2048,

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -298,7 +298,7 @@ crun = [
 
 [machine]
 # Number of CPU's a machine is created with.
-cpus=2
+cpus=1
 
 # The size of the disk in GB created when init-ing a podman-machine VM
 disk_size = 20


### PR DESCRIPTION
1 CPU core typically is not enough for most use cases, so we default to available cores/2 for new machines.

Fixes: https://github.com/containers/podman/issues/17066

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
