### PR TITLE
Implement negated label match function

### DIFF
--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -107,13 +107,7 @@ func PrepareFilters(r *http.Request) (map[string][]string, error) {
 func MatchLabelFilters(filterValues []string, labels map[string]string) bool {
 outer:
 	for _, filterValue := range filterValues {
-		filterArray := strings.SplitN(filterValue, "=", 2)
-		filterKey := filterArray[0]
-		if len(filterArray) > 1 {
-			filterValue = filterArray[1]
-		} else {
-			filterValue = ""
-		}
+		filterKey, filterValue := splitFilterValue(filterValue)
 		for labelKey, labelValue := range labels {
 			if filterValue == "" || labelValue == filterValue {
 				if labelKey == filterKey || matchPattern(filterKey, labelKey) {
@@ -124,6 +118,32 @@ outer:
 		return false
 	}
 	return true
+}
+
+// MatchNegatedLabelFilters matches negated labels and returns true if they are valid
+func MatchNegatedLabelFilters(filterValues []string, labels map[string]string) bool {
+	for _, filterValue := range filterValues {
+		filterKey, filterValue := splitFilterValue(filterValue)
+		for labelKey, labelValue := range labels {
+			if filterValue == "" || labelValue == filterValue {
+				if labelKey == filterKey || matchPattern(filterKey, labelKey) {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+func splitFilterValue(filterValue string) (string, string) {
+	filterArray := strings.SplitN(filterValue, "=", 2)
+	filterKey := filterArray[0]
+	if len(filterArray) > 1 {
+		filterValue = filterArray[1]
+	} else {
+		filterValue = ""
+	}
+	return filterKey, filterValue
 }
 
 func matchPattern(pattern string, value string) bool {

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -78,6 +78,80 @@ func TestMatchLabelFilters(t *testing.T) {
 	}
 }
 
+func TestMatchNegatedLabelFilters(t *testing.T) {
+	testLabels := map[string]string{
+		"label1": "",
+		"label2": "test",
+		"label3": "",
+	}
+	type args struct {
+		filterValues []string
+		labels       map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Do not match when all filters the same as labels",
+			args: args{
+				filterValues: []string{"label1", "label3", "label2=test"},
+				labels:       testLabels,
+			},
+			want: false,
+		},
+		{
+			name: "Do not match when filter value not provided in args",
+			args: args{
+				filterValues: []string{"label2"},
+				labels:       testLabels,
+			},
+			want: false,
+		},
+		{
+			name: "Do not match when no filter value is given",
+			args: args{
+				filterValues: []string{"label2="},
+				labels:       testLabels,
+			},
+			want: false,
+		},
+		{
+			name: "Match when filter value differs",
+			args: args{
+				filterValues: []string{"label2=differs"},
+				labels:       testLabels,
+			},
+			want: true,
+		},
+		{
+			name: "Match when filter value not listed in labels",
+			args: args{
+				filterValues: []string{"label1=xyz"},
+				labels:       testLabels,
+			},
+			want: true,
+		},
+		{
+			name: "Match when one from many not ok",
+			args: args{
+				filterValues: []string{"label1=xyz", "invalid=valid"},
+				labels:       testLabels,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MatchNegatedLabelFilters(tt.args.filterValues, tt.args.labels); got != tt.want {
+				t.Errorf("MatchNegatedLabelFilters() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestComputeUntilTimestamp(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Adds a proper way to match on negated label filters (label!). (label!) filters. The current logic used is to do !MatchLabelFilter() but this results in chained negated labels being ORed together instead of ANDed.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
