### PR TITLE
revert two commits for containers/podman/pull/20088

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -561,6 +561,24 @@ type SetOptions struct {
 	// backwards compatibility with older versions of libpod for which we must
 	// query the database configuration. Not included in the on-disk config.
 	StorageConfigGraphDriverNameSet bool `toml:"-"`
+
+	// StaticDirSet indicates if the StaticDir has been explicitly set by the
+	// config or by the user. It's required to guarantee backwards compatibility
+	// with older versions of libpod for which we must query the database
+	// configuration. Not included in the on-disk config.
+	StaticDirSet bool `toml:"-"`
+
+	// VolumePathSet indicates if the VolumePath has been explicitly set by the
+	// config or by the user. It's required to guarantee backwards compatibility
+	// with older versions of libpod for which we must query the database
+	// configuration. Not included in the on-disk config.
+	VolumePathSet bool `toml:"-"`
+
+	// TmpDirSet indicates if the TmpDir has been explicitly set by the config
+	// or by the user. It's required to guarantee backwards compatibility with
+	// older versions of libpod for which we must query the database
+	// configuration. Not included in the on-disk config.
+	TmpDirSet bool `toml:"-"`
 }
 
 // NetworkConfig represents the "network" TOML config table

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -306,6 +306,8 @@ func defaultEngineConfig() (*EngineConfig, error) {
 
 	c.graphRoot = storeOpts.GraphRoot
 	c.ImageCopyTmpDir = getDefaultTmpDir()
+	c.StaticDir = filepath.Join(storeOpts.GraphRoot, "libpod")
+	c.VolumePath = filepath.Join(storeOpts.GraphRoot, "volumes")
 
 	c.VolumePluginTimeout = DefaultVolumePluginTimeout
 	c.CompressionFormat = "gzip"


### PR DESCRIPTION
I didn't catch leftover issues in containers/podman/pull/20088 using the sqlite backend.  So I prefer reverting the two commits here (which break vendoring in Podman) and buy me some time.
