### PR TITLE
pkg/subscriptions: add /etc/crypto-policies/config in fips mode

### DIFF
--- a/pkg/subscriptions/subscriptions.go
+++ b/pkg/subscriptions/subscriptions.go
@@ -362,6 +362,35 @@ func addFIPSModeSubscription(mounts *[]rspec.Mount, containerRunDir, mountPoint,
 		}
 		*mounts = append(*mounts, m)
 	}
+
+	// Make sure we set the config to FIPS so that the container does not overwrite
+	// /etc/crypto-policies/back-ends when crypto-policies-scripts is reinstalled.
+	cryptoPoliciesConfigFile := filepath.Join(containerRunDir, "fips-config")
+	file, err := os.Create(cryptoPoliciesConfigFile)
+	if err != nil {
+		return fmt.Errorf("creating fips config file in container for FIPS mode: %w", err)
+	}
+	defer file.Close()
+	if _, err := file.WriteString("FIPS\n"); err != nil {
+		return fmt.Errorf("writing fips config file in container for FIPS mode: %w", err)
+	}
+	if err = label.Relabel(cryptoPoliciesConfigFile, mountLabel, false); err != nil {
+		return fmt.Errorf("applying correct labels on fips-config file: %w", err)
+	}
+	if err := file.Chown(uid, gid); err != nil {
+		return fmt.Errorf("chown fips-config file: %w", err)
+	}
+
+	policyConfig := "/etc/crypto-policies/config"
+	if !mountExists(*mounts, policyConfig) {
+		m := rspec.Mount{
+			Source:      cryptoPoliciesConfigFile,
+			Destination: policyConfig,
+			Type:        "bind",
+			Options:     []string{"bind", "rprivate"},
+		}
+		*mounts = append(*mounts, m)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Make sure /etc/crypto-policies/config is bind mounted from the host so it does contain the proper FIPS value and a reinstall of crypto-policies-scripts does not overwrite the existing files with the default config.

Fixes https://issues.redhat.com/browse/RHEL-9836

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
