### PR TITLE
libnetwork/cni: ignore ENOENT while reading networks

### DIFF
--- a/libnetwork/cni/network.go
+++ b/libnetwork/cni/network.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -201,7 +202,10 @@ func (n *cniNetwork) loadNetworks() error {
 
 		net, err := createNetworkFromCNIConfigList(conf, file)
 		if err != nil {
-			logrus.Errorf("CNI config list %s could not be converted to a libpod config, skipping: %v", file, err)
+			// ignore ENOENT as the config has been removed in the meantime so we can just ignore this case
+			if !errors.Is(err, fs.ErrNotExist) {
+				logrus.Errorf("CNI config list %s could not be converted to a libpod config, skipping: %v", file, err)
+			}
 			continue
 		}
 		logrus.Debugf("Successfully loaded network %s: %v", net.Name, net)


### PR DESCRIPTION
At this point we already read the config file but here we have to get timestamp here so we can hit another ENOENT if it was removed in the meantime. Just ignore this and do not log an error as this is normal behavior when another process is deleting a network in parallel.

Fixes containers/podman#20173

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
