### PR TITLE
Add support for vrf option on netavark

### DIFF
--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -204,7 +204,10 @@ func (n *netavarkNetwork) networkCreate(newNetwork *types.Network, defaultNet bo
 				}
 				// rust only support "true" or "false" while go can parse 1 and 0 as well so we need to change it
 				newNetwork.Options[types.NoDefaultRoute] = strconv.FormatBool(val)
-
+			case types.VRFOption:
+				if len(value) == 0 {
+					return nil, errors.New("invalid vrf name")
+				}
 			default:
 				return nil, fmt.Errorf("unsupported bridge network option %s", key)
 			}

--- a/libnetwork/netavark/testfiles/valid/vrf.json
+++ b/libnetwork/netavark/testfiles/valid/vrf.json
@@ -1,0 +1,22 @@
+{
+    "name": "vrf",
+    "id": "60527704a34bd163f6b64857b601585f4b00a02a5f2f00fe139ab72347fd6cdc",
+    "driver": "bridge",
+    "network_interface": "podman16",
+    "created": "2021-10-06T18:50:54.25770461+02:00",
+    "subnets": [
+        {
+            "subnet": "10.89.13.0/24",
+            "gateway": "10.89.13.1"
+        }
+    ],
+    "ipv6_enabled": false,
+    "internal": false,
+    "dns_enabled": true,
+    "options": {
+        "vrf": "test-vrf"
+    },
+    "ipam_options": {
+        "driver": "host-local"
+    }
+}

--- a/libnetwork/types/const.go
+++ b/libnetwork/types/const.go
@@ -43,6 +43,7 @@ const (
 	MetricOption   = "metric"
 	NoDefaultRoute = "no_default_route"
 	BclimOption    = "bclim"
+	VRFOption      = "vrf"
 )
 
 type NetworkBackend string


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
Add support for the vrf option of the netavark network stack that was introduced on https://github.com/containers/netavark/commit/4b6d5ab26316b007779e0a504ab9a90a21b2e2dc.