### PR TITLE
Use MatchNegatedLabelFilter function for networks

### DIFF
--- a/libnetwork/util/filters.go
+++ b/libnetwork/util/filters.go
@@ -67,7 +67,7 @@ func createPruneFilterFuncs(key string, filterValues []string) (types.FilterFunc
 		}, nil
 	case "label!":
 		return func(net types.Network) bool {
-			return !filters.MatchLabelFilters(filterValues, net.Labels)
+			return filters.MatchNegatedLabelFilters(filterValues, net.Labels)
 		}, nil
 	case "until":
 		until, err := filters.ComputeUntilTimestamp(filterValues)


### PR DESCRIPTION
Changes `createPruneFilterFuncs` to use `filters.MatchNegatedLabelFilters` instead of `!filters.MatchLabelFilters` when matching on negated labels (label!).

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
