### PR TITLE
Add privileged mode flag to containers.conf

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -289,6 +289,13 @@ is imposed.
 
 Copy the content from the underlying image into the newly created volume when the container is created instead of when it is started. If `false`, the container engine will not copy the content until the container is started. Setting it to `true` may have negative performance implications.
 
+**privileged**=false
+
+Run all containers in privileged mode. The privileged field should almost
+never be set, containers running in privileged mode have no separation from
+the host other then namespaces. This means they can easily break out of
+confinement.
+
 **read_only**=true|false
 
 Run all containers with root file system mounted read-only. Set to false by default.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -213,6 +213,9 @@ type ContainersConfig struct {
 	// performance implications.
 	PrepareVolumeOnCreate bool `toml:"prepare_volume_on_create,omitempty"`
 
+	// Privileged causes engine to run all containers in privileged mode
+	Privileged bool `toml:"privileged,omitempty"`
+
 	// ReadOnly causes engine to run all containers with root file system mounted read-only
 	ReadOnly bool `toml:"read_only,omitempty"`
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -516,6 +516,7 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(config.Containers.LogTag).To(gomega.Equal("{{.Name}}|{{.ID}}"))
 			gomega.Expect(config.Containers.LogSizeMax).To(gomega.Equal(int64(100000)))
 			gomega.Expect(config.Containers.ReadOnly).To(gomega.BeTrue())
+			gomega.Expect(config.Containers.Privileged).To(gomega.BeTrue())
 			gomega.Expect(config.Engine.ImageParallelCopies).To(gomega.Equal(uint(10)))
 			gomega.Expect(config.Engine.PlatformToOCIRuntime).To(gomega.Equal(PlatformToOCIRuntimeMap))
 			gomega.Expect(config.Engine.ImageDefaultFormat).To(gomega.Equal("v2s2"))

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -237,6 +237,12 @@ default_sysctls = [
 #
 #prepare_volume_on_create = false
 
+# Run all containers in privileged mode. The privileged field should almost
+# never be set, containers running in privileged mode have no separation from
+# the host other then namespaces. This means they can easily break out of
+# confinement.
+# privileged = false
+
 # Run all containers with root file system mounted read-only
 #
 # read_only = false

--- a/pkg/config/testdata/containers_override.conf
+++ b/pkg/config/testdata/containers_override.conf
@@ -6,6 +6,7 @@ log_tag="{{.Name}}|{{.ID}}"
 log_size_max = 100000
 read_only=true
 label_users=true
+privileged=true
 
 [engine]
 image_parallel_copies=10


### PR DESCRIPTION
This was requested by the HPC community mainly for the use with --modules command. In certain containers they need to always run them in privileged mode.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
