### PR TITLE
pkg/config: use empty default for db_backend

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -507,10 +507,13 @@ conmon_path=[
 ]
 ```
 
-**database_backend**="boltdb"
+**database_backend**=""
 
-The database backend of Podman.  Supported values are "boltdb" (default) and
-"sqlite". Please run `podman-system-reset` prior to changing the database
+The database backend of Podman.  Supported values are "" (default), "boltdb"
+and "sqlite". An empty value means it will check whenever a boltdb already
+exists and use it when it does, otherwise it will use sqlite as default
+(e.g. new installs). This allows for backwards compatibility with older versions.
+Please run `podman-system-reset` prior to changing the database
 backend of an existing deployment, to make sure Podman can operate correctly.
 
 **detach_keys**="ctrl-p,ctrl-q"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,24 +30,6 @@ const (
 	bindirPrefix = "$BINDIR"
 )
 
-// RuntimeStateStore is a constant indicating which state store implementation
-// should be used by engine
-type RuntimeStateStore int
-
-const (
-	// InvalidStateStore is an invalid state store
-	InvalidStateStore RuntimeStateStore = iota
-	// InMemoryStateStore is an in-memory state that will not persist data
-	// on containers and pods between engine instances or after system
-	// reboot
-	InMemoryStateStore RuntimeStateStore = iota
-	// SQLiteStateStore is a state backed by a SQLite database
-	// It is presently disabled
-	SQLiteStateStore RuntimeStateStore = iota
-	// BoltDBStateStore is a state backed by a BoltDB database
-	BoltDBStateStore RuntimeStateStore = iota
-)
-
 var validImageVolumeModes = []string{_typeBind, "tmpfs", "ignore"}
 
 // ProxyEnv is a list of Proxy Environment variables
@@ -482,13 +464,6 @@ type EngineConfig struct {
 	// SDNotify tells container engine to allow containers to notify the host systemd of
 	// readiness using the SD_NOTIFY mechanism.
 	SDNotify bool `toml:"-"`
-
-	// StateType is the type of the backing state store. Avoid using multiple
-	// values for this with the same containers/storage configuration on the
-	// same system. Different state types do not interact, and each will see a
-	// separate set of containers, which may cause conflicts in
-	// containers/storage. As such this is not exposed via the config file.
-	StateType RuntimeStateStore `toml:"-"`
 
 	// ServiceTimeout is the number of seconds to wait without a connection
 	// before the `podman system service` times out and exits

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -44,13 +44,10 @@ var _ = Describe("Config", func() {
 			}
 			gomega.Expect(defaultConfig.Engine.SSHConfig).To(gomega.ContainSubstring("/.ssh/config"))
 			gomega.Expect(defaultConfig.Engine.EventsContainerCreateInspectData).To(gomega.BeFalse())
-			gomega.Expect(defaultConfig.Engine.DBBackend).To(gomega.BeEquivalentTo(stringBoltDB))
+			gomega.Expect(defaultConfig.Engine.DBBackend).To(gomega.Equal(""))
 			gomega.Expect(defaultConfig.Engine.PodmanshTimeout).To(gomega.BeEquivalentTo(30))
 			gomega.Expect(defaultConfig.Engine.AddCompression).To(gomega.BeNil())
 
-			dbBackend, err := defaultConfig.DBBackend()
-			gomega.Expect(dbBackend).To(gomega.BeEquivalentTo(DBBackendBoltDB))
-			gomega.Expect(err).To(gomega.BeNil())
 			path, err := defaultConfig.ImageCopyTmpDir()
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(path).To(gomega.BeEquivalentTo("/var/tmp"))
@@ -476,9 +473,6 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(config.Engine.SSHConfig).To(gomega.Equal("/foo/bar/.ssh/config"))
 
 			gomega.Expect(config.Engine.DBBackend).To(gomega.Equal(stringSQLite))
-			dbBackend, err := config.DBBackend()
-			gomega.Expect(err).To(gomega.BeNil())
-			gomega.Expect(dbBackend).To(gomega.BeEquivalentTo(DBBackendSQLite))
 			gomega.Expect(config.Containers.CgroupConf).To(gomega.Equal(cgroupConf))
 			gomega.Expect(*config.Containers.OOMScoreAdj).To(gomega.Equal(int(750)))
 			gomega.Expect(config.Engine.KubeGenerateType).To(gomega.Equal("pod"))
@@ -648,9 +642,9 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(defConf).NotTo(gomega.BeNil())
 
-			defConf.Engine.DBBackend = ""
+			defConf.Engine.DBBackend = "blah"
 			err = defConf.Engine.Validate()
-			gomega.Expect(err).ToNot(gomega.BeNil())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 		})
 	})
 

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -454,10 +454,14 @@ default_sysctls = [
 # short-name aliases defined in containers-registries.conf(5).
 #compat_api_enforce_docker_hub = true
 
-# The database backend of Podman.  Supported values are "boltdb" (default) and
-# "sqlite". Please run `podman-system-reset` prior to changing the database
+# The database backend of Podman.  Supported values are "" (default), "boltdb"
+# and "sqlite". An empty value means it will check whenever a boltdb already
+# exists and use it when it does, otherwise it will use sqlite as default
+# (e.g. new installs). This allows for backwards compatibility with older versions.
+# Please run `podman-system-reset` prior to changing the database
 # backend of an existing deployment, to make sure Podman can operate correctly.
-#database_backend="boltdb"
+#
+#database_backend = ""
 
 # Specify the keys sequence used to detach a container.
 # Format is a single character [a-Z] or a comma separated sequence of

--- a/pkg/config/containers.conf-freebsd
+++ b/pkg/config/containers.conf-freebsd
@@ -29,10 +29,14 @@
 #
 #base_hosts_file = ""
 
-# The database backend of Podman.  Supported values are "boltdb" (default) and
-# "sqlite". Please run `podman-system-reset` prior to changing the database
+# The database backend of Podman.  Supported values are "" (default), "boltdb"
+# and "sqlite". An empty value means it will check whenever a boltdb already
+# exists and use it when it does, otherwise it will use sqlite as default
+# (e.g. new installs). This allows for backwards compatibility with older versions.
+# Please run `podman-system-reset` prior to changing the database
 # backend of an existing deployment, to make sure Podman can operate correctly.
-#database_backend="boltdb"
+#
+#database_backend = ""
 
 # List of default capabilities for containers. If it is empty or commented out,
 # the default capabilities defined in the container engine will be added.

--- a/pkg/config/db_backend.go
+++ b/pkg/config/db_backend.go
@@ -13,6 +13,12 @@ const (
 	// SQLite backend.
 	DBBackendSQLite
 
+	// DBBackendDefault describes that no explicit backend has been set.
+	// It should default to sqlite unless there is already an existing boltdb,
+	// this allows for backwards compatibility on upgrades. The actual detection
+	// logic must live in podman as we only know there were to look for the file.
+	DBBackendDefault
+
 	stringBoltDB = "boltdb"
 	stringSQLite = "sqlite"
 )
@@ -24,6 +30,8 @@ func (d DBBackend) String() string {
 		return stringBoltDB
 	case DBBackendSQLite:
 		return stringSQLite
+	case DBBackendDefault:
+		return ""
 	default:
 		return fmt.Sprintf("unsupported database backend: %d", d)
 	}
@@ -32,7 +40,7 @@ func (d DBBackend) String() string {
 // Validate returns whether the DBBackend is supported.
 func (d DBBackend) Validate() error {
 	switch d {
-	case DBBackendBoltDB, DBBackendSQLite:
+	case DBBackendBoltDB, DBBackendSQLite, DBBackendDefault:
 		return nil
 	default:
 		return fmt.Errorf("unsupported database backend: %d", d)
@@ -49,12 +57,9 @@ func ParseDBBackend(raw string) (DBBackend, error) {
 		return DBBackendBoltDB, nil
 	case stringSQLite:
 		return DBBackendSQLite, nil
+	case "":
+		return DBBackendDefault, nil
 	default:
 		return DBBackendUnsupported, fmt.Errorf("unsupported database backend: %q", raw)
 	}
-}
-
-// DBBackend returns the configured database backend.
-func (c *Config) DBBackend() (DBBackend, error) {
-	return ParseDBBackend(c.Engine.DBBackend)
 }

--- a/pkg/config/db_backend_test.go
+++ b/pkg/config/db_backend_test.go
@@ -14,7 +14,7 @@ func TestDBBackend(t *testing.T) {
 	}{
 		{stringBoltDB, true, DBBackendBoltDB},
 		{stringSQLite, true, DBBackendSQLite},
-		{"", false, DBBackendUnsupported},
+		{"", true, DBBackendDefault},
 		{stringSQLite + " ", false, DBBackendUnsupported},
 	}
 

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -120,8 +120,6 @@ const (
 	CgroupfsCgroupsManager = "cgroupfs"
 	// DefaultApparmorProfile  specifies the default apparmor profile for the container.
 	DefaultApparmorProfile = apparmor.Profile
-	// DefaultDBBackend specifies the default database backend to be used by Podman.
-	DefaultDBBackend = DBBackendBoltDB
 	// DefaultHostsFile is the default path to the hosts file.
 	DefaultHostsFile = "/etc/hosts"
 	// SystemdCgroupsManager represents systemd native cgroup manager.
@@ -317,7 +315,6 @@ func defaultEngineConfig() (*EngineConfig, error) {
 	c.HooksDir = DefaultHooksDirs
 	c.ImageDefaultTransport = _defaultTransport
 	c.ImageVolumeMode = _defaultImageVolumeMode
-	c.StateType = BoltDBStateStore
 
 	c.ImageBuildFormat = "oci"
 
@@ -424,7 +421,6 @@ func defaultEngineConfig() (*EngineConfig, error) {
 		"/run/current-system/sw/bin/conmonrs",
 	}
 	c.PullPolicy = DefaultPullPolicy
-	c.DBBackend = stringBoltDB
 	c.RuntimeSupportsJSON = []string{
 		"crun",
 		"runc",


### PR DESCRIPTION
Podman should default to sqlite for new installs, however to not break upgrades we should detect if a boltdb database exists and use that in such case. Now in order to distinguish between an explicitly set "sqlite" and "boltdb" and nothing set we use an empty default.

With that podman can know if we really should use the default or if it was configured for a db explicitly. The actual detection logic must be implemented in podman as we only know the file locations there.

This commit also drops the unused StateType as this was not used at all.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
