### PR TITLE
Copier: use StringWithinTransport instead of DockerReference

### DIFF
--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -361,7 +361,11 @@ func (c *copier) copy(ctx context.Context, source, destination types.ImageRefere
 		defer cancel()
 		defer timer.Stop()
 
-		fmt.Fprintf(c.imageCopyOptions.ReportWriter, "Pulling image %s inside systemd: setting pull timeout to %s\n", source.DockerReference(), time.Duration(numExtensions)*extension)
+		fmt.Fprintf(c.imageCopyOptions.ReportWriter,
+			"Pulling image %s inside systemd: setting pull timeout to %s\n",
+			source.StringWithinTransport(),
+			time.Duration(numExtensions)*extension,
+		)
 
 		// From `man systemd.service(5)`:
 		//


### PR DESCRIPTION
When trying an invalid image DockerReference maybe nil

This change addresses: https://github.com/containers/podman/issues/20432