### PR TITLE
libimage: add !remote tag

### DIFF
--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/corrupted_test.go
+++ b/libimage/corrupted_test.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/disk_usage.go
+++ b/libimage/disk_usage.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/events.go
+++ b/libimage/events.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/filters.go
+++ b/libimage/filters.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/filters_test.go
+++ b/libimage/filters_test.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/history.go
+++ b/libimage/history.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/history_test.go
+++ b/libimage/history_test.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/image.go
+++ b/libimage/image.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/image_config.go
+++ b/libimage/image_config.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/image_test.go
+++ b/libimage/image_test.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/image_tree.go
+++ b/libimage/image_tree.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/import.go
+++ b/libimage/import.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/import_test.go
+++ b/libimage/import_test.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/inspect.go
+++ b/libimage/inspect.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/layer_tree.go
+++ b/libimage/layer_tree.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/load.go
+++ b/libimage/load.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/load_test.go
+++ b/libimage/load_test.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/manifest_list_test.go
+++ b/libimage/manifest_list_test.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/normalize.go
+++ b/libimage/normalize.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/normalize_test.go
+++ b/libimage/normalize_test.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/oci.go
+++ b/libimage/oci.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/platform.go
+++ b/libimage/platform.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/pull_test.go
+++ b/libimage/pull_test.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/push.go
+++ b/libimage/push.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/push_test.go
+++ b/libimage/push_test.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/remove_test.go
+++ b/libimage/remove_test.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/runtime_test.go
+++ b/libimage/runtime_test.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/save.go
+++ b/libimage/save.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/save_test.go
+++ b/libimage/save_test.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (

--- a/libimage/search.go
+++ b/libimage/search.go
@@ -1,3 +1,6 @@
+//go:build !remote
+// +build !remote
+
 package libimage
 
 import (


### PR DESCRIPTION
To prevent the podman remote client from using libimage which causes a lot of bloat due the c/image and c/storage dependencies add the `!remote` tag.

This will cause a hard compile time failure if the remote client ends up pulling in libimage.

Fixes #1702

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
