### PR TITLE
UserConnection is used by non linux platforms

### DIFF
--- a/pkg/cgroups/cgroups_linux.go
+++ b/pkg/cgroups/cgroups_linux.go
@@ -135,8 +135,8 @@ func getAvailableControllers(exclude map[string]controllerHandler, cgroup2 bool)
 	return controllers, nil
 }
 
-// GetAvailableControllers get string:bool map of all the available controllers
-func GetAvailableControllers(exclude map[string]controllerHandler, cgroup2 bool) ([]string, error) {
+// AvailableControllers get string:bool map of all the available controllers
+func AvailableControllers(exclude map[string]controllerHandler, cgroup2 bool) ([]string, error) {
 	availableControllers, err := getAvailableControllers(exclude, cgroup2)
 	if err != nil {
 		return nil, err
@@ -392,20 +392,13 @@ func (c *CgroupControl) CreateSystemdUnit(path string) error {
 	return systemdCreate(c.config.Resources, path, conn)
 }
 
-// GetUserConnection returns an user connection to D-BUS
-func GetUserConnection(uid int) (*systemdDbus.Conn, error) {
-	return systemdDbus.NewConnection(func() (*dbus.Conn, error) {
-		return dbusAuthConnection(uid, dbus.SessionBusPrivateNoAutoStartup)
-	})
-}
-
 // CreateSystemdUserUnit creates the systemd cgroup for the specified user
 func (c *CgroupControl) CreateSystemdUserUnit(path string, uid int) error {
 	if !c.systemd {
 		return fmt.Errorf("the cgroup controller is not using systemd")
 	}
 
-	conn, err := GetUserConnection(uid)
+	conn, err := UserConnection(uid)
 	if err != nil {
 		return err
 	}

--- a/pkg/cgroups/cgroups_supported.go
+++ b/pkg/cgroups/cgroups_supported.go
@@ -15,6 +15,8 @@ import (
 	"syscall"
 	"time"
 
+	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/godbus/dbus/v5"
 	"golang.org/x/sys/unix"
 )
 
@@ -35,6 +37,13 @@ func IsCgroup2UnifiedMode() (bool, error) {
 		}
 	})
 	return isUnified, isUnifiedErr
+}
+
+// UserConnection returns an user connection to D-BUS
+func UserConnection(uid int) (*systemdDbus.Conn, error) {
+	return systemdDbus.NewConnection(func() (*dbus.Conn, error) {
+		return dbusAuthConnection(uid, dbus.SessionBusPrivateNoAutoStartup)
+	})
 }
 
 // UserOwnsCurrentSystemdCgroup checks whether the current EUID owns the

--- a/pkg/cgroups/utils_linux.go
+++ b/pkg/cgroups/utils_linux.go
@@ -104,8 +104,8 @@ func ReadFile(dir, file string) (string, error) {
 	return buf.String(), err
 }
 
-// GetBlkioFiles gets the proper files for blkio weights
-func GetBlkioFiles(cgroupPath string) (wtFile, wtDevFile string) {
+// BlkioFiles gets the proper files for blkio weights
+func BlkioFiles(cgroupPath string) (wtFile, wtDevFile string) {
 	var weightFile string
 	var weightDeviceFile string
 	// in this important since runc keeps these variables private, they won't be set


### PR DESCRIPTION
Take this oppurtunity to remove Get prefix on functions in cgroups.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
