### PR TITLE
[v0.55.x][git cherry-pick 5c81adc] apparmor: fix parsing beta/alpha version

### DIFF
--- a/pkg/apparmor/apparmor_linux.go
+++ b/pkg/apparmor/apparmor_linux.go
@@ -212,6 +212,11 @@ func parseAAParserVersion(output string) (int, error) {
 	words := strings.Split(lines[0], " ")
 	version := words[len(words)-1]
 
+	// trim "-beta1" suffix from version="3.0.0-beta1" if exists
+	version = strings.SplitN(version, "-", 2)[0]
+	// also trim "~..." suffix used historically (https://gitlab.com/apparmor/apparmor/-/commit/bca67d3d27d219d11ce8c9cc70612bd637f88c10)
+	version = strings.SplitN(version, "~", 2)[0]
+
 	// split by major minor version
 	v := strings.Split(version, ".")
 	if len(v) == 0 || len(v) > 3 {


### PR DESCRIPTION
Copied from github.com/moby/moby who already has a fix for it. Tested manually on a Ubuntu 23.10 (beta) VM.

Fixes: #containers/podman/issues/20278

Cherry-pick via v0.55, for CRI-O v1.28.x (see https://github.com/cri-o/cri-o/blob/release-1.28/go.mod#L23)
