### PR TITLE
parse: support `no-dereference` mount option

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -14,7 +14,7 @@ import (
 
 // ValidateVolumeOpts validates a volume's options
 func ValidateVolumeOpts(options []string) ([]string, error) {
-	var foundRootPropagation, foundRWRO, foundLabelChange, bindType, foundExec, foundDev, foundSuid, foundChown, foundUpperDir, foundWorkDir, foundCopy int
+	var foundRootPropagation, foundRWRO, foundLabelChange, bindType, foundExec, foundDev, foundSuid, foundChown, foundUpperDir, foundWorkDir, foundCopy, foundCopySymlink int
 	finalOpts := make([]string, 0, len(options))
 	for _, opt := range options {
 		// support advanced options like upperdir=/path, workdir=/path
@@ -92,6 +92,11 @@ func ValidateVolumeOpts(options []string) ([]string, error) {
 			foundCopy++
 			if foundCopy > 1 {
 				return nil, fmt.Errorf("invalid options %q, can only specify 1 'copy' or 'nocopy' option", strings.Join(options, ", "))
+			}
+		case "no-dereference":
+			foundCopySymlink++
+			if foundCopySymlink > 1 {
+				return nil, fmt.Errorf("invalid options %q, can only specify 1 'no-dereference' option", strings.Join(options, ", "))
 			}
 		default:
 			return nil, fmt.Errorf("invalid option type %q", opt)


### PR DESCRIPTION
Requries crun 1.11+ where the option is called `copy-symlink`.
Required in containers/podman/pull/20356.


<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
