### PR TITLE
Fix inspection of unsigned schema1 images

### DIFF
--- a/libimage/inspect.go
+++ b/libimage/inspect.go
@@ -185,16 +185,16 @@ func (i *Image) Inspect(ctx context.Context, options *InspectOptions) (*ImageDat
 		if err != nil {
 			return nil, err
 		}
-		var dockerManifest manifest.Schema2V1Image
-		if err := json.Unmarshal(rawConfig, &dockerManifest); err != nil {
+		var dockerConfig manifest.Schema2V1Image
+		if err := json.Unmarshal(rawConfig, &dockerConfig); err != nil {
 			return nil, err
 		}
-		data.Comment = dockerManifest.Comment
+		data.Comment = dockerConfig.Comment
 		// NOTE: Health checks may be listed in the container config or
 		// the config.
-		data.HealthCheck = dockerManifest.ContainerConfig.Healthcheck
-		if data.HealthCheck == nil && dockerManifest.Config != nil {
-			data.HealthCheck = dockerManifest.Config.Healthcheck
+		data.HealthCheck = dockerConfig.ContainerConfig.Healthcheck
+		if data.HealthCheck == nil && dockerConfig.Config != nil {
+			data.HealthCheck = dockerConfig.Config.Healthcheck
 		}
 	}
 

--- a/libimage/inspect.go
+++ b/libimage/inspect.go
@@ -180,7 +180,7 @@ func (i *Image) Inspect(ctx context.Context, options *InspectOptions) (*ImageDat
 		}
 
 	// Docker image
-	case manifest.DockerV2Schema1MediaType, manifest.DockerV2Schema2MediaType:
+	case manifest.DockerV2Schema2MediaType:
 		rawConfig, err := i.rawConfigBlob(ctx)
 		if err != nil {
 			return nil, err
@@ -196,6 +196,10 @@ func (i *Image) Inspect(ctx context.Context, options *InspectOptions) (*ImageDat
 		if data.HealthCheck == nil && dockerConfig.Config != nil {
 			data.HealthCheck = dockerConfig.Config.Healthcheck
 		}
+
+	case manifest.DockerV2Schema1MediaType, manifest.DockerV2Schema1SignedMediaType:
+		// There seem to be at least _some_ images with .Healthcheck set in schema1 (possibly just as an artifact
+		// of testing format conversion?), so this could plausibly read these values.
 	}
 
 	if data.Annotations == nil {


### PR DESCRIPTION
… by not doing anything, like with the (much more common) signed schema1 images.

Fixes https://github.com/containers/podman/issues/20156 .