### PR TITLE
Moving policy.json and default.yaml from containers/skopeo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@ GO_BUILD=$(GO) build
 BUILDTAGS := containers_image_openpgp,systemd,exclude_graphdriver_devicemapper
 DESTDIR ?=
 PREFIX := /usr/local
+ifeq ($(shell uname -s),FreeBSD)
+CONTAINERSCONFDIR ?= /usr/local/etc/containers
+else
+CONTAINERSCONFDIR ?= /etc/containers
+endif
+REGISTRIESDDIR ?= ${CONTAINERSCONFDIR}/registries.d
 CONFIGDIR := ${PREFIX}/share/containers
 
 define go-build
@@ -90,6 +96,11 @@ build/golangci-lint:
 install:
 	install -d ${DESTDIR}/${CONFIGDIR}
 	install -m 0644 pkg/config/containers.conf ${DESTDIR}/${CONFIGDIR}/containers.conf
+	install -d -m 755 ${DESTDIR}${LOOKASIDEDIR}
+	install -d -m 755 ${DESTDIR}${CONTAINERSCONFDIR}
+	install -m 644 default-policy.json ${DESTDIR}${CONTAINERSCONFDIR}/policy.json
+	install -d -m 755 ${DESTDIR}${REGISTRIESDDIR}
+	install -m 644 default.yaml ${DESTDIR}${REGISTRIESDDIR}/default.yaml
 
 	$(MAKE) -C docs install
 

--- a/default-policy.json
+++ b/default-policy.json
@@ -1,0 +1,14 @@
+{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ],
+    "transports":
+        {
+            "docker-daemon":
+                {
+                    "": [{"type":"insecureAcceptAnything"}]
+                }
+        }
+}

--- a/default.yaml
+++ b/default.yaml
@@ -1,0 +1,28 @@
+# This is a default registries.d configuration file.  You may
+# add to this file or create additional files in registries.d/.
+#
+# lookaside: for reading/writing simple signing signatures
+# lookaside-staging: for writing simple signing signatures, preferred over lookaside
+#
+# lookaside and lookaside-staging take a value of the following:
+#   lookaside:  {schema}://location
+#
+# For reading signatures, schema may be http, https, or file.
+# For writing signatures, schema may only be file.
+
+# The default locations are built-in, for both reading and writing:
+# /var/lib/containers/sigstore for root, or
+# ~/.local/share/containers/sigstore for non-root users.
+default-docker:
+#  lookaside: https://…
+#  lookaside-staging: file:///…
+
+# The 'docker' indicator here is the start of the configuration
+# for docker registries.
+#
+# docker:
+#
+#   privateregistry.com:
+#    lookaside: https://privateregistry.com/sigstore/
+#    lookaside-staging: /mnt/nfs/privateregistry/sigstore
+


### PR DESCRIPTION
All major distros (Fedora, debian, archlinux, gentoo, alpine, opensuse) are placing these 2 files in containers-common package. Why not fix it upstream?

2nd step towards addressing https://github.com/containers/skopeo/issues/2170

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
