### PR TITLE
Image copier: make sure ReportWriter is not nil before accessing

### DIFF
--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -364,11 +364,13 @@ func (c *copier) copy(ctx context.Context, source, destination types.ImageRefere
 		defer cancel()
 		defer timer.Stop()
 
-		fmt.Fprintf(c.imageCopyOptions.ReportWriter,
-			"Pulling image %s inside systemd: setting pull timeout to %s\n",
-			source.StringWithinTransport(),
-			time.Duration(numExtensions)*extension,
-		)
+		if c.imageCopyOptions.ReportWriter != nil {
+			fmt.Fprintf(c.imageCopyOptions.ReportWriter,
+				"Pulling image %s inside systemd: setting pull timeout to %s\n",
+				source.StringWithinTransport(),
+				time.Duration(numExtensions)*extension,
+			)
+		}
 
 		// From `man systemd.service(5)`:
 		//


### PR DESCRIPTION
When running in Quiet mode, the ReportWriter can be nil causing a crash

This fix addressed the issue explained in https://github.com/containers/podman/pull/20889#issuecomment-1838540557

@vrothberg @rhatdan 