### PR TITLE
[0.57] backport #1754  + v0.57.1

### DIFF
--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -32,6 +32,8 @@ func ifRootlessConfigPath() (string, error) {
 }
 
 var defaultHelperBinariesDir = []string{
+	// Relative to the binary directory
+	"$BINDIR/../libexec/podman",
 	// Homebrew install paths
 	"/usr/local/opt/podman/libexec/podman",
 	"/opt/homebrew/opt/podman/libexec/podman",
@@ -42,6 +44,4 @@ var defaultHelperBinariesDir = []string{
 	"/usr/local/lib/podman",
 	"/usr/libexec/podman",
 	"/usr/lib/podman",
-	// Relative to the binary directory
-	"$BINDIR/../libexec/podman",
 }

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -338,7 +338,8 @@ func defaultEngineConfig() (*EngineConfig, error) {
 
 	c.HelperBinariesDir.Set(defaultHelperBinariesDir)
 	if additionalHelperBinariesDir != "" {
-		c.HelperBinariesDir.Set(append(c.HelperBinariesDir.Get(), additionalHelperBinariesDir))
+		// Prioritize addtionalHelperBinariesDir over defaults.
+		c.HelperBinariesDir.Set(append([]string{additionalHelperBinariesDir}, c.HelperBinariesDir.Get()...))
 	}
 	c.HooksDir.Set(DefaultHooksDirs)
 	c.ImageDefaultTransport = _defaultTransport

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.57.1"
+const Version = "0.57.2-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.57.1-dev"
+const Version = "0.57.1"


### PR DESCRIPTION
Backport https://github.com/containers/common/pull/1754 and cut new release so podman 4.8.2 can vendor this.
