### PR TITLE
Use `TZDIR` as override lookup path

### DIFF
--- a/pkg/config/config_local.go
+++ b/pkg/config/config_local.go
@@ -67,11 +67,11 @@ func (c *ContainersConfig) validateTZ() error {
 		"/etc/zoneinfo",
 	}
 
-	// Allow using TZDIR per:
+	// Allow using TZDIR to override the lookupPaths. Ref:
 	// https://sourceware.org/git/?p=glibc.git;a=blob;f=time/tzfile.c;h=8a923d0cccc927a106dc3e3c641be310893bab4e;hb=HEAD#l149
 	tzdir := os.Getenv("TZDIR")
 	if tzdir != "" {
-		lookupPaths = append(lookupPaths, tzdir)
+		lookupPaths = []string{tzdir}
 	}
 
 	for _, paths := range lookupPaths {


### PR DESCRIPTION
The TZDIR environment variable override the lookup paths and does not append them. This patch fixes that behavior and is a follow-up on:

https://github.com/containers/common/pull/1772

Ref: https://github.com/containers/podman/pull/21063#discussion_r1432809463

cc @edsantiago 