### PR TITLE
chore: delete obsolete // +build lines

### DIFF
--- a/cmd/seccomp/generate.go
+++ b/cmd/seccomp/generate.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/corrupted_test.go
+++ b/libimage/corrupted_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/disk_usage.go
+++ b/libimage/disk_usage.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/events.go
+++ b/libimage/events.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/filters.go
+++ b/libimage/filters.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/filters_test.go
+++ b/libimage/filters_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/history.go
+++ b/libimage/history.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/history_test.go
+++ b/libimage/history_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/image.go
+++ b/libimage/image.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/image_config.go
+++ b/libimage/image_config.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/image_test.go
+++ b/libimage/image_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/image_tree.go
+++ b/libimage/image_tree.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/import.go
+++ b/libimage/import.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/import_test.go
+++ b/libimage/import_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/inspect.go
+++ b/libimage/inspect.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/layer_tree.go
+++ b/libimage/layer_tree.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/load.go
+++ b/libimage/load.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/load_test.go
+++ b/libimage/load_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/manifest_list_test.go
+++ b/libimage/manifest_list_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/normalize.go
+++ b/libimage/normalize.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/normalize_test.go
+++ b/libimage/normalize_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/oci.go
+++ b/libimage/oci.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/platform.go
+++ b/libimage/platform.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/pull_test.go
+++ b/libimage/pull_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/push.go
+++ b/libimage/push.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/push_test.go
+++ b/libimage/push_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/remove_test.go
+++ b/libimage/remove_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/runtime_test.go
+++ b/libimage/runtime_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/save.go
+++ b/libimage/save.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/save_test.go
+++ b/libimage/save_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libimage/search.go
+++ b/libimage/search.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libimage
 

--- a/libnetwork/cni/cni_conversion.go
+++ b/libnetwork/cni/cni_conversion.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package cni
 

--- a/libnetwork/cni/cni_exec.go
+++ b/libnetwork/cni/cni_exec.go
@@ -17,7 +17,6 @@
 // limitations under the License.
 
 //go:build linux || freebsd
-// +build linux freebsd
 
 package cni
 

--- a/libnetwork/cni/cni_suite_test.go
+++ b/libnetwork/cni/cni_suite_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cni_test
 

--- a/libnetwork/cni/cni_types.go
+++ b/libnetwork/cni/cni_types.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package cni
 

--- a/libnetwork/cni/config.go
+++ b/libnetwork/cni/config.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package cni
 

--- a/libnetwork/cni/config_freebsd.go
+++ b/libnetwork/cni/config_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd
-// +build freebsd
 
 package cni
 

--- a/libnetwork/cni/config_linux.go
+++ b/libnetwork/cni/config_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cni
 

--- a/libnetwork/cni/config_test.go
+++ b/libnetwork/cni/config_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cni_test
 

--- a/libnetwork/cni/network.go
+++ b/libnetwork/cni/network.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package cni
 

--- a/libnetwork/cni/run.go
+++ b/libnetwork/cni/run.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package cni
 

--- a/libnetwork/cni/run_test.go
+++ b/libnetwork/cni/run_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cni_test
 

--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package netavark
 

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package netavark_test
 

--- a/libnetwork/netavark/const.go
+++ b/libnetwork/netavark/const.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package netavark
 

--- a/libnetwork/netavark/exec.go
+++ b/libnetwork/netavark/exec.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package netavark
 

--- a/libnetwork/netavark/ipam.go
+++ b/libnetwork/netavark/ipam.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package netavark
 

--- a/libnetwork/netavark/ipam_test.go
+++ b/libnetwork/netavark/ipam_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package netavark
 

--- a/libnetwork/netavark/netavark_suite_test.go
+++ b/libnetwork/netavark/netavark_suite_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package netavark_test
 

--- a/libnetwork/netavark/network.go
+++ b/libnetwork/netavark/network.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package netavark
 

--- a/libnetwork/netavark/plugin_test.go
+++ b/libnetwork/netavark/plugin_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package netavark_test
 

--- a/libnetwork/netavark/run.go
+++ b/libnetwork/netavark/run.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package netavark
 

--- a/libnetwork/netavark/run_test.go
+++ b/libnetwork/netavark/run_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package netavark_test
 

--- a/libnetwork/network/interface.go
+++ b/libnetwork/network/interface.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package network
 

--- a/libnetwork/slirp4netns/slirp4netns.go
+++ b/libnetwork/slirp4netns/slirp4netns.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package slirp4netns
 

--- a/pkg/apparmor/apparmor_linux.go
+++ b/pkg/apparmor/apparmor_linux.go
@@ -1,5 +1,4 @@
 //go:build linux && apparmor
-// +build linux,apparmor
 
 package apparmor
 

--- a/pkg/apparmor/apparmor_linux_template.go
+++ b/pkg/apparmor/apparmor_linux_template.go
@@ -1,5 +1,4 @@
 //go:build linux && apparmor
-// +build linux,apparmor
 
 package apparmor
 

--- a/pkg/apparmor/apparmor_linux_test.go
+++ b/pkg/apparmor/apparmor_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux && apparmor
-// +build linux,apparmor
 
 package apparmor
 

--- a/pkg/apparmor/apparmor_unsupported.go
+++ b/pkg/apparmor/apparmor_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux || !apparmor
-// +build !linux !apparmor
 
 package apparmor
 

--- a/pkg/cgroups/blkio_linux.go
+++ b/pkg/cgroups/blkio_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cgroups
 

--- a/pkg/cgroups/cgroups_linux.go
+++ b/pkg/cgroups/cgroups_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cgroups
 

--- a/pkg/cgroups/cgroups_linux_test.go
+++ b/pkg/cgroups/cgroups_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cgroups
 

--- a/pkg/cgroups/cgroups_supported.go
+++ b/pkg/cgroups/cgroups_supported.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cgroups
 

--- a/pkg/cgroups/cgroups_unsupported.go
+++ b/pkg/cgroups/cgroups_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package cgroups
 

--- a/pkg/cgroups/cpu_linux.go
+++ b/pkg/cgroups/cpu_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cgroups
 

--- a/pkg/cgroups/cpuset_linux.go
+++ b/pkg/cgroups/cpuset_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cgroups
 

--- a/pkg/cgroups/memory_linux.go
+++ b/pkg/cgroups/memory_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cgroups
 

--- a/pkg/cgroups/pids_linux.go
+++ b/pkg/cgroups/pids_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cgroups
 

--- a/pkg/cgroups/systemd.go
+++ b/pkg/cgroups/systemd.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package cgroups
 

--- a/pkg/cgroups/systemd_linux.go
+++ b/pkg/cgroups/systemd_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cgroups
 

--- a/pkg/cgroups/utils_linux.go
+++ b/pkg/cgroups/utils_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cgroups
 

--- a/pkg/cgroupv2/cgroups_unsupported.go
+++ b/pkg/cgroupv2/cgroups_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package cgroupv2
 

--- a/pkg/chown/chown_unix.go
+++ b/pkg/chown/chown_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package chown
 

--- a/pkg/config/config_local.go
+++ b/pkg/config/config_local.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package config
 

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package config
 

--- a/pkg/config/config_remote.go
+++ b/pkg/config/config_remote.go
@@ -1,5 +1,4 @@
 //go:build remote
-// +build remote
 
 package config
 

--- a/pkg/config/config_remote_test.go
+++ b/pkg/config/config_remote_test.go
@@ -1,5 +1,4 @@
 //go:build remote
-// +build remote
 
 package config
 

--- a/pkg/config/config_unsupported.go
+++ b/pkg/config/config_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package config
 

--- a/pkg/config/default_common.go
+++ b/pkg/config/default_common.go
@@ -1,5 +1,4 @@
 //go:build !freebsd
-// +build !freebsd
 
 package config
 

--- a/pkg/config/default_unsupported.go
+++ b/pkg/config/default_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows
-// +build !linux,!windows
 
 package config
 

--- a/pkg/config/nosystemd.go
+++ b/pkg/config/nosystemd.go
@@ -1,5 +1,4 @@
 //go:build !systemd || !cgo
-// +build !systemd !cgo
 
 package config
 

--- a/pkg/config/systemd.go
+++ b/pkg/config/systemd.go
@@ -1,5 +1,4 @@
 //go:build systemd && cgo
-// +build systemd,cgo
 
 package config
 

--- a/pkg/parse/parse_unix.go
+++ b/pkg/parse/parse_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin || freebsd
-// +build linux darwin freebsd
 
 package parse
 

--- a/pkg/password/password_supported.go
+++ b/pkg/password/password_supported.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin || freebsd
-// +build linux darwin freebsd
 
 package password
 

--- a/pkg/password/password_windows.go
+++ b/pkg/password/password_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package password
 

--- a/pkg/retry/retry_unsupported.go
+++ b/pkg/retry/retry_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package retry
 

--- a/pkg/rootlessport/rootlessport_linux.go
+++ b/pkg/rootlessport/rootlessport_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Rootlessport Config type for use in podman/cmd/rootlessport.
 package rootlessport

--- a/pkg/seccomp/errno_list.go
+++ b/pkg/seccomp/errno_list.go
@@ -1,5 +1,4 @@
 //go:build linux && seccomp
-// +build linux,seccomp
 
 package seccomp
 

--- a/pkg/seccomp/filter.go
+++ b/pkg/seccomp/filter.go
@@ -1,5 +1,4 @@
 //go:build seccomp
-// +build seccomp
 
 // NOTE: this package has originally been copied from
 // github.com/opencontainers/runc and modified to work for other use cases

--- a/pkg/seccomp/filter_test.go
+++ b/pkg/seccomp/filter_test.go
@@ -1,5 +1,4 @@
 //go:build seccomp
-// +build seccomp
 
 package seccomp
 

--- a/pkg/seccomp/generate.go
+++ b/pkg/seccomp/generate.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 // Copyright 2013-2021 Docker, Inc.
 

--- a/pkg/seccomp/seccomp_linux.go
+++ b/pkg/seccomp/seccomp_linux.go
@@ -1,5 +1,4 @@
 //go:build seccomp
-// +build seccomp
 
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/seccomp/seccomp_test.go
+++ b/pkg/seccomp/seccomp_test.go
@@ -1,5 +1,4 @@
 //go:build seccomp
-// +build seccomp
 
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/seccomp/seccomp_unsupported.go
+++ b/pkg/seccomp/seccomp_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux || !seccomp
-// +build !linux !seccomp
 
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/seccomp/supported.go
+++ b/pkg/seccomp/supported.go
@@ -1,5 +1,4 @@
 //go:build linux && seccomp
-// +build linux,seccomp
 
 package seccomp
 

--- a/pkg/seccomp/validate.go
+++ b/pkg/seccomp/validate.go
@@ -1,5 +1,4 @@
 //go:build seccomp
-// +build seccomp
 
 package seccomp
 

--- a/pkg/seccomp/validate_test.go
+++ b/pkg/seccomp/validate_test.go
@@ -1,5 +1,4 @@
 //go:build seccomp
-// +build seccomp
 
 package seccomp
 

--- a/pkg/servicereaper/service.go
+++ b/pkg/servicereaper/service.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package servicereaper
 

--- a/pkg/signal/signal_linux.go
+++ b/pkg/signal/signal_linux.go
@@ -1,5 +1,4 @@
 //go:build linux && !mips && !mipsle && !mips64 && !mips64le
-// +build linux,!mips,!mipsle,!mips64,!mips64le
 
 // Signal handling for Linux only.
 package signal

--- a/pkg/signal/signal_linux_mipsx.go
+++ b/pkg/signal/signal_linux_mipsx.go
@@ -1,6 +1,4 @@
 //go:build linux && (mips || mipsle || mips64 || mips64le)
-// +build linux
-// +build mips mipsle mips64 mips64le
 
 // Special signal handling for mips architecture
 package signal

--- a/pkg/signal/signal_unsupported.go
+++ b/pkg/signal/signal_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Signal handling for Linux only.
 package signal

--- a/pkg/sysinfo/numcpu_linux.go
+++ b/pkg/sysinfo/numcpu_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package sysinfo
 

--- a/pkg/sysinfo/numcpu_other.go
+++ b/pkg/sysinfo/numcpu_other.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows
-// +build !linux,!windows
 
 package sysinfo
 

--- a/pkg/sysinfo/numcpu_windows.go
+++ b/pkg/sysinfo/numcpu_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package sysinfo
 

--- a/pkg/sysinfo/nummem_linux.go
+++ b/pkg/sysinfo/nummem_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package sysinfo
 

--- a/pkg/sysinfo/nummem_unsupported.go
+++ b/pkg/sysinfo/nummem_unsupported.go
@@ -1,5 +1,4 @@
 //go:build (windows && ignore) || osx
-// +build windows,ignore osx
 
 package sysinfo
 

--- a/pkg/sysinfo/sysinfo_solaris.go
+++ b/pkg/sysinfo/sysinfo_solaris.go
@@ -1,5 +1,4 @@
 //go:build solaris && cgo
-// +build solaris,cgo
 
 package sysinfo
 

--- a/pkg/sysinfo/sysinfo_unix.go
+++ b/pkg/sysinfo/sysinfo_unix.go
@@ -1,5 +1,4 @@
 //go:build !linux && !solaris && !windows
-// +build !linux,!solaris,!windows
 
 package sysinfo
 

--- a/pkg/sysinfo/sysinfo_windows.go
+++ b/pkg/sysinfo/sysinfo_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package sysinfo
 

--- a/pkg/timezone/timezone_linux.go
+++ b/pkg/timezone/timezone_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package timezone
 

--- a/pkg/umask/umask_unix.go
+++ b/pkg/umask/umask_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 package umask
 

--- a/pkg/umask/umask_unsupported.go
+++ b/pkg/umask/umask_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !darwin
-// +build !linux,!darwin
 
 package umask
 


### PR DESCRIPTION
This PR removes outdated `// +build` build constraints. Use `go fix ./...` to remove the `// +build` lines that have become obsolete in Go 1.18. See https://go.dev/doc/go1.18#go-build-lines.

