### PR TITLE
Refactor: replace raw loops with funcs from slices and maps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	go.etcd.io/bbolt v1.3.8
 	golang.org/x/crypto v0.17.0
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/sync v0.6.0
 	golang.org/x/sys v0.15.0
 	golang.org/x/term v0.15.0
@@ -127,7 +128,6 @@ require (
 	go.mongodb.org/mongo-driver v1.13.1 // indirect
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/libnetwork/cni/cni_conversion.go
+++ b/libnetwork/cni/cni_conversion.go
@@ -17,8 +17,8 @@ import (
 	internalutil "github.com/containers/common/libnetwork/internal/util"
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/libnetwork/util"
-	pkgutil "github.com/containers/common/pkg/util"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sys/unix"
 )
 
@@ -358,7 +358,7 @@ func convertSpecgenPortsToCNIPorts(ports []types.PortMapping) ([]cniPortMapEntry
 		protocols := strings.Split(port.Protocol, ",")
 
 		for _, protocol := range protocols {
-			if !pkgutil.StringInSlice(protocol, []string{"tcp", "udp", "sctp"}) {
+			if !slices.Contains([]string{"tcp", "udp", "sctp"}, protocol) {
 				return nil, fmt.Errorf("unknown port protocol %s", protocol)
 			}
 			cniPort := cniPortMapEntry{
@@ -420,11 +420,11 @@ func parseOptions(networkOptions map[string]string, networkDriver string) (*opti
 		case types.ModeOption:
 			switch networkDriver {
 			case types.MacVLANNetworkDriver:
-				if !pkgutil.StringInSlice(v, types.ValidMacVLANModes) {
+				if !slices.Contains(types.ValidMacVLANModes, v) {
 					return nil, fmt.Errorf("unknown macvlan mode %q", v)
 				}
 			case types.IPVLANNetworkDriver:
-				if !pkgutil.StringInSlice(v, types.ValidIPVLANModes) {
+				if !slices.Contains(types.ValidIPVLANModes, v) {
 					return nil, fmt.Errorf("unknown ipvlan mode %q", v)
 				}
 			default:

--- a/libnetwork/cni/config.go
+++ b/libnetwork/cni/config.go
@@ -10,8 +10,8 @@ import (
 
 	internalutil "github.com/containers/common/libnetwork/internal/util"
 	"github.com/containers/common/libnetwork/types"
-	pkgutil "github.com/containers/common/pkg/util"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 )
 
 func (n *cniNetwork) NetworkUpdate(_ string, _ types.NetworkUpdateOptions) error {
@@ -205,7 +205,7 @@ func createIPMACVLAN(network *types.Network) error {
 		if err != nil {
 			return err
 		}
-		if !pkgutil.StringInSlice(network.NetworkInterface, interfaceNames) {
+		if !slices.Contains(interfaceNames, network.NetworkInterface) {
 			return fmt.Errorf("parent interface %s does not exist", network.NetworkInterface)
 		}
 	}

--- a/libnetwork/etchosts/hosts.go
+++ b/libnetwork/etchosts/hosts.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/containers/common/pkg/config"
-	"github.com/containers/common/pkg/util"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -220,7 +220,7 @@ func checkIfEntryExists(current HostEntry, entries HostEntries) bool {
 		if current.IP == rm.IP {
 			// it is enough if one of the names match, in this case we remove the full entry
 			for _, name := range current.Names {
-				if util.StringInSlice(name, rm.Names) {
+				if slices.Contains(rm.Names, name) {
 					return true
 				}
 			}

--- a/libnetwork/internal/util/bridge.go
+++ b/libnetwork/internal/util/bridge.go
@@ -7,13 +7,13 @@ import (
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/libnetwork/util"
 	"github.com/containers/common/pkg/config"
-	pkgutil "github.com/containers/common/pkg/util"
+	"golang.org/x/exp/slices"
 )
 
 func CreateBridge(n NetUtil, network *types.Network, usedNetworks []*net.IPNet, subnetPools []config.SubnetPool) error {
 	if network.NetworkInterface != "" {
 		bridges := GetBridgeInterfaceNames(n)
-		if pkgutil.StringInSlice(network.NetworkInterface, bridges) {
+		if slices.Contains(bridges, network.NetworkInterface) {
 			return fmt.Errorf("bridge name %s already in use", network.NetworkInterface)
 		}
 		if !types.NameRegex.MatchString(network.NetworkInterface) {

--- a/libnetwork/internal/util/util.go
+++ b/libnetwork/internal/util/util.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/pkg/config"
-	"github.com/containers/common/pkg/util"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 )
 
 // GetBridgeInterfaceNames returns all bridge interface names
@@ -51,7 +51,7 @@ func GetFreeDeviceName(n NetUtil) (string, error) {
 	// Start by 1, 0 is reserved for the default network
 	for i := 1; i < 1000000; i++ {
 		deviceName := fmt.Sprintf("%s%d", n.DefaultInterfaceName(), i)
-		if !util.StringInSlice(deviceName, names) {
+		if !slices.Contains(names, deviceName) {
 			logrus.Debugf("found free device name %s", deviceName)
 			return deviceName, nil
 		}

--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -15,14 +15,14 @@ import (
 
 	internalutil "github.com/containers/common/libnetwork/internal/util"
 	"github.com/containers/common/libnetwork/types"
-	"github.com/containers/common/pkg/util"
 	"github.com/containers/storage/pkg/stringid"
+	"golang.org/x/exp/slices"
 )
 
 func sliceRemoveDuplicates(strList []string) []string {
 	list := make([]string, 0, len(strList))
 	for _, item := range strList {
-		if !util.StringInSlice(item, list) {
+		if !slices.Contains(list, item) {
 			list = append(list, item)
 		}
 	}
@@ -70,7 +70,7 @@ func (n *netavarkNetwork) NetworkUpdate(name string, options types.NetworkUpdate
 	networkDNSServersBefore := network.NetworkDNSServers
 	networkDNSServersAfter := []string{}
 	for _, server := range networkDNSServersBefore {
-		if util.StringInSlice(server, options.RemoveDNSServers) {
+		if slices.Contains(options.RemoveDNSServers, server) {
 			continue
 		}
 		networkDNSServersAfter = append(networkDNSServersAfter, server)
@@ -272,7 +272,7 @@ func createIpvlanOrMacvlan(network *types.Network) error {
 		if err != nil {
 			return err
 		}
-		if !util.StringInSlice(network.NetworkInterface, interfaceNames) {
+		if !slices.Contains(interfaceNames, network.NetworkInterface) {
 			return fmt.Errorf("parent interface %s does not exist", network.NetworkInterface)
 		}
 	}
@@ -318,11 +318,11 @@ func createIpvlanOrMacvlan(network *types.Network) error {
 		switch key {
 		case types.ModeOption:
 			if isMacVlan {
-				if !util.StringInSlice(value, types.ValidMacVLANModes) {
+				if !slices.Contains(types.ValidMacVLANModes, value) {
 					return fmt.Errorf("unknown macvlan mode %q", value)
 				}
 			} else {
-				if !util.StringInSlice(value, types.ValidIPVLANModes) {
+				if !slices.Contains(types.ValidIPVLANModes, value) {
 					return fmt.Errorf("unknown ipvlan mode %q", value)
 				}
 			}
@@ -472,7 +472,7 @@ func getAllPlugins(dirs []string) []string {
 		if err == nil {
 			for _, entry := range entries {
 				name := entry.Name()
-				if !util.StringInSlice(name, plugins) {
+				if !slices.Contains(plugins, name) {
 					plugins = append(plugins, name)
 				}
 			}

--- a/libnetwork/netavark/run.go
+++ b/libnetwork/netavark/run.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/containers/common/libnetwork/internal/util"
 	"github.com/containers/common/libnetwork/types"
-	pkgutil "github.com/containers/common/pkg/util"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 )
 
 type netavarkOptions struct {
@@ -174,7 +174,7 @@ func (n *netavarkNetwork) convertNetOpts(opts types.NetworkOptions) (*netavarkOp
 			return nil, false, err
 		}
 		netavarkOptions.Networks[network] = net
-		if !pkgutil.StringInSlice(net.Driver, builtinDrivers) {
+		if !slices.Contains(builtinDrivers, net.Driver) {
 			needsPlugin = true
 		}
 	}

--- a/libnetwork/resolvconf/resolv.go
+++ b/libnetwork/resolvconf/resolv.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containers/common/pkg/util"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -111,7 +111,7 @@ func getDefaultResolvConf(params *Params) ([]byte, bool, error) {
 
 // unsetSearchDomainsIfNeeded removes the search domain when they contain a single dot as element.
 func unsetSearchDomainsIfNeeded(searches []string) []string {
-	if util.StringInSlice(".", searches) {
+	if slices.Contains(searches, ".") {
 		return nil
 	}
 	return searches
@@ -173,7 +173,7 @@ func Remove(path string, nameservers []string) error {
 	oldNameservers := getNameservers(contents)
 	newNameserver := make([]string, 0, len(oldNameservers))
 	for _, ns := range oldNameservers {
-		if !util.StringInSlice(ns, nameservers) {
+		if !slices.Contains(nameservers, ns) {
 			newNameserver = append(newNameserver, ns)
 		}
 	}

--- a/libnetwork/util/filters.go
+++ b/libnetwork/util/filters.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/pkg/filters"
 	"github.com/containers/common/pkg/util"
+	"golang.org/x/exp/slices"
 )
 
 func GenerateNetworkFilters(f map[string][]string) ([]types.FilterFunc, error) {
@@ -32,7 +33,7 @@ func createFilterFuncs(key string, filterValues []string) (types.FilterFunc, err
 	case types.Driver:
 		// matches network driver
 		return func(net types.Network) bool {
-			return util.StringInSlice(net.Driver, filterValues)
+			return slices.Contains(filterValues, net.Driver)
 		}, nil
 
 	case "id":

--- a/pkg/capabilities/capabilities_test.go
+++ b/pkg/capabilities/capabilities_test.go
@@ -69,8 +69,8 @@ func TestMergeCapabilitiesAddAll(t *testing.T) {
 	caps, err = MergeCapabilities(base, adds, drops)
 	require.Nil(t, err)
 	assert.NotEqual(t, caps, allCaps)
-	assert.False(t, stringInSlice("CAP_SETUID", caps))
-	assert.False(t, stringInSlice("CAP_CHOWN", caps))
+	assert.NotContains(t, caps, "CAP_SETUID")
+	assert.NotContains(t, caps, "CAP_CHOWN")
 }
 
 func TestMergeCapabilitiesAddAllDropAll(t *testing.T) {

--- a/pkg/cgroups/cgroups_linux.go
+++ b/pkg/cgroups/cgroups_linux.go
@@ -21,6 +21,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs2"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/maps"
 )
 
 var (
@@ -491,10 +492,7 @@ func (c *CgroupControl) AddPid(pid int) error {
 		return fs2.CreateCgroupPath(path, c.config)
 	}
 
-	names := make([]string, 0, len(handlers))
-	for n := range handlers {
-		names = append(names, n)
-	}
+	names := maps.Keys(handlers)
 
 	for _, c := range c.additionalControllers {
 		if !c.symlink {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,12 +13,12 @@ import (
 	"github.com/containers/common/internal/attributedstring"
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/pkg/capabilities"
-	"github.com/containers/common/pkg/util"
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/unshare"
 	units "github.com/docker/go-units"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -1228,7 +1228,7 @@ func ValidateImageVolumeMode(mode string) error {
 	if mode == "" {
 		return nil
 	}
-	if util.StringInSlice(mode, validImageVolumeModes) {
+	if slices.Contains(validImageVolumeModes, mode) {
 		return nil
 	}
 

--- a/pkg/configmaps/configmaps.go
+++ b/pkg/configmaps/configmaps.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/storage/pkg/lockfile"
 	"github.com/containers/storage/pkg/regexp"
 	"github.com/containers/storage/pkg/stringid"
+	"golang.org/x/exp/maps"
 )
 
 // maxConfigMapSize is the max size for configMap data - 512kB
@@ -235,11 +236,7 @@ func (s *ConfigMapManager) List() ([]ConfigMap, error) {
 	if err != nil {
 		return nil, err
 	}
-	ls := make([]ConfigMap, 0, len(configMaps))
-	for _, v := range configMaps {
-		ls = append(ls, v)
-	}
-	return ls, nil
+	return maps.Values(configMaps), nil
 }
 
 // LookupConfigMapData returns configMap metadata as well as configMap data in bytes.

--- a/pkg/configmaps/filedriver/filedriver.go
+++ b/pkg/configmaps/filedriver/filedriver.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 
 	"github.com/containers/storage/pkg/lockfile"
+	"golang.org/x/exp/maps"
 )
 
 // configMapsDataFile is the file where configMaps data/payload will be stored
@@ -56,10 +57,7 @@ func (d *Driver) List() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	allID := make([]string, 0, len(configMapData))
-	for k := range configMapData {
-		allID = append(allID, k)
-	}
+	allID := maps.Keys(configMapData)
 	sort.Strings(allID)
 	return allID, err
 }

--- a/pkg/secrets/filedriver/filedriver.go
+++ b/pkg/secrets/filedriver/filedriver.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 
 	"github.com/containers/storage/pkg/lockfile"
+	"golang.org/x/exp/maps"
 )
 
 // secretsDataFile is the file where secrets data/payload will be stored
@@ -56,10 +57,7 @@ func (d *Driver) List() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	allID := make([]string, 0, len(secretData))
-	for k := range secretData {
-		allID = append(allID, k)
-	}
+	allID := maps.Keys(secretData)
 	sort.Strings(allID)
 	return allID, err
 }

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/storage/pkg/lockfile"
 	"github.com/containers/storage/pkg/regexp"
 	"github.com/containers/storage/pkg/stringid"
+	"golang.org/x/exp/maps"
 )
 
 // maxSecretSize is the max size for secret data - 512kB
@@ -289,11 +290,7 @@ func (s *SecretsManager) List() ([]Secret, error) {
 	if err != nil {
 		return nil, err
 	}
-	ls := make([]Secret, 0, len(secrets))
-	for _, v := range secrets {
-		ls = append(ls, v)
-	}
-	return ls, nil
+	return maps.Values(secrets), nil
 }
 
 // LookupSecretData returns secret metadata as well as secret data in bytes.

--- a/pkg/ssh/connection_golang.go
+++ b/pkg/ssh/connection_golang.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/knownhosts"
+	"golang.org/x/exp/maps"
 )
 
 func golangConnectionCreate(options ConnectionCreateOptions) error {
@@ -273,10 +274,7 @@ func ValidateAndConfigure(uri *url.URL, iden string, insecureIsMachineConnection
 			dedup[fp] = s
 		}
 
-		var uniq []ssh.Signer
-		for _, s := range dedup {
-			uniq = append(uniq, s)
-		}
+		uniq := maps.Values(dedup)
 		authMethods = append(authMethods, ssh.PublicKeysCallback(func() ([]ssh.Signer, error) {
 			return uniq, nil
 		}))

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -9,16 +9,14 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 )
 
-// StringInSlice determines if a string is in a string slice, returns bool
+// StringInSlice determines if a string is in a string slice, returns bool.
+//
+// Deprecated: Use [golang.org/x/exp/slices.Contains] instead.
 func StringInSlice(s string, sl []string) bool {
-	for _, i := range sl {
-		if i == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(sl, s)
 }
 
 // StringMatchRegexSlice determines if a given string matches one of the given regexes, returns bool


### PR DESCRIPTION
This PR replaces raw loops with functions from [slices](https://pkg.go.dev/golang.org/x/exp/slices) and [maps](https://pkg.go.dev/golang.org/x/exp/maps) packages. By doing this, we are simplifying our code base, enhancing readability, and improving maintainability.

Also, deprecate unneeded function `util.StringInSlice` that can be replaced with [`slices.Contains`](https://pkg.go.dev/golang.org/x/exp/slices#Contains).

When we upgrade to Go 1.21, `golang.org/x/exp/slices` will be replaced by [`slices`](https://pkg.go.dev/slices) from std.