### PR TITLE
Fix staticcheck issues; show all lint issues in CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,7 +40,6 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: "${{ env.LINT_VERSION }}"
-        only-new-issues: true
         args: --verbose
     # Extra linters, only checking new code from a pull request.
     - name: Extra golangci-lint config. switcharoo


### PR DESCRIPTION
This PR fixes two `staticcheck` lint issues `SA1019: storageTransport.Transport.GetStoreImage is deprecated`.  Additionally, change `lint` CI step to show all issues.

Fixes failed action https://github.com/containers/common/actions/runs/7417114742/job/20183119311.