### PR TITLE
Simplify tests with testing.TempDir instead of os.MkdirTemp

### DIFF
--- a/libimage/corrupted_test.go
+++ b/libimage/corrupted_test.go
@@ -16,8 +16,7 @@ import (
 
 func TestCorruptedLayers(t *testing.T) {
 	// Regression tests for https://bugzilla.redhat.com/show_bug.cgi?id=1966872.
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 	pullOptions := &PullOptions{}
 	pullOptions.Writer = os.Stdout

--- a/libimage/filters_test.go
+++ b/libimage/filters_test.go
@@ -17,8 +17,7 @@ func TestFilterReference(t *testing.T) {
 	busyboxLatest := "quay.io/libpod/busybox:latest"
 	alpineLatest := "quay.io/libpod/alpine:latest"
 
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	pullOptions := &PullOptions{}
@@ -93,8 +92,7 @@ func TestFilterDigest(t *testing.T) {
 	busyboxLatest := "quay.io/libpod/busybox:latest"
 	alpineLatest := "quay.io/libpod/alpine:latest"
 
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	pullOptions := &PullOptions{}
@@ -136,8 +134,7 @@ func TestFilterID(t *testing.T) {
 	busyboxLatest := "quay.io/libpod/busybox:latest"
 	alpineLatest := "quay.io/libpod/alpine:latest"
 
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	pullOptions := &PullOptions{}
@@ -175,8 +172,7 @@ func TestFilterManifest(t *testing.T) {
 	busyboxLatest := "quay.io/libpod/busybox:latest"
 	alpineLatest := "quay.io/libpod/alpine:latest"
 
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	pullOptions := &PullOptions{}
@@ -229,8 +225,7 @@ func TestFilterAfterSinceBeforeUntil(t *testing.T) {
 	busyboxLatest := "quay.io/libpod/busybox:latest"
 	alpineLatest := "quay.io/libpod/alpine:latest"
 
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	pullOptions := &PullOptions{}
@@ -282,8 +277,7 @@ func TestFilterIdLabel(t *testing.T) {
 	busyboxLatest := "quay.io/libpod/busybox:latest"
 	alpineLatest := "quay.io/libpod/alpine:latest"
 
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	pullOptions := &PullOptions{}

--- a/libimage/history_test.go
+++ b/libimage/history_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestHistory(t *testing.T) {
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	name := "quay.io/libpod/alpine:3.10.2"

--- a/libimage/image_test.go
+++ b/libimage/image_test.go
@@ -22,8 +22,7 @@ func TestImageFunctions(t *testing.T) {
 	busyboxLatest := busybox + ":latest"
 	busyboxDigest := busybox + "@"
 
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	// Looking up image by invalid sha.
@@ -190,8 +189,7 @@ func TestLookupImage(t *testing.T) {
 	alpineNoTag := "quay.io/libpod/alpine"
 	alpineLatest := alpineNoTag + ":latest"
 
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	pullOptions := &PullOptions{}
@@ -245,8 +243,7 @@ func TestLookupImage(t *testing.T) {
 }
 
 func TestInspectHealthcheck(t *testing.T) {
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	imageName := "quay.io/libpod/healthcheck:config-only"
@@ -265,8 +262,7 @@ func TestInspectHealthcheck(t *testing.T) {
 }
 
 func TestTag(t *testing.T) {
-	runtime, image, cleanup := getImageAndRuntime(t)
-	defer cleanup()
+	runtime, image := getImageAndRuntime(t)
 
 	digest := "sha256:adab3844f497ab9171f070d4cae4114b5aec565ac772e2f2579405b78be67c96"
 
@@ -303,8 +299,7 @@ func TestTag(t *testing.T) {
 }
 
 func TestTagAndUntagParallel(t *testing.T) {
-	runtime, image, cleanup := getImageAndRuntime(t)
-	defer cleanup()
+	runtime, image := getImageAndRuntime(t)
 
 	tagCount := 10
 	wg := sync.WaitGroup{}
@@ -354,8 +349,7 @@ func TestTagAndUntagParallel(t *testing.T) {
 }
 
 func TestUntag(t *testing.T) {
-	runtime, image, cleanup := getImageAndRuntime(t)
-	defer cleanup()
+	runtime, image := getImageAndRuntime(t)
 
 	digest := "sha256:adab3844f497ab9171f070d4cae4114b5aec565ac772e2f2579405b78be67c96"
 
@@ -394,12 +388,12 @@ func TestUntag(t *testing.T) {
 	require.ErrorIs(t, err, errUntagDigest, "check for specific digest error")
 }
 
-func getImageAndRuntime(t *testing.T) (*Runtime, *Image, func()) {
+func getImageAndRuntime(t *testing.T) (*Runtime, *Image) {
 	// Note: this will resolve pull from the GCR registry (see
 	// testdata/registries.conf).
 	busyboxLatest := "docker.io/library/busybox:latest"
 
-	runtime, cleanup := testNewRuntime(t)
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	pullOptions := &PullOptions{}
@@ -410,5 +404,5 @@ func getImageAndRuntime(t *testing.T) (*Runtime, *Image, func()) {
 
 	image := pulledImages[0]
 
-	return runtime, image, cleanup
+	return runtime, image
 }

--- a/libimage/import_test.go
+++ b/libimage/import_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestImport(t *testing.T) {
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	importOptions := &ImportOptions{}

--- a/libimage/load_test.go
+++ b/libimage/load_test.go
@@ -22,8 +22,7 @@ func TestLoad(t *testing.T) {
 		os.Unsetenv("TMPDIR")
 	}()
 
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 	loadOptions := &LoadOptions{}
 	loadOptions.Writer = os.Stdout

--- a/libimage/manifest_list_test.go
+++ b/libimage/manifest_list_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestCreateManifestList(t *testing.T) {
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	list, err := runtime.CreateManifestList("mylist")
@@ -44,8 +43,7 @@ func TestCreateManifestList(t *testing.T) {
 // Inspect must contain both formats i.e OCIv1 and docker
 func TestInspectManifestListWithAnnotations(t *testing.T) {
 	listName := "testinspect"
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	list, err := runtime.CreateManifestList(listName)
@@ -84,8 +82,7 @@ func TestInspectManifestListWithAnnotations(t *testing.T) {
 func TestCreateAndTagManifestList(t *testing.T) {
 	tagName := "testlisttagged"
 	listName := "testlist"
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	list, err := runtime.CreateManifestList(listName)
@@ -121,8 +118,7 @@ func TestCreateAndTagManifestList(t *testing.T) {
 func TestCreateAndRemoveManifestList(t *testing.T) {
 	tagName := "manifestlisttagged"
 	listName := "manifestlist"
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	list, err := runtime.CreateManifestList(listName)

--- a/libimage/manifests/manifests_test.go
+++ b/libimage/manifests/manifests_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -50,10 +49,7 @@ func TestSaveLoad(t *testing.T) {
 		t.Skip("Test can only run as root")
 	}
 
-	dir, err := os.MkdirTemp("", "manifests")
-	assert.Nilf(t, err, "error creating temporary directory")
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	storeOptions := storage.StoreOptions{
 		GraphRoot:       filepath.Join(dir, "root"),
 		RunRoot:         filepath.Join(dir, "runroot"),
@@ -168,10 +164,7 @@ func TestReference(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	dir, err := os.MkdirTemp("", "manifests")
-	assert.Nilf(t, err, "error creating temporary directory")
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	storeOptions := storage.StoreOptions{
 		GraphRoot:       filepath.Join(dir, "root"),
 		RunRoot:         filepath.Join(dir, "runroot"),
@@ -268,10 +261,7 @@ func TestPushManifest(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	dir, err := os.MkdirTemp("", "manifests")
-	assert.Nilf(t, err, "error creating temporary directory")
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	storeOptions := storage.StoreOptions{
 		GraphRoot:       filepath.Join(dir, "root"),
 		RunRoot:         filepath.Join(dir, "runroot"),
@@ -288,11 +278,7 @@ func TestPushManifest(t *testing.T) {
 		}
 	}()
 
-	dest, err := os.MkdirTemp("", "manifests")
-	assert.Nilf(t, err, "error creating temporary directory")
-	defer os.RemoveAll(dest)
-
-	destRef, err := alltransports.ParseImageName(fmt.Sprintf("dir:%s", dest))
+	destRef, err := alltransports.ParseImageName(fmt.Sprintf("dir:%s", t.TempDir()))
 	assert.Nilf(t, err, "ParseImageName()")
 
 	ref, err := alltransports.ParseImageName(otherListImage)

--- a/libimage/pull_test.go
+++ b/libimage/pull_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestPull(t *testing.T) {
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 	pullOptions := &PullOptions{}
 	pullOptions.Writer = os.Stdout
@@ -81,8 +80,8 @@ func TestPull(t *testing.T) {
 }
 
 func TestPullPlatforms(t *testing.T) {
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
+
 	ctx := context.Background()
 	pullOptions := &PullOptions{}
 	pullOptions.Writer = os.Stdout
@@ -141,8 +140,7 @@ func TestPullPlatforms(t *testing.T) {
 }
 
 func TestPullPlatformsWithEmptyRegistriesConf(t *testing.T) {
-	runtime, cleanup := testNewRuntime(t, testNewRuntimeOptions{registriesConfPath: "/dev/null"})
-	defer cleanup()
+	runtime := testNewRuntime(t, testNewRuntimeOptions{registriesConfPath: "/dev/null"})
 	ctx := context.Background()
 	pullOptions := &PullOptions{}
 	pullOptions.Writer = os.Stdout
@@ -171,8 +169,7 @@ func TestPullPlatformsWithEmptyRegistriesConf(t *testing.T) {
 }
 
 func TestPullPolicy(t *testing.T) {
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 	pullOptions := &PullOptions{}
 
@@ -191,8 +188,7 @@ func TestPullPolicy(t *testing.T) {
 
 func TestShortNameAndIDconflict(t *testing.T) {
 	// Regression test for https://github.com/containers/podman/issues/12761
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 	pullOptions := &PullOptions{}
 	pullOptions.Writer = os.Stdout
@@ -228,8 +224,7 @@ func TestPullOCINoReference(t *testing.T) {
 	// specified reference is preserved in the image name.
 
 	busybox := "docker.io/library/busybox:latest"
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 	pullOptions := &PullOptions{}
 	pullOptions.Writer = os.Stdout

--- a/libimage/push_test.go
+++ b/libimage/push_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestPush(t *testing.T) {
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	// Prefetch alpine.
@@ -29,9 +28,7 @@ func TestPush(t *testing.T) {
 	pushOptions := &PushOptions{}
 	pushOptions.Writer = os.Stdout
 
-	workdir, err := os.MkdirTemp("", "libimagepush")
-	require.NoError(t, err)
-	defer os.RemoveAll(workdir)
+	workdir := t.TempDir()
 
 	for _, test := range []struct {
 		source      string
@@ -77,8 +74,7 @@ func TestPush(t *testing.T) {
 }
 
 func TestPushOtherPlatform(t *testing.T) {
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	// Prefetch alpine.
@@ -104,8 +100,7 @@ func TestPushOtherPlatform(t *testing.T) {
 }
 
 func TestPushWithForceCompression(t *testing.T) {
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	// Prefetch alpine.

--- a/libimage/remove_test.go
+++ b/libimage/remove_test.go
@@ -16,8 +16,7 @@ func TestRemoveImages(t *testing.T) {
 	// testdata/registries.conf).
 	busyboxLatest := "docker.io/library/busybox:latest"
 
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	pullOptions := &PullOptions{}

--- a/libimage/save_test.go
+++ b/libimage/save_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestSave(t *testing.T) {
-	runtime, cleanup := testNewRuntime(t)
-	defer cleanup()
+	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
 	// Prefetch alpine, busybox.
@@ -73,9 +72,7 @@ func TestSave(t *testing.T) {
 		_, err = runtime.Load(ctx, imageCache.Name(), loadOptions)
 		require.NoError(t, err)
 
-		tmp, err := os.MkdirTemp("", "libimagesavetest")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmp)
+		tmp := t.TempDir()
 		if !test.isDir {
 			tmp += "/archive.tar"
 		}

--- a/pkg/chown/chown_test.go
+++ b/pkg/chown/chown_test.go
@@ -14,13 +14,6 @@ func TestDangerousHostPath(t *testing.T) {
 		t.Skip("Current paths are supported only by Linux")
 	}
 
-	// Create a temp dir that is not dangerous
-	td, err := os.MkdirTemp("/tmp", "validDir")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(td)
-
 	tests := []struct {
 		Path             string
 		Expected         bool
@@ -34,7 +27,7 @@ func TestDangerousHostPath(t *testing.T) {
 			"",
 		},
 		{
-			td,
+			t.TempDir(), // Create a temp dir that is not dangerous
 			false,
 			false,
 			"",
@@ -65,11 +58,7 @@ func TestChangeHostPathOwnership(t *testing.T) {
 	}
 
 	// Create a temp dir that is not dangerous
-	td, err := os.MkdirTemp("/tmp", "validDir")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	// Get host path info
 	f, err := os.Lstat(td)

--- a/pkg/configmaps/configmaps_test.go
+++ b/pkg/configmaps/configmaps_test.go
@@ -2,7 +2,6 @@ package configmaps
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,28 +9,17 @@ import (
 
 var drivertype = "file"
 
-var opts map[string]string
-
-func setup() (*ConfigMapManager, string, error) {
-	testpath, err := os.MkdirTemp("", "cmdata")
-	if err != nil {
-		return nil, "", err
-	}
+func setup(t *testing.T) (manager *ConfigMapManager, opts map[string]string) {
+	testpath := t.TempDir()
 	manager, err := NewManager(testpath)
-	opts = map[string]string{"path": testpath}
-	return manager, testpath, err
-}
-
-func cleanup(testpath string) {
-	os.RemoveAll(testpath)
+	require.NoError(t, err)
+	return manager, map[string]string{"path": testpath}
 }
 
 func TestAddSecretAndLookupData(t *testing.T) {
-	manager, testpath, err := setup()
-	require.NoError(t, err)
-	defer cleanup(testpath)
+	manager, opts := setup(t)
 
-	_, err = manager.Store("myconfigmap", []byte("mydata"), drivertype, opts)
+	_, err := manager.Store("myconfigmap", []byte("mydata"), drivertype, opts)
 	require.NoError(t, err)
 
 	_, err = manager.lookupConfigMap("myconfigmap")
@@ -45,12 +33,10 @@ func TestAddSecretAndLookupData(t *testing.T) {
 }
 
 func TestAddConfigMapName(t *testing.T) {
-	manager, testpath, err := setup()
-	require.NoError(t, err)
-	defer cleanup(testpath)
+	manager, opts := setup(t)
 
 	// test one char configmap name
-	_, err = manager.Store("a", []byte("mydata"), drivertype, opts)
+	_, err := manager.Store("a", []byte("mydata"), drivertype, opts)
 	require.NoError(t, err)
 
 	_, err = manager.lookupConfigMap("a")
@@ -82,9 +68,7 @@ func TestAddConfigMapName(t *testing.T) {
 }
 
 func TestAddMultipleConfigMaps(t *testing.T) {
-	manager, testpath, err := setup()
-	require.NoError(t, err)
-	defer cleanup(testpath)
+	manager, opts := setup(t)
 
 	id, err := manager.Store("myconfigmap", []byte("mydata"), drivertype, opts)
 	require.NoError(t, err)
@@ -116,11 +100,9 @@ func TestAddMultipleConfigMaps(t *testing.T) {
 }
 
 func TestAddConfigMapDupName(t *testing.T) {
-	manager, testpath, err := setup()
-	require.NoError(t, err)
-	defer cleanup(testpath)
+	manager, opts := setup(t)
 
-	_, err = manager.Store("myconfigmap", []byte("mydata"), drivertype, opts)
+	_, err := manager.Store("myconfigmap", []byte("mydata"), drivertype, opts)
 	require.NoError(t, err)
 
 	_, err = manager.Store("myconfigmap", []byte("mydata"), drivertype, opts)
@@ -128,9 +110,7 @@ func TestAddConfigMapDupName(t *testing.T) {
 }
 
 func TestAddConfigMapPrefix(t *testing.T) {
-	manager, testpath, err := setup()
-	require.NoError(t, err)
-	defer cleanup(testpath)
+	manager, opts := setup(t)
 
 	// If the randomly generated configmap id is something like "abcdeiuoergnadufigh"
 	// we should still allow someone to store a configmap with the name "abcd" or "a"
@@ -142,11 +122,9 @@ func TestAddConfigMapPrefix(t *testing.T) {
 }
 
 func TestRemoveConfigMap(t *testing.T) {
-	manager, testpath, err := setup()
-	require.NoError(t, err)
-	defer cleanup(testpath)
+	manager, opts := setup(t)
 
-	_, err = manager.Store("myconfigmap", []byte("mydata"), drivertype, opts)
+	_, err := manager.Store("myconfigmap", []byte("mydata"), drivertype, opts)
 	require.NoError(t, err)
 
 	_, err = manager.lookupConfigMap("myconfigmap")
@@ -163,18 +141,14 @@ func TestRemoveConfigMap(t *testing.T) {
 }
 
 func TestRemoveConfigMapNoExist(t *testing.T) {
-	manager, testpath, err := setup()
-	require.NoError(t, err)
-	defer cleanup(testpath)
+	manager, _ := setup(t)
 
-	_, err = manager.Delete("myconfigmap")
+	_, err := manager.Delete("myconfigmap")
 	require.Error(t, err)
 }
 
 func TestLookupAllConfigMaps(t *testing.T) {
-	manager, testpath, err := setup()
-	require.NoError(t, err)
-	defer cleanup(testpath)
+	manager, opts := setup(t)
 
 	id, err := manager.Store("myconfigmap", []byte("mydata"), drivertype, opts)
 	require.NoError(t, err)
@@ -186,9 +160,7 @@ func TestLookupAllConfigMaps(t *testing.T) {
 }
 
 func TestInspectConfigMapId(t *testing.T) {
-	manager, testpath, err := setup()
-	require.NoError(t, err)
-	defer cleanup(testpath)
+	manager, opts := setup(t)
 
 	id, err := manager.Store("myconfigmap", []byte("mydata"), drivertype, opts)
 	require.NoError(t, err)
@@ -209,20 +181,16 @@ func TestInspectConfigMapId(t *testing.T) {
 }
 
 func TestInspectConfigMapBogus(t *testing.T) {
-	manager, testpath, err := setup()
-	require.NoError(t, err)
-	defer cleanup(testpath)
+	manager, _ := setup(t)
 
-	_, err = manager.Lookup("bogus")
+	_, err := manager.Lookup("bogus")
 	require.Error(t, err)
 }
 
 func TestConfigMapList(t *testing.T) {
-	manager, testpath, err := setup()
-	require.NoError(t, err)
-	defer cleanup(testpath)
+	manager, opts := setup(t)
 
-	_, err = manager.Store("myconfigmap", []byte("mydata"), drivertype, opts)
+	_, err := manager.Store("myconfigmap", []byte("mydata"), drivertype, opts)
 	require.NoError(t, err)
 	_, err = manager.Store("myconfigmap2", []byte("mydata2"), drivertype, opts)
 	require.NoError(t, err)

--- a/pkg/configmaps/filedriver/filedriver_test.go
+++ b/pkg/configmaps/filedriver/filedriver_test.go
@@ -1,24 +1,14 @@
 package filedriver
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func setup() (*Driver, error) {
-	tmppath, err := os.MkdirTemp("", "configmapsdata")
-	if err != nil {
-		return nil, err
-	}
-	return NewDriver(tmppath)
-}
-
 func TestStoreAndLookupConfigMapData(t *testing.T) {
-	tstdriver, err := setup()
+	tstdriver, err := NewDriver(t.TempDir())
 	require.NoError(t, err)
-	defer os.Remove(tstdriver.configMapsDataFilePath)
 
 	err = tstdriver.Store("unique_id", []byte("somedata"))
 	require.NoError(t, err)
@@ -29,9 +19,8 @@ func TestStoreAndLookupConfigMapData(t *testing.T) {
 }
 
 func TestStoreDupID(t *testing.T) {
-	tstdriver, err := setup()
+	tstdriver, err := NewDriver(t.TempDir())
 	require.NoError(t, err)
-	defer os.Remove(tstdriver.configMapsDataFilePath)
 
 	err = tstdriver.Store("unique_id", []byte("somedata"))
 	require.NoError(t, err)
@@ -41,18 +30,16 @@ func TestStoreDupID(t *testing.T) {
 }
 
 func TestLookupBogus(t *testing.T) {
-	tstdriver, err := setup()
+	tstdriver, err := NewDriver(t.TempDir())
 	require.NoError(t, err)
-	defer os.Remove(tstdriver.configMapsDataFilePath)
 
 	_, err = tstdriver.Lookup("bogus")
 	require.Error(t, err)
 }
 
 func TestDeleteConfigMapData(t *testing.T) {
-	tstdriver, err := setup()
+	tstdriver, err := NewDriver(t.TempDir())
 	require.NoError(t, err)
-	defer os.Remove(tstdriver.configMapsDataFilePath)
 
 	err = tstdriver.Store("unique_id", []byte("somedata"))
 	require.NoError(t, err)
@@ -64,18 +51,16 @@ func TestDeleteConfigMapData(t *testing.T) {
 }
 
 func TestDeleteConfigMapDataNotExist(t *testing.T) {
-	tstdriver, err := setup()
+	tstdriver, err := NewDriver(t.TempDir())
 	require.NoError(t, err)
-	defer os.Remove(tstdriver.configMapsDataFilePath)
 
 	err = tstdriver.Delete("bogus")
 	require.Error(t, err)
 }
 
 func TestList(t *testing.T) {
-	tstdriver, err := setup()
+	tstdriver, err := NewDriver(t.TempDir())
 	require.NoError(t, err)
-	defer os.Remove(tstdriver.configMapsDataFilePath)
 
 	err = tstdriver.Store("unique_id", []byte("somedata"))
 	require.NoError(t, err)

--- a/pkg/hooks/exec/exec_test.go
+++ b/pkg/hooks/exec/exec_test.go
@@ -147,10 +147,7 @@ func TestRunCwd(t *testing.T) {
 		Path: path,
 		Args: []string{"sh", "-c", "pwd"},
 	}
-	cwd, err := os.MkdirTemp("", "userdata")
-	if err != nil {
-		t.Fatal(err)
-	}
+	cwd := t.TempDir()
 	var stderr, stdout bytes.Buffer
 	hookErr, err := RunWithOptions(ctx, RunOptions{Hook: hook, Dir: cwd, State: []byte("{}"), Stdout: &stdout, Stderr: &stderr, PostKillTimeout: DefaultPostKillTimeout})
 	if err != nil {

--- a/pkg/secrets/filedriver/filedriver_test.go
+++ b/pkg/secrets/filedriver/filedriver_test.go
@@ -1,24 +1,14 @@
 package filedriver
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func setup() (*Driver, error) {
-	tmppath, err := os.MkdirTemp("", "secretsdata")
-	if err != nil {
-		return nil, err
-	}
-	return NewDriver(tmppath)
-}
-
 func TestStoreAndLookupSecretData(t *testing.T) {
-	tstdriver, err := setup()
+	tstdriver, err := NewDriver(t.TempDir())
 	require.NoError(t, err)
-	defer os.Remove(tstdriver.secretsDataFilePath)
 
 	err = tstdriver.Store("unique_id", []byte("somedata"))
 	require.NoError(t, err)
@@ -29,9 +19,8 @@ func TestStoreAndLookupSecretData(t *testing.T) {
 }
 
 func TestStoreDupID(t *testing.T) {
-	tstdriver, err := setup()
+	tstdriver, err := NewDriver(t.TempDir())
 	require.NoError(t, err)
-	defer os.Remove(tstdriver.secretsDataFilePath)
 
 	err = tstdriver.Store("unique_id", []byte("somedata"))
 	require.NoError(t, err)
@@ -41,18 +30,16 @@ func TestStoreDupID(t *testing.T) {
 }
 
 func TestLookupBogus(t *testing.T) {
-	tstdriver, err := setup()
+	tstdriver, err := NewDriver(t.TempDir())
 	require.NoError(t, err)
-	defer os.Remove(tstdriver.secretsDataFilePath)
 
 	_, err = tstdriver.Lookup("bogus")
 	require.Error(t, err)
 }
 
 func TestDeleteSecretData(t *testing.T) {
-	tstdriver, err := setup()
+	tstdriver, err := NewDriver(t.TempDir())
 	require.NoError(t, err)
-	defer os.Remove(tstdriver.secretsDataFilePath)
 
 	err = tstdriver.Store("unique_id", []byte("somedata"))
 	require.NoError(t, err)
@@ -64,18 +51,16 @@ func TestDeleteSecretData(t *testing.T) {
 }
 
 func TestDeleteSecretDataNotExist(t *testing.T) {
-	tstdriver, err := setup()
+	tstdriver, err := NewDriver(t.TempDir())
 	require.NoError(t, err)
-	defer os.Remove(tstdriver.secretsDataFilePath)
 
 	err = tstdriver.Delete("bogus")
 	require.Error(t, err)
 }
 
 func TestList(t *testing.T) {
-	tstdriver, err := setup()
+	tstdriver, err := NewDriver(t.TempDir())
 	require.NoError(t, err)
-	defer os.Remove(tstdriver.secretsDataFilePath)
 
 	err = tstdriver.Store("unique_id", []byte("somedata"))
 	require.NoError(t, err)

--- a/pkg/sysinfo/sysinfo_linux_test.go
+++ b/pkg/sysinfo/sysinfo_linux_test.go
@@ -12,12 +12,10 @@ import (
 )
 
 func TestReadProcBool(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "test-sysinfo-proc")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	procFile := filepath.Join(tmpDir, "read-proc-bool")
-	err = os.WriteFile(procFile, []byte("1"), 0o644)
+	err := os.WriteFile(procFile, []byte("1"), 0o644)
 	require.NoError(t, err)
 
 	if !readProcBool(procFile) {
@@ -37,15 +35,13 @@ func TestReadProcBool(t *testing.T) {
 }
 
 func TestCgroupEnabled(t *testing.T) {
-	cgroupDir, err := os.MkdirTemp("", "cgroup-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(cgroupDir)
+	cgroupDir := t.TempDir()
 
 	if cgroupEnabled(cgroupDir, "test") {
 		t.Fatal("cgroupEnabled should be false")
 	}
 
-	err = os.WriteFile(path.Join(cgroupDir, "test"), []byte{}, 0o644)
+	err := os.WriteFile(path.Join(cgroupDir, "test"), []byte{}, 0o644)
 	require.NoError(t, err)
 
 	if !cgroupEnabled(cgroupDir, "test") {


### PR DESCRIPTION
This PR refactors tests by removing code lines. Changes:

- Use [`T.TempDir`](https://pkg.go.dev/testing#T.TempDir) instead of [`os.MkdirTemp`](https://pkg.go.dev/os#MkdirTemp). `T.TempDir` automatically removes the temporary directory.
- Remove `defer cleanup()` that previously calls `os.RemoveAll(tempDir)`.
- Move global variable `var opts map[string]string` to `setup()`.
- Use [`T.Cleanup`](https://pkg.go.dev/testing#T.Cleanup) for executing `runtime.Shutdown(true)`.
