### PR TITLE
chore: replace 'interface{}' with 'any' for consistency

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,6 +76,10 @@ linters-settings:
     check-type-assertions: true
   gocyclo:
     min-complexity: 35
+  gofmt:
+    rewrite-rules:
+      - pattern: 'interface{}'
+        replacement: 'any'
 
 issues:
     # Excluding configuration per-path, per-linter, per-text and per-source

--- a/internal/attributedstring/slice.go
+++ b/internal/attributedstring/slice.go
@@ -42,8 +42,8 @@ func (a *Slice) Set(values []string) {
 }
 
 // UnmarshalTOML is the custom unmarshal method for Slice.
-func (a *Slice) UnmarshalTOML(data interface{}) error {
-	iFaceSlice, ok := data.([]interface{})
+func (a *Slice) UnmarshalTOML(data any) error {
+	iFaceSlice, ok := data.([]any)
 	if !ok {
 		return fmt.Errorf("unable to cast to interface array: %v", data)
 	}
@@ -53,7 +53,7 @@ func (a *Slice) UnmarshalTOML(data interface{}) error {
 		switch val := x.(type) {
 		case string: // Strings are directly appended to the slice.
 			loadedStrings = append(loadedStrings, val)
-		case map[string]interface{}: // The attribute struct is represented as a map.
+		case map[string]any: // The attribute struct is represented as a map.
 			for k, v := range val { // Iterate over all _supported_ keys.
 				switch k {
 				case "append":
@@ -81,7 +81,7 @@ func (a *Slice) UnmarshalTOML(data interface{}) error {
 
 // MarshalTOML is the custom marshal method for Slice.
 func (a *Slice) MarshalTOML() ([]byte, error) {
-	iFaceSlice := make([]interface{}, 0, len(a.Values))
+	iFaceSlice := make([]any, 0, len(a.Values))
 
 	for _, x := range a.Values {
 		iFaceSlice = append(iFaceSlice, x)

--- a/libnetwork/cni/cni_conversion.go
+++ b/libnetwork/cni/cni_conversion.go
@@ -31,13 +31,13 @@ func createNetworkFromCNIConfigList(conf *libcni.NetworkConfigList, confPath str
 		IPAMOptions: map[string]string{},
 	}
 
-	cniJSON := make(map[string]interface{})
+	cniJSON := make(map[string]any)
 	err := json.Unmarshal(conf.Bytes, &cniJSON)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal network config %s: %w", conf.Name, err)
 	}
 	if args, ok := cniJSON["args"]; ok {
-		if key, ok := args.(map[string]interface{}); ok {
+		if key, ok := args.(map[string]any); ok {
 			// read network labels and options from the conf file
 			network.Labels = getNetworkArgsFromConfList(key, podmanLabelKey)
 			network.Options = getNetworkArgsFromConfList(key, podmanOptionsKey)
@@ -214,9 +214,9 @@ func convertIPAMConfToNetwork(network *types.Network, ipam *ipamConfig, confPath
 }
 
 // getNetworkArgsFromConfList returns the map of args in a conflist, argType should be labels or options
-func getNetworkArgsFromConfList(args map[string]interface{}, argType string) map[string]string {
+func getNetworkArgsFromConfList(args map[string]any, argType string) map[string]string {
 	if args, ok := args[argType]; ok {
-		if labels, ok := args.(map[string]interface{}); ok {
+		if labels, ok := args.(map[string]any); ok {
 			result := make(map[string]string, len(labels))
 			for k, v := range labels {
 				if v, ok := v.(string); ok {
@@ -298,7 +298,7 @@ func (n *cniNetwork) createCNIConfigListFromNetwork(network *types.Network, writ
 	// the dnsname plugin also needs to be updated for 1.0.0
 	// TODO change to 1.0.0 when most distros support it
 	ncList := newNcList(network.Name, "0.4.0", network.Labels, network.Options)
-	var plugins []interface{}
+	var plugins []any
 
 	switch network.Driver {
 	case types.BridgeNetworkDriver:

--- a/libnetwork/cni/cni_types.go
+++ b/libnetwork/cni/cni_types.go
@@ -115,7 +115,7 @@ type dnsNameConfig struct {
 }
 
 // ncList describes a generic map
-type ncList map[string]interface{}
+type ncList map[string]any
 
 // newNcList creates a generic map of values with string
 // keys and adds in version and network name

--- a/libnetwork/cni/run.go
+++ b/libnetwork/cni/run.go
@@ -69,7 +69,7 @@ func (n *cniNetwork) Setup(namespacePath string, options types.SetupOptions) (ma
 			// If we have more than one static ip we need parse the ips via runtime config,
 			// make sure to add the ips capability to the first plugin otherwise it doesn't get the ips
 			if len(netOpts.StaticIPs) > 0 && !network.cniNet.Plugins[0].Network.Capabilities["ips"] {
-				caps := map[string]interface{}{
+				caps := map[string]any{
 					"capabilities": map[string]bool{"ips": true},
 				}
 				network.cniNet.Plugins[0], retErr = libcni.InjectConf(network.cniNet.Plugins[0], caps)
@@ -174,7 +174,7 @@ func getRuntimeConfig(netns, conName, conID, networkName string, ports []cniPort
 			// Only K8S_POD_NAME is used by dnsname to get the container name.
 			{"K8S_POD_NAME", conName},
 		},
-		CapabilityArgs: map[string]interface{}{},
+		CapabilityArgs: map[string]any{},
 	}
 
 	// Propagate environment CNI_ARGS

--- a/libnetwork/netavark/exec.go
+++ b/libnetwork/netavark/exec.go
@@ -76,7 +76,7 @@ func getRustLogEnv() string {
 // used to marshal the netavark output into it. This can be nil.
 // All errors return by this function should be of the type netavarkError
 // to provide a helpful error message.
-func (n *netavarkNetwork) execNetavark(args []string, needPlugin bool, stdin, result interface{}) error {
+func (n *netavarkNetwork) execNetavark(args []string, needPlugin bool, stdin, result any) error {
 	// set the netavark log level to the same as the podman
 	env := append(os.Environ(), getRustLogEnv())
 	// Netavark need access to iptables in $PATH. As it turns out debian doesn't put
@@ -101,11 +101,11 @@ func (n *netavarkNetwork) execNetavark(args []string, needPlugin bool, stdin, re
 	return n.execBinary(n.netavarkBinary, append(n.getCommonNetavarkOptions(needPlugin), args...), stdin, result, env)
 }
 
-func (n *netavarkNetwork) execPlugin(path string, args []string, stdin, result interface{}) error {
+func (n *netavarkNetwork) execPlugin(path string, args []string, stdin, result any) error {
 	return n.execBinary(path, args, stdin, result, nil)
 }
 
-func (n *netavarkNetwork) execBinary(path string, args []string, stdin, result interface{}, env []string) error {
+func (n *netavarkNetwork) execBinary(path string, args []string, stdin, result any, env []string) error {
 	stdinR, stdinW, err := os.Pipe()
 	if err != nil {
 		return newNetavarkError("failed to create stdin pipe", err)

--- a/libnetwork/netavark/ipam.go
+++ b/libnetwork/netavark/ipam.go
@@ -47,7 +47,7 @@ func (e *ipamError) Error() string {
 	return msg
 }
 
-func newIPAMError(cause error, msg string, args ...interface{}) *ipamError {
+func newIPAMError(cause error, msg string, args ...any) *ipamError {
 	return &ipamError{
 		msg:   fmt.Sprintf(msg, args...),
 		cause: cause,

--- a/libnetwork/netavark/netavark_suite_test.go
+++ b/libnetwork/netavark/netavark_suite_test.go
@@ -67,7 +67,7 @@ type equalSubnetMatcher struct {
 	expected *net.IPNet
 }
 
-func (m *equalSubnetMatcher) Match(actual interface{}) (bool, error) {
+func (m *equalSubnetMatcher) Match(actual any) (bool, error) {
 	util.NormalizeIP(&m.expected.IP)
 
 	subnet, ok := actual.(*net.IPNet)
@@ -79,10 +79,10 @@ func (m *equalSubnetMatcher) Match(actual interface{}) (bool, error) {
 	return reflect.DeepEqual(subnet, m.expected), nil
 }
 
-func (m *equalSubnetMatcher) FailureMessage(actual interface{}) string {
+func (m *equalSubnetMatcher) FailureMessage(actual any) string {
 	return fmt.Sprintf("Expected subnet %#v to equal subnet %#v", actual, m.expected)
 }
 
-func (m *equalSubnetMatcher) NegatedFailureMessage(actual interface{}) string {
+func (m *equalSubnetMatcher) NegatedFailureMessage(actual any) string {
 	return fmt.Sprintf("Expected subnet %#v not to equal subnet %#v", actual, m.expected)
 }

--- a/libnetwork/slirp4netns/slirp4netns.go
+++ b/libnetwork/slirp4netns/slirp4netns.go
@@ -705,7 +705,7 @@ func openSlirp4netnsPort(apiSocket, proto, hostip string, hostport, guestport ui
 	}
 	// if there is no 'error' key in the received JSON data, then the operation was
 	// successful.
-	var y map[string]interface{}
+	var y map[string]any
 	if err := json.Unmarshal(buf[0:readLength], &y); err != nil {
 		return fmt.Errorf("parsing error status from slirp4netns: %w", err)
 	}

--- a/pkg/apparmor/internal/supported/supportedfakes/fake_verifier_impl.go
+++ b/pkg/apparmor/internal/supported/supportedfakes/fake_verifier_impl.go
@@ -53,7 +53,7 @@ type FakeVerifierImpl struct {
 	unshareIsRootlessReturnsOnCall map[int]struct {
 		result1 bool
 	}
-	invocations      map[string][][]interface{}
+	invocations      map[string][][]any
 	invocationsMutex sync.RWMutex
 }
 
@@ -63,7 +63,7 @@ func (fake *FakeVerifierImpl) ExecLookPath(arg1 string) (string, error) {
 	fake.execLookPathArgsForCall = append(fake.execLookPathArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	fake.recordInvocation("ExecLookPath", []interface{}{arg1})
+	fake.recordInvocation("ExecLookPath", []any{arg1})
 	fake.execLookPathMutex.Unlock()
 	if fake.ExecLookPathStub != nil {
 		return fake.ExecLookPathStub(arg1)
@@ -126,7 +126,7 @@ func (fake *FakeVerifierImpl) OsStat(arg1 string) (os.FileInfo, error) {
 	fake.osStatArgsForCall = append(fake.osStatArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	fake.recordInvocation("OsStat", []interface{}{arg1})
+	fake.recordInvocation("OsStat", []any{arg1})
 	fake.osStatMutex.Unlock()
 	if fake.OsStatStub != nil {
 		return fake.OsStatStub(arg1)
@@ -188,7 +188,7 @@ func (fake *FakeVerifierImpl) RuncIsEnabled() bool {
 	ret, specificReturn := fake.runcIsEnabledReturnsOnCall[len(fake.runcIsEnabledArgsForCall)]
 	fake.runcIsEnabledArgsForCall = append(fake.runcIsEnabledArgsForCall, struct {
 	}{})
-	fake.recordInvocation("RuncIsEnabled", []interface{}{})
+	fake.recordInvocation("RuncIsEnabled", []any{})
 	fake.runcIsEnabledMutex.Unlock()
 	if fake.RuncIsEnabledStub != nil {
 		return fake.RuncIsEnabledStub()
@@ -240,7 +240,7 @@ func (fake *FakeVerifierImpl) UnshareIsRootless() bool {
 	ret, specificReturn := fake.unshareIsRootlessReturnsOnCall[len(fake.unshareIsRootlessArgsForCall)]
 	fake.unshareIsRootlessArgsForCall = append(fake.unshareIsRootlessArgsForCall, struct {
 	}{})
-	fake.recordInvocation("UnshareIsRootless", []interface{}{})
+	fake.recordInvocation("UnshareIsRootless", []any{})
 	fake.unshareIsRootlessMutex.Unlock()
 	if fake.UnshareIsRootlessStub != nil {
 		return fake.UnshareIsRootlessStub()
@@ -287,7 +287,7 @@ func (fake *FakeVerifierImpl) UnshareIsRootlessReturnsOnCall(i int, result1 bool
 	}{result1}
 }
 
-func (fake *FakeVerifierImpl) Invocations() map[string][][]interface{} {
+func (fake *FakeVerifierImpl) Invocations() map[string][][]any {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.execLookPathMutex.RLock()
@@ -298,21 +298,21 @@ func (fake *FakeVerifierImpl) Invocations() map[string][][]interface{} {
 	defer fake.runcIsEnabledMutex.RUnlock()
 	fake.unshareIsRootlessMutex.RLock()
 	defer fake.unshareIsRootlessMutex.RUnlock()
-	copiedInvocations := map[string][][]interface{}{}
+	copiedInvocations := map[string][][]any{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *FakeVerifierImpl) recordInvocation(key string, args []interface{}) {
+func (fake *FakeVerifierImpl) recordInvocation(key string, args []any) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]interface{}{}
+		fake.invocations = map[string][][]any{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]interface{}{}
+		fake.invocations[key] = [][]any{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/pkg/formats/formats.go
+++ b/pkg/formats/formats.go
@@ -30,31 +30,31 @@ type Writer interface {
 
 // JSONStructArray for JSON output
 type JSONStructArray struct {
-	Output []interface{}
+	Output []any
 }
 
 // StdoutTemplateArray for Go template output
 type StdoutTemplateArray struct {
-	Output   []interface{}
+	Output   []any
 	Template string
 	Fields   map[string]string
 }
 
 // JSONStruct for JSON output
 type JSONStruct struct {
-	Output interface{}
+	Output any
 }
 
 // StdoutTemplate for Go template output
 type StdoutTemplate struct {
-	Output   interface{}
+	Output   any
 	Template string
 	Fields   map[string]string
 }
 
 // YAMLStruct for YAML output
 type YAMLStruct struct {
-	Output interface{}
+	Output any
 }
 
 func setJSONFormatEncoder(isTerminal bool, w io.Writer) *json.Encoder {

--- a/pkg/formats/templates.go
+++ b/pkg/formats/templates.go
@@ -10,7 +10,7 @@ import (
 // basicFunctions are the set of initial
 // functions provided to every template.
 var basicFunctions = template.FuncMap{
-	"json": func(v interface{}) string {
+	"json": func(v any) string {
 		buf := &bytes.Buffer{}
 		enc := json.NewEncoder(buf)
 		enc.SetEscapeHTML(false)

--- a/pkg/report/formatter.go
+++ b/pkg/report/formatter.go
@@ -137,7 +137,7 @@ func (f *Formatter) Init(w io.Writer, minwidth, tabwidth, padding int, padchar b
 
 // Execute applies a parsed template to the specified data object,
 // and writes the output to Formatter.Writer.
-func (f *Formatter) Execute(data interface{}) error {
+func (f *Formatter) Execute(data any) error {
 	return f.template.Execute(f.writer, data)
 }
 

--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -36,7 +36,7 @@ var escapedReplacer = strings.NewReplacer(
 
 var DefaultFuncs = FuncMap{
 	"join": strings.Join,
-	"json": func(v interface{}) string {
+	"json": func(v any) string {
 		buf := new(bytes.Buffer)
 		enc := json.NewEncoder(buf)
 		enc.SetEscapeHTML(false)
@@ -93,7 +93,7 @@ func truncateWithLength(source string, length int) string {
 //	1) unchanged --format includes headers
 //	2) --format '{{.ID}"        # no headers
 //	3) --format 'table {{.ID}}' # includes headers
-func Headers(object interface{}, overrides map[string]string) []map[string]string {
+func Headers(object any, overrides map[string]string) []map[string]string {
 	value := reflect.ValueOf(object)
 	if value.Kind() == reflect.Ptr {
 		value = value.Elem()

--- a/pkg/ssh/types.go
+++ b/pkg/ssh/types.go
@@ -70,11 +70,11 @@ type ConnectionScpReport struct {
 // Info is the overall struct that describes the host system
 // running libpod/podman
 type Info struct {
-	Host       *HostInfo              `json:"host"`
-	Store      *StoreInfo             `json:"store"`
-	Registries map[string]interface{} `json:"registries"`
-	Plugins    Plugins                `json:"plugins"`
-	Version    Version                `json:"version"`
+	Host       *HostInfo      `json:"host"`
+	Store      *StoreInfo     `json:"store"`
+	Registries map[string]any `json:"registries"`
+	Plugins    Plugins        `json:"plugins"`
+	Version    Version        `json:"version"`
 }
 
 // Version is an output struct for API
@@ -121,8 +121,8 @@ type HostInfo struct {
 	OCIRuntime        *OCIRuntimeInfo  `json:"ociRuntime"`
 	OS                string           `json:"os"`
 	// RemoteSocket returns the UNIX domain socket the Podman service is listening on
-	RemoteSocket *RemoteSocket          `json:"remoteSocket,omitempty"`
-	RuntimeInfo  map[string]interface{} `json:"runtimeInfo,omitempty"`
+	RemoteSocket *RemoteSocket  `json:"remoteSocket,omitempty"`
+	RuntimeInfo  map[string]any `json:"runtimeInfo,omitempty"`
 	// ServiceIsRemote is true when the podman/libpod service is remote to the client
 	ServiceIsRemote bool         `json:"serviceIsRemote"`
 	Security        SecurityInfo `json:"security"`
@@ -179,11 +179,11 @@ type OCIRuntimeInfo struct {
 // StoreInfo describes the container storage and its
 // attributes
 type StoreInfo struct {
-	ConfigFile      string                 `json:"configFile"`
-	ContainerStore  ContainerStore         `json:"containerStore"`
-	GraphDriverName string                 `json:"graphDriverName"`
-	GraphOptions    map[string]interface{} `json:"graphOptions"`
-	GraphRoot       string                 `json:"graphRoot"`
+	ConfigFile      string         `json:"configFile"`
+	ContainerStore  ContainerStore `json:"containerStore"`
+	GraphDriverName string         `json:"graphDriverName"`
+	GraphOptions    map[string]any `json:"graphOptions"`
+	GraphRoot       string         `json:"graphRoot"`
 	// GraphRootAllocated is how much space the graphroot has in bytes
 	GraphRootAllocated uint64 `json:"graphRootAllocated"`
 	// GraphRootUsed is how much of graphroot is used in bytes

--- a/pkg/systemd/systemd_linux.go
+++ b/pkg/systemd/systemd_linux.go
@@ -143,7 +143,7 @@ func RunUnderSystemdScope(pid int, slice string, unitName string) error {
 	return nil
 }
 
-func newProp(name string, units interface{}) systemdDbus.Property {
+func newProp(name string, units any) systemdDbus.Property {
 	return systemdDbus.Property{
 		Name:  name,
 		Value: dbus.MakeVariant(units),


### PR DESCRIPTION
The PR replaces `interface{}` with the alias `any` for consistency (`interface{}` - 43 occurrences, `any` - 63). It's done by running `gofmt -w -r "interface{} -> any" -l .`. And enables `gofmt`'s rewrite rule to ensure `interface{}` won't be committed.