### PR TITLE
Refactor map init with short declaration syntax

### DIFF
--- a/internal/attributedstring/slice.go
+++ b/internal/attributedstring/slice.go
@@ -88,9 +88,8 @@ func (a *Slice) MarshalTOML() ([]byte, error) {
 	}
 
 	if a.Attributes.Append != nil {
-		Attributes := make(map[string]any)
-		Attributes["append"] = *a.Attributes.Append
-		iFaceSlice = append(iFaceSlice, Attributes)
+		attributes := map[string]any{"append": *a.Attributes.Append}
+		iFaceSlice = append(iFaceSlice, attributes)
 	}
 
 	buf := new(bytes.Buffer)

--- a/libimage/manifest_list_test.go
+++ b/libimage/manifest_list_test.go
@@ -66,8 +66,7 @@ func TestInspectManifestListWithAnnotations(t *testing.T) {
 	require.NoError(t, err)
 
 	annotateOptions := ManifestListAnnotateOptions{}
-	annotations := make(map[string]string)
-	annotations["hello"] = "world"
+	annotations := map[string]string{"hello": "world"}
 	annotateOptions.Annotations = annotations
 
 	err = list.AnnotateInstance(digest, &annotateOptions)

--- a/libnetwork/cni/cni_types.go
+++ b/libnetwork/cni/cni_types.go
@@ -138,8 +138,6 @@ func newNcList(name, version string, labels, options map[string]string) ncList {
 
 // newHostLocalBridge creates a new LocalBridge for host-local
 func newHostLocalBridge(name string, isGateWay, ipMasq bool, mtu, vlan int, ipamConf *ipamConfig) *hostLocalBridge {
-	caps := make(map[string]bool)
-	caps["ips"] = true
 	bridge := hostLocalBridge{
 		PluginType:  "bridge",
 		BrName:      name,
@@ -153,7 +151,7 @@ func newHostLocalBridge(name string, isGateWay, ipMasq bool, mtu, vlan int, ipam
 		bridge.IPAM = *ipamConf
 		// if we use host-local set the ips cap to ensure we can set static ips via runtime config
 		if ipamConf.PluginType == types.HostLocalIPAMDriver {
-			bridge.Capabilities = caps
+			bridge.Capabilities = map[string]bool{"ips": true}
 		}
 	}
 	return &bridge
@@ -215,13 +213,10 @@ func newIPAMDefaultRoute(isIPv6 bool) (ipamRoute, error) {
 // newPortMapPlugin creates a predefined, default portmapping
 // configuration
 func newPortMapPlugin() portMapConfig {
-	caps := make(map[string]bool)
-	caps["portMappings"] = true
-	p := portMapConfig{
+	return portMapConfig{
 		PluginType:   "portmap",
-		Capabilities: caps,
+		Capabilities: map[string]bool{"portMappings": true},
 	}
-	return p
 }
 
 // newFirewallPlugin creates a generic firewall plugin
@@ -245,12 +240,10 @@ func newTuningPlugin() tuningConfig {
 // newDNSNamePlugin creates the dnsname config with a given
 // domainname
 func newDNSNamePlugin(domainName string) dnsNameConfig {
-	caps := make(map[string]bool, 1)
-	caps["aliases"] = true
 	return dnsNameConfig{
 		PluginType:   "dnsname",
 		DomainName:   domainName,
-		Capabilities: caps,
+		Capabilities: map[string]bool{"aliases": true},
 	}
 }
 

--- a/libnetwork/cni/run.go
+++ b/libnetwork/cni/run.go
@@ -69,8 +69,9 @@ func (n *cniNetwork) Setup(namespacePath string, options types.SetupOptions) (ma
 			// If we have more than one static ip we need parse the ips via runtime config,
 			// make sure to add the ips capability to the first plugin otherwise it doesn't get the ips
 			if len(netOpts.StaticIPs) > 0 && !network.cniNet.Plugins[0].Network.Capabilities["ips"] {
-				caps := make(map[string]interface{})
-				caps["capabilities"] = map[string]bool{"ips": true}
+				caps := map[string]interface{}{
+					"capabilities": map[string]bool{"ips": true},
+				}
 				network.cniNet.Plugins[0], retErr = libcni.InjectConf(network.cniNet.Plugins[0], caps)
 				if retErr != nil {
 					return retErr

--- a/pkg/cgroups/cgroups_linux.go
+++ b/pkg/cgroups/cgroups_linux.go
@@ -73,12 +73,13 @@ const (
 var handlers map[string]controllerHandler
 
 func init() {
-	handlers = make(map[string]controllerHandler)
-	handlers[CPU] = getCPUHandler()
-	handlers[CPUset] = getCpusetHandler()
-	handlers[Memory] = getMemoryHandler()
-	handlers[Pids] = getPidsHandler()
-	handlers[Blkio] = getBlkioHandler()
+	handlers = map[string]controllerHandler{
+		CPU:    getCPUHandler(),
+		CPUset: getCpusetHandler(),
+		Memory: getMemoryHandler(),
+		Pids:   getPidsHandler(),
+		Blkio:  getBlkioHandler(),
+	}
 }
 
 // getAvailableControllers get the available controllers

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -295,9 +295,8 @@ func defaultMachineConfig() MachineConfig {
 
 // defaultFarmConfig returns the default farms configuration.
 func defaultFarmConfig() FarmConfig {
-	emptyList := make(map[string][]string)
 	return FarmConfig{
-		List: emptyList,
+		List: map[string][]string{},
 	}
 }
 

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -31,17 +31,13 @@ func TestAddSecretAndLookupData(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(testpath)
 
-	metaData := make(map[string]string)
-	metaData["immutable"] = "true"
-
-	labels := make(map[string]string)
-	labels["foo"] = "bar"
-	labels["another"] = "label"
-
 	storeOpts := StoreOptions{
 		DriverOpts: opts,
-		Metadata:   metaData,
-		Labels:     labels,
+		Metadata:   map[string]string{"immutable": "true"},
+		Labels: map[string]string{
+			"foo":     "bar",
+			"another": "label",
+		},
 	}
 
 	id1, err := manager.Store("mysecret", []byte("mydata"), drivertype, storeOpts)


### PR DESCRIPTION
This PR refactors initialization for simple maps by using short declaration syntax. The syntax is more readable and shorter for simple maps.