### PR TITLE
linters: enable contextcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,7 +33,6 @@ linters:
     - godox
     - lll
     - nestif
-    - contextcheck
     - cyclop
     - depguard
     - errchkjson
@@ -84,3 +83,8 @@ issues:
     - path: _test\.go
       linters:
         - dupl
+    # Exclude "should pass the context parameter" for libimage.LookupImage because of backward compatibility.
+    - path: "libimage"
+      text: "LookupImage"
+      linters:
+        - contextcheck

--- a/libimage/corrupted_test.go
+++ b/libimage/corrupted_test.go
@@ -69,7 +69,7 @@ func TestCorruptedLayers(t *testing.T) {
 	_, err = image.Inspect(ctx, nil)
 	require.Error(t, err, "inspecting corrupted image should fail")
 
-	err = image.isCorrupted(imageName)
+	err = image.isCorrupted(ctx, imageName)
 	require.Error(t, err, "image is corrupted")
 
 	exists, err = runtime.Exists(imageName)

--- a/libimage/disk_usage.go
+++ b/libimage/disk_usage.go
@@ -36,7 +36,7 @@ func (r *Runtime) DiskUsage(ctx context.Context) ([]ImageDiskUsage, int64, error
 		return nil, -1, err
 	}
 
-	layerTree, err := r.layerTree(images)
+	layerTree, err := r.layerTree(ctx, images)
 	if err != nil {
 		return nil, -1, err
 	}
@@ -79,7 +79,7 @@ func (r *Runtime) DiskUsage(ctx context.Context) ([]ImageDiskUsage, int64, error
 
 // diskUsageForImage returns the disk-usage baseistics for the specified image.
 func diskUsageForImage(ctx context.Context, image *Image, tree *layerTree) ([]ImageDiskUsage, error) {
-	if err := image.isCorrupted(""); err != nil {
+	if err := image.isCorrupted(ctx, ""); err != nil {
 		return nil, err
 	}
 

--- a/libimage/history.go
+++ b/libimage/history.go
@@ -25,7 +25,7 @@ func (i *Image) History(ctx context.Context) ([]ImageHistory, error) {
 		return nil, err
 	}
 
-	layerTree, err := i.runtime.layerTree(nil)
+	layerTree, err := i.runtime.layerTree(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/libimage/image.go
+++ b/libimage/image.go
@@ -84,7 +84,7 @@ func (i *Image) reload() error {
 }
 
 // isCorrupted returns an error if the image may be corrupted.
-func (i *Image) isCorrupted(name string) error {
+func (i *Image) isCorrupted(ctx context.Context, name string) error {
 	// If it's a manifest list, we're good for now.
 	if _, err := i.getManifestList(); err == nil {
 		return nil
@@ -95,7 +95,7 @@ func (i *Image) isCorrupted(name string) error {
 		return err
 	}
 
-	img, err := ref.NewImage(context.Background(), nil)
+	img, err := ref.NewImage(ctx, nil)
 	if err != nil {
 		if name == "" {
 			name = i.ID()[:12]
@@ -257,7 +257,7 @@ func (i *Image) TopLayer() string {
 
 // Parent returns the parent image or nil if there is none
 func (i *Image) Parent(ctx context.Context) (*Image, error) {
-	tree, err := i.runtime.layerTree(nil)
+	tree, err := i.runtime.layerTree(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +291,7 @@ func (i *Image) Children(ctx context.Context) ([]*Image, error) {
 // created for this invocation only.
 func (i *Image) getChildren(ctx context.Context, all bool, tree *layerTree) ([]*Image, error) {
 	if tree == nil {
-		t, err := i.runtime.layerTree(nil)
+		t, err := i.runtime.layerTree(ctx, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -1030,7 +1030,7 @@ func getImageID(ctx context.Context, src types.ImageReference, sys *types.System
 //   - 2) a bool indicating whether architecture, os or variant were set (some callers need that to decide whether they need to throw an error)
 //   - 3) a fatal error that occurred prior to check for matches (e.g., storage errors etc.)
 func (i *Image) matchesPlatform(ctx context.Context, os, arch, variant string) (error, bool, error) {
-	if err := i.isCorrupted(""); err != nil {
+	if err := i.isCorrupted(ctx, ""); err != nil {
 		return err, false, nil
 	}
 	inspectInfo, err := i.inspectInfo(ctx)

--- a/libimage/image_tree.go
+++ b/libimage/image_tree.go
@@ -3,6 +3,7 @@
 package libimage
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -37,7 +38,7 @@ func (i *Image) Tree(traverseChildren bool) (string, error) {
 		fmt.Fprintf(sb, "No Image Layers")
 	}
 
-	layerTree, err := i.runtime.layerTree(nil)
+	layerTree, err := i.runtime.layerTree(context.Background(), nil)
 	if err != nil {
 		return "", err
 	}

--- a/libimage/layer_tree.go
+++ b/libimage/layer_tree.go
@@ -91,14 +91,14 @@ func (l *layerNode) repoTags() ([]string, error) {
 
 // layerTree extracts a layerTree from the layers in the local storage and
 // relates them to the specified images.
-func (r *Runtime) layerTree(images []*Image) (*layerTree, error) {
+func (r *Runtime) layerTree(ctx context.Context, images []*Image) (*layerTree, error) {
 	layers, err := r.store.Layers()
 	if err != nil {
 		return nil, err
 	}
 
 	if images == nil {
-		images, err = r.ListImages(context.Background(), nil, nil)
+		images, err = r.ListImages(ctx, nil, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -510,7 +510,7 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 
 	// If the local image is corrupted, we need to repull it.
 	if localImage != nil {
-		if err := localImage.isCorrupted(imageName); err != nil {
+		if err := localImage.isCorrupted(ctx, imageName); err != nil {
 			logrus.Error(err)
 			localImage = nil
 		}

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -171,7 +171,7 @@ func (r *Runtime) Exists(name string) (bool, error) {
 	if image == nil {
 		return false, nil
 	}
-	if err := image.isCorrupted(name); err != nil {
+	if err := image.isCorrupted(context.Background(), name); err != nil {
 		logrus.Error(err)
 		return false, nil
 	}
@@ -608,7 +608,7 @@ func (r *Runtime) ListImages(ctx context.Context, names []string, options *ListI
 	// as the layer tree will computed once for all instead of once for
 	// each individual image (see containers/podman/issues/17828).
 
-	tree, err := r.layerTree(images)
+	tree, err := r.layerTree(ctx, images)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The PR enables [`contextcheck` ](https://github.com/kkHAIKE/contextcheck)linter and fixes up its issues in `libimage`.