### PR TITLE
Fix image filters parsing

### DIFF
--- a/libimage/filters.go
+++ b/libimage/filters.go
@@ -87,6 +87,7 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 		return tree, nil
 	}
 
+	var wantedReferenceMatches, unwantedReferenceMatches []string
 	filters := map[string][]filterFunc{}
 	duplicate := map[string]string{}
 	for _, f := range options.Filters {
@@ -178,7 +179,12 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 			filter = filterManifest(ctx, manifest)
 
 		case "reference":
-			filter = filterReferences(r, value)
+			if negate {
+				unwantedReferenceMatches = append(unwantedReferenceMatches, value)
+			} else {
+				wantedReferenceMatches = append(wantedReferenceMatches, value)
+			}
+			continue
 
 		case "until":
 			until, err := r.until(value)
@@ -195,6 +201,11 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 		}
 		filters[key] = append(filters[key], filter)
 	}
+
+	// reference filters is a special case as it does an OR for positive matches
+	// and an AND logic for negative matches
+	filter := filterReferences(r, wantedReferenceMatches, unwantedReferenceMatches)
+	filters["reference"] = append(filters["reference"], filter)
 
 	return filters, nil
 }
@@ -267,55 +278,97 @@ func filterManifest(ctx context.Context, value bool) filterFunc {
 	}
 }
 
-// filterReferences creates a reference filter for matching the specified value.
-func filterReferences(r *Runtime, value string) filterFunc {
-	lookedUp, _, _ := r.LookupImage(value, nil)
+// filterReferences creates a reference filter for matching the specified wantedReferenceMatches value (OR logic)
+// and for matching the unwantedReferenceMatches values (AND logic)
+func filterReferences(r *Runtime, wantedReferenceMatches, unwantedReferenceMatches []string) filterFunc {
 	return func(img *Image) (bool, error) {
-		if lookedUp != nil {
-			if lookedUp.ID() == img.ID() {
+		// Empty reference filters, return true
+		if len(wantedReferenceMatches) == 0 && len(unwantedReferenceMatches) == 0 {
+			return true, nil
+		}
+
+		unwantedMatched := false
+		// Go through the unwanted matches first
+		for _, value := range unwantedReferenceMatches {
+			matches, err := imageMatchesReferenceFilter(r, img, value)
+			if err != nil {
+				return false, err
+			}
+			if matches {
+				unwantedMatched = true
+			}
+		}
+
+		// If there are no wanted match filters, then return false for the image
+		// that matched the unwanted value otherwise return true
+		if len(wantedReferenceMatches) == 0 {
+			return !unwantedMatched, nil
+		}
+
+		// Go through the wanted matches
+		// If an image matches the wanted filter but it also matches the unwanted
+		// filter, don't add it to the output
+		for _, value := range wantedReferenceMatches {
+			matches, err := imageMatchesReferenceFilter(r, img, value)
+			if err != nil {
+				return false, err
+			}
+			if matches && !unwantedMatched {
 				return true, nil
-			}
-		}
-
-		refs, err := img.NamesReferences()
-		if err != nil {
-			return false, err
-		}
-
-		for _, ref := range refs {
-			refString := ref.String() // FQN with tag/digest
-			candidates := []string{refString}
-
-			// Split the reference into 3 components (twice if digested/tagged):
-			// 1) Fully-qualified reference
-			// 2) Without domain
-			// 3) Without domain and path
-			if named, isNamed := ref.(reference.Named); isNamed {
-				candidates = append(candidates,
-					reference.Path(named),                           // path/name without tag/digest (Path() removes it)
-					refString[strings.LastIndex(refString, "/")+1:]) // name with tag/digest
-
-				trimmedString := reference.TrimNamed(named).String()
-				if refString != trimmedString {
-					tagOrDigest := refString[len(trimmedString):]
-					candidates = append(candidates,
-						trimmedString,                     // FQN without tag/digest
-						reference.Path(named)+tagOrDigest, // path/name with tag/digest
-						trimmedString[strings.LastIndex(trimmedString, "/")+1:]) // name without tag/digest
-				}
-			}
-
-			for _, candidate := range candidates {
-				// path.Match() is also used by Docker's reference.FamiliarMatch().
-				matched, _ := path.Match(value, candidate)
-				if matched {
-					return true, nil
-				}
 			}
 		}
 
 		return false, nil
 	}
+}
+
+// imageMatchesReferenceFilter returns true if an image matches the filter value given
+func imageMatchesReferenceFilter(r *Runtime, img *Image, value string) (bool, error) {
+	lookedUp, _, _ := r.LookupImage(value, nil)
+	if lookedUp != nil {
+		if lookedUp.ID() == img.ID() {
+			return true, nil
+		}
+	}
+
+	refs, err := img.NamesReferences()
+	if err != nil {
+		return false, err
+	}
+
+	for _, ref := range refs {
+		refString := ref.String() // FQN with tag/digest
+		candidates := []string{refString}
+
+		// Split the reference into 3 components (twice if digested/tagged):
+		// 1) Fully-qualified reference
+		// 2) Without domain
+		// 3) Without domain and path
+		if named, isNamed := ref.(reference.Named); isNamed {
+			candidates = append(candidates,
+				reference.Path(named),                           // path/name without tag/digest (Path() removes it)
+				refString[strings.LastIndex(refString, "/")+1:]) // name with tag/digest
+
+			trimmedString := reference.TrimNamed(named).String()
+			if refString != trimmedString {
+				tagOrDigest := refString[len(trimmedString):]
+				candidates = append(candidates,
+					trimmedString,                     // FQN without tag/digest
+					reference.Path(named)+tagOrDigest, // path/name with tag/digest
+					trimmedString[strings.LastIndex(trimmedString, "/")+1:]) // name without tag/digest
+			}
+		}
+
+		for _, candidate := range candidates {
+			// path.Match() is also used by Docker's reference.FamiliarMatch().
+			matched, _ := path.Match(value, candidate)
+			if matched {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
 }
 
 // filterLabel creates a label for matching the specified value.

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -76,13 +76,10 @@ func FiltersFromRequest(r *http.Request) ([]string, error) {
 
 	libpodFilters := make([]string, 0, len(filters))
 	for filterKey, filterSlice := range filters {
-		f := filterKey
 		for _, filterValue := range filterSlice {
-			f += "=" + filterValue
+			libpodFilters = append(libpodFilters, fmt.Sprintf("%s=%s", filterKey, filterValue))
 		}
-		libpodFilters = append(libpodFilters, f)
 	}
-
 	return libpodFilters, nil
 }
 

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -1,7 +1,12 @@
 package filters
 
 import (
+	"net/http"
+	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMatchLabelFilters(t *testing.T) {
@@ -184,4 +189,21 @@ func TestComputeUntilTimestamp(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFiltersFromRequest(t *testing.T) {
+	// simulate https request
+	req := http.Request{
+		URL: &url.URL{
+			RawQuery: "all=false&filters=%7B%22label%22%3A%5B%22xyz%3Dbar%22%2C%22abc%22%5D%2C%22reference%22%3A%5B%22test%22%5D%7D",
+		},
+	}
+	// call req.ParseForm so it can parse the RawQuery data
+	err := req.ParseForm()
+	require.NoError(t, err)
+
+	expectedLibpodFilters := []string{"label=xyz=bar", "label=abc", "reference=test"}
+	got, err := FiltersFromRequest(&req)
+	require.NoError(t, err)
+	assert.Equal(t, expectedLibpodFilters, got)
 }


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
Fix the libpodFilters parsing to ensure that
we get a list of filters in the form of key=value.
This matches what the docker endpoint does for filter
parsing as well.

When multiple filters are given, only return objects
that match all the filters given by the user.
This matches Docker behavior.