### PR TITLE
Drop warning to info on missing content from mounts.conf

### DIFF
--- a/pkg/subscriptions/subscriptions.go
+++ b/pkg/subscriptions/subscriptions.go
@@ -231,7 +231,7 @@ func addSubscriptionsFromMountsFile(filePath, mountLabel, containerRunDir string
 		fileInfo, err := os.Stat(hostDirOrFile)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				logrus.Warnf("Path %q from %q doesn't exist, skipping", hostDirOrFile, filePath)
+				logrus.Infof("Path %q from %q doesn't exist, skipping", hostDirOrFile, filePath)
 				continue
 			}
 			return nil, err


### PR DESCRIPTION
quay.io/buildah/stable and quay.io/podman/stable images now forward the mounts.conf subscriptions into their containers but if the host is not using subscription manager these pass throughs warn about missing files, which is not useful to the user.

fixes: https://github.com/containers/podman/issues/20812

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
