### PR TITLE
pkg/manifests.list.preferOCI() learn about some new OCI fields

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -421,11 +421,20 @@ func FromBlob(manifestBytes []byte) (List, error) {
 
 func (l *list) preferOCI() bool {
 	// If we have any data that's only in the OCI format, use that.
+	if l.oci.ArtifactType != "" {
+		return true
+	}
+	if l.oci.Subject != nil {
+		return true
+	}
 	for _, m := range l.oci.Manifests {
-		if len(m.URLs) > 0 {
+		if m.ArtifactType != "" {
 			return true
 		}
 		if len(m.Annotations) > 0 {
+			return true
+		}
+		if len(m.Data) > 0 {
 			return true
 		}
 	}


### PR DESCRIPTION
The OCI image index structure has grown a few new fields since the last time we looked, so we should be paying attention to whether any of them are being used when deciding if we need to use the OCI format instead of the Docker format.

The Docker format also grew a "URLs" field, so we can't use its mere presence as a heuristic any more.