### PR TITLE
pkg/manifests.list.AddInstance(): don't set Platform to an empty struct

### DIFF
--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -205,5 +205,5 @@ func TestFiltersFromRequest(t *testing.T) {
 	expectedLibpodFilters := []string{"label=xyz=bar", "label=abc", "reference=test"}
 	got, err := FiltersFromRequest(&req)
 	require.NoError(t, err)
-	assert.Equal(t, expectedLibpodFilters, got)
+	assert.ElementsMatch(t, expectedLibpodFilters, got)
 }


### PR DESCRIPTION
If the Platform struct for an OCI instance being added to an image index is empty, set the Platform pointer field in the Descriptor struct to `nil` instead of setting it to point to a Platform struct filled with empty values.  I expect this to be the case for at least some OCI artifacts being added to indexes.

Likewise, if we're updating the Platform for an OCI instance and its value goes to zero, set its pointer to `nil` to avoid the same case.

When reading information back from a descriptor, or setting a field in the Platform struct, don't assume that Platform is (already) set to a non-nil value.