### PR TITLE
Change default image volume mode to "anonymous"

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,7 +31,7 @@ const (
 	bindirPrefix = "$BINDIR"
 )
 
-var validImageVolumeModes = []string{_typeBind, "tmpfs", "ignore"}
+var validImageVolumeModes = []string{"anonymous", "tmpfs", "ignore"}
 
 // ProxyEnv is a list of Proxy Environment variables
 var ProxyEnv = []string{

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -14,9 +14,6 @@ const (
 	// DefaultSignaturePolicyPath is the default value for the
 	// policy.json file.
 	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
-
-	// Mount type for mounting host dir
-	_typeBind = "bind"
 )
 
 // podman remote clients on darwin cannot use unshare.isRootless() to determine the configuration file locations.

--- a/pkg/config/config_freebsd.go
+++ b/pkg/config/config_freebsd.go
@@ -14,9 +14,6 @@ const (
 	// DefaultSignaturePolicyPath is the default value for the
 	// policy.json file.
 	DefaultSignaturePolicyPath = "/usr/local/etc/containers/policy.json"
-
-	// Mount type for mounting host dir
-	_typeBind = "nullfs"
 )
 
 // podman remote clients on freebsd cannot use unshare.isRootless() to determine the configuration file locations.

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -17,9 +17,6 @@ const (
 	// DefaultSignaturePolicyPath is the default value for the
 	// policy.json file.
 	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
-
-	// Mount type for mounting host dir
-	_typeBind = "bind"
 )
 
 func selinuxEnabled() bool {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -37,11 +37,7 @@ var _ = Describe("Config", func() {
 			gomega.Expect(defaultConfig.NetNS()).To(gomega.BeEquivalentTo("private"))
 			gomega.Expect(defaultConfig.IPCNS()).To(gomega.BeEquivalentTo("shareable"))
 			gomega.Expect(defaultConfig.Engine.InfraImage).To(gomega.BeEquivalentTo(""))
-			if runtime.GOOS == "freebsd" {
-				gomega.Expect(defaultConfig.Engine.ImageVolumeMode).To(gomega.BeEquivalentTo("nullfs"))
-			} else {
-				gomega.Expect(defaultConfig.Engine.ImageVolumeMode).To(gomega.BeEquivalentTo("bind"))
-			}
+			gomega.Expect(defaultConfig.Engine.ImageVolumeMode).To(gomega.BeEquivalentTo("anonymous"))
 			gomega.Expect(defaultConfig.Engine.SSHConfig).To(gomega.ContainSubstring("/.ssh/config"))
 			gomega.Expect(defaultConfig.Engine.EventsContainerCreateInspectData).To(gomega.BeFalse())
 			gomega.Expect(defaultConfig.Engine.DBBackend).To(gomega.Equal(""))

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -341,7 +341,7 @@ default_sysctls = [
 #]
 
 # The firewall driver to be used by netavark.
-# The default is empty which means netavark will pick one accordingly. Current supported 
+# The default is empty which means netavark will pick one accordingly. Current supported
 # drivers are "iptables", "none" (no firewall rules will be created) and "firewalld" (firewalld is
 # experimental at the moment and not recommend outside of testing). In the future we are
 # planning to add support for a "nftables" driver.
@@ -549,7 +549,7 @@ default_sysctls = [
 #image_parallel_copies = 0
 
 # Tells container engines how to handle the built-in image volumes.
-#   * bind: An anonymous named volume will be created and mounted
+#   * anonymous: An anonymous named volume will be created and mounted
 #     into the container.
 #   * tmpfs: The volume is mounted onto the container as a tmpfs,
 #     which allows users to create content that disappears when

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -29,7 +29,7 @@ const (
 	_defaultTransport = "docker://"
 
 	// _defaultImageVolumeMode is a mode to handle built-in image volumes.
-	_defaultImageVolumeMode = _typeBind
+	_defaultImageVolumeMode = "anonymous"
 
 	// defaultInitName is the default name of the init binary
 	defaultInitName = "catatonit"


### PR DESCRIPTION
We have not supported type=bind image volumes since pre-1.0 Podman - we phased them out when we added support for actual volumes. Also, our image volume valid modes checker did not even allow the actual default (anonymous). This is technically a breaking change, so it will go into Podman 5.0 - but I strongly doubt anyone is actually using this field if no one has noticed this issue before now.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
