### PR TITLE
pkg/manifests.list.preferOCI(): pay attention to annotations in indexes

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -469,6 +469,9 @@ func (l *list) preferOCI() bool {
 	if l.oci.Subject != nil {
 		return true
 	}
+	if len(l.oci.Annotations) > 0 {
+		return true
+	}
 	for _, m := range l.oci.Manifests {
 		if m.ArtifactType != "" {
 			return true

--- a/pkg/manifests/testdata/fedora.index.json
+++ b/pkg/manifests/testdata/fedora.index.json
@@ -38,8 +38,5 @@
             "size": 529
         }
     ],
-    "schemaVersion": 2,
-    "annotations": {
-      "foo": "bar"
-    }
+    "schemaVersion": 2
 }


### PR DESCRIPTION
Account for the presence of annotations in the OCI version of an index or list when deciding if the structure should be saved in OCI format. This requires removing an annotation from the test data so that the presence of "features" information for one of its instances will be the deciding factor.

I thought we could get by in #1816 without this, but without it, setting annotations in the index doesn't force us to save it in OCI format, even without any of the indicators present that would force us to use the Docker format, effectively throwing away those annotations.