### PR TITLE
Fix `podman system df` panic

### DIFF
--- a/libimage/layer_tree.go
+++ b/libimage/layer_tree.go
@@ -148,8 +148,10 @@ func (r *Runtime) layerTree(ctx context.Context, images []*Image) (*layerTree, e
 func (t *layerTree) layersOf(image *Image) []*storage.Layer {
 	var layers []*storage.Layer
 	node := t.node(image.TopLayer())
-	for node != nil && node.layer != nil {
-		layers = append(layers, node.layer)
+	for node != nil {
+		if node.layer != nil {
+			layers = append(layers, node.layer)
+		}
 		node = node.parent
 	}
 	return layers

--- a/libimage/layer_tree.go
+++ b/libimage/layer_tree.go
@@ -148,7 +148,7 @@ func (r *Runtime) layerTree(ctx context.Context, images []*Image) (*layerTree, e
 func (t *layerTree) layersOf(image *Image) []*storage.Layer {
 	var layers []*storage.Layer
 	node := t.node(image.TopLayer())
-	for node != nil {
+	for node != nil && node.layer != nil {
 		layers = append(layers, node.layer)
 		node = node.parent
 	}


### PR DESCRIPTION
Fix panic when running `podman system df` where a `node.layer` is nil.

Fixes https://github.com/containers/podman/issues/20942