### PR TITLE
Support the execution of SSH commands with optional input.

### DIFF
--- a/pkg/ssh/connection_native.go
+++ b/pkg/ssh/connection_native.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -100,7 +101,7 @@ func nativeConnectionCreate(options ConnectionCreateOptions) error {
 	})
 }
 
-func nativeConnectionExec(options ConnectionExecOptions) (*ConnectionExecReport, error) {
+func nativeConnectionExec(options ConnectionExecOptions, input io.Reader) (*ConnectionExecReport, error) {
 	dst, uri, err := Validate(options.User, options.Host, options.Port, options.Identity)
 	if err != nil {
 		return nil, err
@@ -134,6 +135,9 @@ func nativeConnectionExec(options ConnectionExecOptions) (*ConnectionExecReport,
 	info := exec.Command(ssh, args...)
 	info.Stdout = output
 	info.Stderr = errors
+	if input != nil {
+		info.Stdin = input
+	}
 	err = info.Run()
 	if err != nil {
 		return nil, err

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"fmt"
+	"io"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -27,15 +28,19 @@ func Dial(options *ConnectionDialOptions, kind EngineMode) (*ssh.Client, error) 
 }
 
 func Exec(options *ConnectionExecOptions, kind EngineMode) (string, error) {
+	return ExecWithInput(options, kind, nil)
+}
+
+func ExecWithInput(options *ConnectionExecOptions, kind EngineMode, input io.Reader) (string, error) {
 	var rep *ConnectionExecReport
 	var err error
 	if kind == NativeMode {
-		rep, err = nativeConnectionExec(*options)
+		rep, err = nativeConnectionExec(*options, input)
 		if err != nil {
 			return "", err
 		}
 	} else {
-		rep, err = golangConnectionExec(*options)
+		rep, err = golangConnectionExec(*options, input)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -48,6 +48,26 @@ func TestExec(t *testing.T) {
 	require.Error(t, err, "failed to connect: ssh: handshake failed: ssh: disconnect, reason 2: Too many authentication failures")
 }
 
+func TestExecWithInput(t *testing.T) {
+	options := ConnectionExecOptions{
+		Port: 22,
+		Host: "localhost",
+		Args: []string{"md5sum"},
+	}
+
+	input, err := os.Open("/etc/fstab")
+	require.NoError(t, err)
+	defer input.Close()
+
+	_, err = ExecWithInput(&options, NativeMode, input)
+	// exit status 255 is what you get when ssh is not enabled or the connection failed
+	// this means up to that point, everything worked
+	require.Error(t, err, "exit status 255")
+
+	_, err = ExecWithInput(&options, GolangMode, input)
+	require.Error(t, err, "failed to connect: ssh: handshake failed: ssh: disconnect, reason 2: Too many authentication failures")
+}
+
 func TestDial(t *testing.T) {
 	options := ConnectionDialOptions{
 		Port: 22,


### PR DESCRIPTION
These changes are needed to support https://github.com/containers/podman/pull/21420

Supporting an input file for SSH commands can avoid the use of temporary files.