### PR TITLE
feat: add cdi path to engine config

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -644,6 +644,10 @@ The default path on Windows is:
 
 Path to the OCI hooks directories for automatically executed hooks.
 
+**cdi_spec_dirs**=["/etc/cdi", ...]
+
+Directories to scan for CDI Spec files.
+
 **image_default_format**="oci"|"v2s2"|"v2s1"
 
 Manifest Type (oci, v2s2, or v2s1) to use when pulling, pushing, building

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -328,6 +328,11 @@ type EngineConfig struct {
 	// this slice takes precedence.
 	HooksDir attributedstring.Slice `toml:"hooks_dir,omitempty"`
 
+	// Location of CDI configuration files. These define mounts devices and
+	// other configs according to the CDI spec. In particular this is used
+	// for GPU passthrough.
+	CdiSpecDirs attributedstring.Slice `toml:"cdi_spec_dirs,omitempty"`
+
 	// ImageBuildFormat (DEPRECATED) indicates the default image format to
 	// building container images. Should use ImageDefaultFormat
 	ImageBuildFormat string `toml:"image_build_format,omitempty"`

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -351,6 +351,32 @@ var _ = Describe("Config Local", func() {
 		gomega.Expect(os.Getenv("foo")).To(gomega.BeEquivalentTo("bar"))
 	})
 
+	It("should override cdi_spec_dirs if provided", func() {
+		// Given
+		config1, err := New(nil)
+		// Then
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config1.Engine.CdiSpecDirs.Get()).To(gomega.Equal([]string{"/etc/cdi"}))
+
+		// Given default just get default
+		config2, err := NewConfig("testdata/containers_default.conf")
+		// Then
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config2.Engine.CdiSpecDirs.Get()).To(gomega.Equal([]string{"/etc/cdi"}))
+
+		// Given override just get override
+		config3, err := NewConfig("testdata/containers_override.conf")
+		// Then
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config3.Engine.CdiSpecDirs.Get()).To(gomega.Equal([]string{"/somepath"}))
+
+		// Given override just get override
+		config4, err := NewConfig("testdata/containers_override2.conf")
+		// Then
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(config4.Engine.CdiSpecDirs.Get()).To(gomega.Equal([]string{"/somepath", "/some_other_path"}))
+	})
+
 	It("Expect Remote to be False", func() {
 		// Given
 		// When

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -544,6 +544,12 @@ default_sysctls = [
 #  "/usr/share/containers/oci/hooks.d",
 #]
 
+# Directories to scan for CDI Spec files.
+#
+#cdi_spec_dirs = [
+#  "/etc/cdi",
+#]
+
 # Manifest Type (oci, v2s2, or v2s1) to use when pulling, pushing, building
 # container images. By default image pulled and pushed match the format of the
 # source image. Building/committing defaults to OCI.

--- a/pkg/config/containers.conf-freebsd
+++ b/pkg/config/containers.conf-freebsd
@@ -414,6 +414,12 @@ default_sysctls = [
 #  "/usr/local/share/containers/oci/hooks.d",
 #]
 
+# Directories to scan for CDI Spec files.
+#
+#cdi_spec_dirs = [
+#  "/etc/cdi",
+#]
+
 # Manifest Type (oci, v2s2, or v2s1) to use when pulling, pushing, building
 # container images. By default image pulled and pushed match the format of the
 # source image. Building/committing defaults to OCI.

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -74,6 +74,8 @@ var (
 	ErrInvalidArg = errors.New("invalid argument")
 	// DefaultHooksDirs defines the default hooks directory.
 	DefaultHooksDirs = []string{"/usr/share/containers/oci/hooks.d"}
+	// DefaultCdiSpecDirs defines the default cdi spec directories.
+	DefaultCdiSpecDirs = []string{"/etc/cdi"}
 	// DefaultCapabilities is the default for the default_capabilities option in the containers.conf file.
 	DefaultCapabilities = []string{
 		"CAP_CHOWN",
@@ -347,6 +349,7 @@ func defaultEngineConfig() (*EngineConfig, error) {
 		c.HelperBinariesDir.Set(append([]string{additionalHelperBinariesDir}, c.HelperBinariesDir.Get()...))
 	}
 	c.HooksDir.Set(DefaultHooksDirs)
+	c.CdiSpecDirs.Set(DefaultCdiSpecDirs)
 	c.ImageDefaultTransport = _defaultTransport
 	c.ImageVolumeMode = _defaultImageVolumeMode
 

--- a/pkg/config/testdata/containers_comment.conf
+++ b/pkg/config/testdata/containers_comment.conf
@@ -79,6 +79,12 @@
 # hooks_dir = [
 # ]
 
+# Directories to scan for CDI Spec files.
+#
+#cdi_spec_dirs = [
+#  "/etc/cdi",
+#]
+
 # Size of /dev/shm. Specified as <number><unit>.
 # Unit is optional and can be b (bytes), k (kilobytes), m (megabytes), or g (gigabytes). If the unit is omitted, the system uses bytes.
 # shm_size = "64m"

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -225,6 +225,9 @@ retry_delay="10s"
 hooks_dir = [
 ]
 
+# Directories to scan for CDI Spec files.
+# cdi_spec_dirs = [ "/etc/cdi" ]
+
 # Default infra (pause) image name for pod infra containers
 infra_image = "k8s.gcr.io/pause:3.4.1"
 

--- a/pkg/config/testdata/containers_invalid.conf
+++ b/pkg/config/testdata/containers_invalid.conf
@@ -133,6 +133,9 @@ tmp_dir = "/run/libpod"
 hooks_dir = [
 ]
 
+# Directories to scan for CDI Spec files.
+cdi_spec_dirs = [ "/etc/cdi" ]
+
 # Whether to use chroot instead of pivot_root in the runtime
 no_pivot_root = false
 

--- a/pkg/config/testdata/containers_override.conf
+++ b/pkg/config/testdata/containers_override.conf
@@ -17,6 +17,7 @@ events_logfile_max_size="500"
 events_container_create_inspect_data = true
 pod_exit_policy="stop"
 compression_format="zstd:chunked"
+cdi_spec_dirs = [ "/somepath" ]
 
 [engine.platform_to_oci_runtime]
 hello = "world"

--- a/pkg/config/testdata/containers_override2.conf
+++ b/pkg/config/testdata/containers_override2.conf
@@ -1,0 +1,5 @@
+[containers]
+
+[engine]
+cdi_spec_dirs = [ "/somepath", "/some_other_path" ]
+


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

In response to:
https://github.com/containers/podman/issues/18292

Adds config to pass CDI spec directory, so that it can be overridden. The enables rootless containers since otherwise users have to write to one of the shared, usually only root writeable paths at in /etc or /var.

Named to match cri-o's name