### PR TITLE
libimage/manifests.list.AddArtifact(): handle descriptor+file

### DIFF
--- a/libimage/manifests/manifests.go
+++ b/libimage/manifests/manifests.go
@@ -811,12 +811,14 @@ func (l *list) AddArtifact(ctx context.Context, sys *types.SystemContext, option
 	configDescriptor := internal.DeepCopyDescriptor(&v1.DescriptorEmptyJSON)
 	if options.ConfigDescriptor != nil {
 		configDescriptor = internal.DeepCopyDescriptor(options.ConfigDescriptor)
-	} else if options.ConfigFile != "" {
-		configDescriptor = &v1.Descriptor{
-			MediaType: v1.MediaTypeImageConfig,
-			Digest:    "", // to be figured out below
-			Size:      -1, // to be figured out below
+	}
+	if options.ConfigFile != "" {
+		if options.ConfigDescriptor == nil { // i.e., we assigned the default mediatype
+			configDescriptor.MediaType = v1.MediaTypeImageConfig
 		}
+		configDescriptor.Data = nil
+		configDescriptor.Digest = "" // to be figured out below
+		configDescriptor.Size = -1   // to be figured out below
 	}
 	configFilePath := ""
 	if configDescriptor.Size != 0 {

--- a/libimage/manifests/manifests_test.go
+++ b/libimage/manifests/manifests_test.go
@@ -309,16 +309,6 @@ func TestAddArtifact(t *testing.T) {
 				assert.Equal(t, configFileSize, m.Config.Size, "did not record expected size for config with file")
 			case configDescriptor != nil:
 				assert.Equal(t, configDescriptor.MediaType, m.Config.MediaType, "did not record expected mediaType for empty config")
-				if false {
-					d := configDescriptor.Digest
-					s := configDescriptor.Size
-					if d.Validate() != nil {
-						s = 0
-						d = digest.Canonical.FromString("")
-					}
-					assert.Equal(t, d, m.Config.Digest, "did not record expected digest for empty config")
-					assert.Equal(t, s, m.Config.Size, "did not record expected digest for empty config")
-				}
 				assert.Equal(t, configDescriptor.Digest, m.Config.Digest, "did not record expected digest for empty config")
 				assert.Equal(t, configDescriptor.Size, m.Config.Size, "did not record expected digest for empty config")
 			default:
@@ -412,12 +402,13 @@ func TestAddArtifact(t *testing.T) {
 		}
 		for _, configDescriptor := range []*v1.Descriptor{
 			nil,
+			{MediaType: "application/x-config", Size: 0, Digest: digest.Canonical.FromString("")},
 			{MediaType: v1.MediaTypeImageConfig, Size: 0, Digest: digest.Canonical.FromString("")},
 			&v1.DescriptorEmptyJSON,
 		} {
 			for _, configFile := range []string{
 				"",
-				configFile,
+				emptyConfigFile,
 			} {
 				testCombination(t, file, fileMediaType, manifestArtifactType, platform, configDescriptor, configFile, layerMediaType, annotations, subjectReference, excludeTitles)
 			}


### PR DESCRIPTION
In the case where AddArtifact() is given both a file name and a configuration descriptor, pay attention to both, using the media type from the descriptor, and setting the digest and size based on the file's contents.

Updated a unit test to exercise this combination.