### PR TITLE
libimage/manifests.LoadFromImage(): don't return a stale error

### DIFF
--- a/libimage/manifests/manifests.go
+++ b/libimage/manifests/manifests.go
@@ -179,7 +179,7 @@ func LoadFromImage(store storage.Store, image string) (string, List, error) {
 		return "", nil, fmt.Errorf("decoding artifact list for image %q: %w", image, err)
 	}
 	list.instances[""] = img.ID
-	return img.ID, list, err
+	return img.ID, list, nil
 }
 
 // SaveToImage saves the manifest list or image index as the manifest of an


### PR DESCRIPTION
After we've dealt with potentially-missing files, don't accidentally return the missing file error.