### PR TITLE
pkg/config: rename podman-connections.conf to .json

### DIFF
--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/storage/pkg/ioutils"
 )
 
-const connectionsFile = "podman-connections.conf"
+const connectionsFile = "podman-connections.json"
 
 // connectionsConfigFile returns the path to the rw connections config file
 func connectionsConfigFile() (string, error) {

--- a/pkg/config/connections_test.go
+++ b/pkg/config/connections_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Connections conf", func() {
 
 	BeforeEach(func() {
 		dir := GinkgoT().TempDir()
-		connectionsConfFile = filepath.Join(dir, "connections.conf")
+		connectionsConfFile = filepath.Join(dir, "connections.json")
 		err := os.Setenv("PODMAN_CONNECTIONS_CONF", connectionsConfFile)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		containersConfFile = filepath.Join(dir, "containers.conf")


### PR DESCRIPTION
As per Dan's feedback .conf sounds like a config file that can edited but this file is really only managed by podman so just use the .json suffix to make it more clear hopefully.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
