### PR TITLE
Allow creation of a rootless netns backed by Pasta

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -442,10 +442,10 @@ default_subnet_pools = [
 ]
 ```
 
-**default_rootless_network_cmd**="slirp4netns"
+**default_rootless_network_cmd**="pasta"
 
 Configure which rootless network program to use by default. Valid options are
-`slirp4netns` (default) and `pasta`.
+`slirp4netns` and `pasta` (default).
 
 **network_config_dir**="/etc/cni/net.d/"
 
@@ -770,7 +770,7 @@ Number of times to retry pulling/pushing images in case of failure.
 
 **retry_delay** = ""
 
-Delay between retries in case pulling/pushing image fails. If set, container engines will retry at the set interval, otherwise they delay 2 seconds and then exponentially back off.  
+Delay between retries in case pulling/pushing image fails. If set, container engines will retry at the set interval, otherwise they delay 2 seconds and then exponentially back off.
 
 **runtime**=""
 

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -151,12 +151,12 @@ var _ = Describe("Config Local", func() {
 		// Given
 		config, err := NewConfig("")
 		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config.Network.DefaultRootlessNetworkCmd).To(gomega.Equal("slirp4netns"))
+		gomega.Expect(config.Network.DefaultRootlessNetworkCmd).To(gomega.Equal("pasta"))
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
 		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config2.Network.DefaultRootlessNetworkCmd).To(gomega.Equal("pasta"))
+		gomega.Expect(config2.Network.DefaultRootlessNetworkCmd).To(gomega.Equal("slirp4netns"))
 	})
 
 	It("should fail on invalid device mode", func() {

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -384,9 +384,9 @@ default_sysctls = [
 
 
 # Configure which rootless network program to use by default. Valid options are
-# `slirp4netns` (default) and `pasta`.
+# `slirp4netns` and `pasta` (default).
 #
-#default_rootless_network_cmd = "slirp4netns"
+#default_rootless_network_cmd = "pasta"
 
 # Path to the directory where network configuration files are located.
 # For the CNI backend the default is "/etc/cni/net.d" as root
@@ -662,7 +662,7 @@ default_sysctls = [
 
 # Delay between retries in case pulling/pushing image fails.
 # If set, container engines will retry at the set interval,
-# otherwise they delay 2 seconds and then exponentially back off.  
+# otherwise they delay 2 seconds and then exponentially back off.
 #
 #retry_delay = "2s"
 

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -257,7 +257,7 @@ func defaultConfig() (*Config, error) {
 			DefaultNetwork:            "podman",
 			DefaultSubnet:             DefaultSubnet,
 			DefaultSubnetPools:        DefaultSubnetPools,
-			DefaultRootlessNetworkCmd: "slirp4netns",
+			DefaultRootlessNetworkCmd: "pasta",
 			DNSBindPort:               0,
 			CNIPluginDirs:             attributedstring.NewSlice(DefaultCNIPluginDirs),
 			NetavarkPluginDirs:        attributedstring.NewSlice(DefaultNetavarkPluginDirs),

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -122,7 +122,7 @@ network_config_dir = "/etc/cni/net.d/"
 
 default_subnet_pools = [{"base" = "10.89.0.0/16", "size" = 24}, {"base" = "10.90.0.0/15", "size" = 24}]
 
-default_rootless_network_cmd = "pasta"
+default_rootless_network_cmd = "slirp4netns"
 
 # firewall driver to be used by default
 firewall_driver = "none"


### PR DESCRIPTION
This makes the code for setting up rootless network namespaces dependent on what the default rootless network provider is, and allows Pasta to be used for traffic forwarding on the rootless netns.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
