### PR TITLE
[CI:DOCS] Update documentation to note that volumes use locks.

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -736,10 +736,11 @@ Whether to use chroot instead of pivot_root in the runtime.
 
 **num_locks**=2048
 
-Number of locks available for containers and pods. Each created container or
-pod consumes one lock. The default number available is 2048. If this is
-changed, a lock renumbering must be performed, using the
-`podman system renumber` command.
+Number of locks available for containers, pods, and volumes.
+Each created container, pod, or volume consumes one lock.
+Locks are recycled and can be reused after the associated container, pod, or volume is removed.
+The default number available is 2048.
+If this is changed, a lock renumbering must be performed, using the `podman system renumber` command.
 
 **pod_exit_policy**="continue"
 

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -636,7 +636,8 @@ default_sysctls = [
 #
 #no_pivot_root = false
 
-# Number of locks available for containers and pods.
+# Number of locks available for containers, pods, and volumes. Each container,
+# pod, and volume consumes 1 lock for as long as it exists.
 # If this is changed, a lock renumber must be performed (e.g. with the
 # 'podman system renumber' command).
 #


### PR DESCRIPTION
The existing documentation only describes containers and pods, but volumes also consume locks as well (and have for years), so update documentation to reflect that.

Fixes RHEL-24333

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
