### PR TITLE
Default Pull/Push to use containers.conf Retry, RetryDelay

### DIFF
--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -60,6 +60,23 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 		options = &PullOptions{}
 	}
 
+	defaultConfig, err := config.Default()
+	if err != nil {
+		return nil, err
+	}
+	if options.MaxRetries == nil {
+		options.MaxRetries = &defaultConfig.Engine.Retry
+	}
+	if options.RetryDelay == nil {
+		if defaultConfig.Engine.RetryDelay != "" {
+			duration, err := time.ParseDuration(defaultConfig.Engine.RetryDelay)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse containers.conf retry_delay: %w", err)
+			}
+			options.RetryDelay = &duration
+		}
+	}
+
 	var possiblyUnqualifiedName string // used for short-name resolution
 	ref, err := alltransports.ParseImageName(name)
 	if err != nil {

--- a/libimage/push.go
+++ b/libimage/push.go
@@ -4,8 +4,10 @@ package libimage
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/containers/common/pkg/config"
 	dockerArchiveTransport "github.com/containers/image/v5/docker/archive"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/transports/alltransports"
@@ -29,6 +31,23 @@ type PushOptions struct {
 func (r *Runtime) Push(ctx context.Context, source, destination string, options *PushOptions) ([]byte, error) {
 	if options == nil {
 		options = &PushOptions{}
+	}
+
+	defaultConfig, err := config.Default()
+	if err != nil {
+		return nil, err
+	}
+	if options.MaxRetries == nil {
+		options.MaxRetries = &defaultConfig.Engine.Retry
+	}
+	if options.RetryDelay == nil {
+		if defaultConfig.Engine.RetryDelay != "" {
+			duration, err := time.ParseDuration(defaultConfig.Engine.RetryDelay)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse containers.conf retry_delay: %w", err)
+			}
+			options.RetryDelay = &duration
+		}
 	}
 
 	// Look up the local image.  Note that we need to ignore the platform


### PR DESCRIPTION
libimage should be using the settings in containers/pkg/config for Retry and RetryDelay if they were not set by a caller.

[NO NEW TESTS NEEDED] since it would be difficult to test.