### PR TITLE
pkg/config: remove deprecated MachineEnabled field

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -370,11 +370,6 @@ type EngineConfig struct {
 	// LockType is the type of locking to use.
 	LockType string `toml:"lock_type,omitempty"`
 
-	// MachineEnabled indicates if Podman is running in a podman-machine VM
-	//
-	// This method is soft deprecated, use machine.IsPodmanMachine instead
-	MachineEnabled bool `toml:"machine_enabled,omitempty"`
-
 	// MultiImageArchive - if true, the container engine allows for storing
 	// archives (e.g., of the docker-archive transport) with multiple
 	// images.  By default, Podman creates single-image archives.

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -425,18 +425,6 @@ var _ = Describe("Config Local", func() {
 		gomega.Expect(err).NotTo(gomega.BeNil())
 	})
 
-	It("Set Machine Enabled", func() {
-		// Given
-		config, err := New(nil)
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config.Engine.MachineEnabled).To(gomega.Equal(false))
-		// When
-		config2, err := NewConfig("testdata/containers_default.conf")
-		// Then
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config2.Engine.MachineEnabled).To(gomega.Equal(true))
-	})
-
 	It("default netns", func() {
 		// Given
 		config, err := New(nil)

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -480,7 +480,6 @@ func defaultEngineConfig() (*EngineConfig, error) {
 	// TODO - ideally we should expose a `type LockType string` along with
 	// constants.
 	c.LockType = getDefaultLockType()
-	c.MachineEnabled = false
 	c.ChownCopiedFiles = true
 
 	c.PodExitPolicy = defaultPodExitPolicy
@@ -647,11 +646,6 @@ func (c *Config) Umask() string {
 // currently k8s-file or journald.
 func (c *Config) LogDriver() string {
 	return c.Containers.LogDriver
-}
-
-// MachineEnabled returns if podman is running inside a VM or not.
-func (c *Config) MachineEnabled() bool {
-	return c.Engine.MachineEnabled
 }
 
 // MachineVolumes returns volumes to mount into the VM.

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -201,8 +201,6 @@ env = ["super=duper", "foo=bar"]
 # Directory for temporary files. Must be tmpfs (wiped after reboot)
 tmp_dir = "/run/libpod"
 
-machine_enabled = true
-
 # Whether to use chroot instead of pivot_root in the runtime
 no_pivot_root = false
 

--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -4,9 +4,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-
-	"github.com/containers/common/pkg/config"
-	"github.com/sirupsen/logrus"
 )
 
 type Marker struct {
@@ -29,9 +26,7 @@ var (
 
 func loadMachineMarker(file string) {
 	var kind string
-
-	// Support deprecated config value for compatibility
-	enabled := isLegacyConfigSet()
+	enabled := false
 
 	if content, err := os.ReadFile(file); err == nil {
 		enabled = true
@@ -39,17 +34,6 @@ func loadMachineMarker(file string) {
 	}
 
 	marker = &Marker{enabled, kind}
-}
-
-func isLegacyConfigSet() bool {
-	config, err := config.Default()
-	if err != nil {
-		logrus.Warnf("could not obtain container configuration")
-		return false
-	}
-
-	//nolint:staticcheck //lint:ignore SA1019 deprecated call
-	return config.Engine.MachineEnabled
 }
 
 func IsPodmanMachine() bool {

--- a/pkg/machine/machine_test.go
+++ b/pkg/machine/machine_test.go
@@ -1,7 +1,6 @@
 package machine
 
 import (
-	"github.com/containers/common/pkg/config"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
@@ -10,11 +9,6 @@ var _ = Describe("Machine", func() {
 	BeforeEach(func() {
 		// disable normal init for testing
 		markerSync.Do(func() {})
-
-		// ensure legacy flag is off
-		config, _ := config.Default()
-		//nolint:staticcheck //lint:ignore SA1019 deprecated call
-		config.Engine.MachineEnabled = false
 	})
 
 	It("not a machine", func() {
@@ -62,17 +56,6 @@ var _ = Describe("Machine", func() {
 
 		gomega.Expect(IsPodmanMachine()).To(gomega.BeTrue())
 		gomega.Expect(HostType()).To(gomega.Equal(HyperV))
-		gomega.Expect(IsGvProxyBased()).To(gomega.BeTrue())
-	})
-
-	It("legacy config machine", func() {
-		config, _ := config.Default()
-		//nolint:staticcheck //lint:ignore SA1019 deprecated call
-		config.Engine.MachineEnabled = true
-		loadMachineMarker("testdata/does-not-exist")
-
-		gomega.Expect(IsPodmanMachine()).To(gomega.BeTrue())
-		gomega.Expect(HostType()).To(gomega.BeEmpty())
 		gomega.Expect(IsGvProxyBased()).To(gomega.BeTrue())
 	})
 })


### PR DESCRIPTION
We now only use the marker file, see pkg/machine.
The advantage of this is that pkg/machine no longer imports pkg/config and we use it in rootlessport which means it will debloat the binary there significantly.

The file approach has been added in podman 4.1 (2 years ago) so basically all machines should have it now and this shouldn't break anything.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
