### PR TITLE
docker-archive/DockerV3Schema2MediaType only support Gzip compression

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -837,7 +837,10 @@ the primary uid/gid of the container.
 
 **compression_format**="gzip"
 
-Specifies the compression format to use when pushing an image. Supported values are: `gzip`, `zstd` and `zstd:chunked`.
+Specifies the compression format to use when pushing an image. Supported values
+are: `gzip`, `zstd` and `zstd:chunked`. This field is ignored when pushing
+images to the docker-daemon and docker-archive formats. It is also ignored
+when the manifest format is set to v2s2.
 
 **compression_level**="5"
 

--- a/libimage/push.go
+++ b/libimage/push.go
@@ -8,8 +8,10 @@ import (
 	"time"
 
 	"github.com/containers/common/pkg/config"
+	dockerDaemonTransport "github.com/containers/image/v5/docker"
 	dockerArchiveTransport "github.com/containers/image/v5/docker/archive"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/sirupsen/logrus"
 )
@@ -82,6 +84,14 @@ func (r *Runtime) Push(ctx context.Context, source, destination string, options 
 			return nil, err
 		}
 		destRef = dockerRef
+	}
+
+	// docker-archive and only DockerV2Schema2MediaType support Gzip compression
+	if options.CompressionFormat != nil &&
+		(destRef.Transport().Name() == dockerArchiveTransport.Transport.Name() ||
+			destRef.Transport().Name() == dockerDaemonTransport.Transport.Name() ||
+			options.ManifestMIMEType == manifest.DockerV2Schema2MediaType) {
+		options.CompressionFormat = nil
 	}
 
 	if r.eventChannel != nil {

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -435,6 +435,9 @@ default_sysctls = [
 
 # The compression format to use when pushing an image.
 # Valid options are: `gzip`, `zstd` and `zstd:chunked`.
+# This field is ignored when pushing images to the docker-daemon and
+# docker-archive formats. It is also ignored when the manifest format is set
+# to v2s2.
 #
 #compression_format = "gzip"
 


### PR DESCRIPTION
If user does not specify a compression format and transport is docker-archive of manifesttype is DockerV2Schema2MediaType then we need to force Gzip compression.

This is needed when we transition to zstd or zstd:chunked by default.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
