### PR TITLE
libnetwork/pasta: pass --dns none

### DIFF
--- a/libnetwork/pasta/pasta.go
+++ b/libnetwork/pasta/pasta.go
@@ -47,6 +47,7 @@ func Setup(opts *SetupOptions) error {
 	NoTCPNamespacePorts := true
 	NoUDPNamespacePorts := true
 	NoMapGW := true
+	NoDNS := true
 
 	path, err := opts.Config.FindHelperBinary(BinaryName, true)
 	if err != nil {
@@ -102,6 +103,8 @@ func Setup(opts *SetupOptions) error {
 			NoMapGW = false
 			// not an actual pasta(1) option
 			cmdArgs = append(cmdArgs[:i], cmdArgs[i+1:]...)
+		case "-D", "--dns", "--dns-forward":
+			NoDNS = false
 		}
 	}
 
@@ -119,6 +122,12 @@ func Setup(opts *SetupOptions) error {
 	}
 	if NoMapGW {
 		cmdArgs = append(cmdArgs, "--no-map-gw")
+	}
+	if NoDNS {
+		// disable pasta reading from /etc/resolv.conf which hides the
+		// "Couldn't get any nameserver address" warning when only
+		// localhost resolvers are configured.
+		cmdArgs = append(cmdArgs, "--dns", "none")
 	}
 
 	// always pass --quiet to silence the info output from pasta


### PR DESCRIPTION
We pass --no-map-gw to pasta and when run on a system with only localhost resolvers pasta cannot find a valid nameserver in resolv.conf it will print a warning. We do not use the dns functionality so the warning is just bogus to podman users. Let's disable dns which is only used for the dhcp option or --dns-forward which we do not use by default. If a users sets such an option we use them instead.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
