### PR TITLE
Adjust machine image default

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -770,7 +770,7 @@ Number of times to retry pulling/pushing images in case of failure.
 
 **retry_delay** = ""
 
-Delay between retries in case pulling/pushing image fails. If set, container engines will retry at the set interval, otherwise they delay 2 seconds and then exponentially back off.  
+Delay between retries in case pulling/pushing image fails. If set, container engines will retry at the set interval, otherwise they delay 2 seconds and then exponentially back off.
 
 **runtime**=""
 
@@ -909,13 +909,13 @@ The size of the disk in GB created when init-ing a podman-machine VM
 
 **image**=""
 
-Default image URI when creating a new VM using `podman machine init`.
-Options: On Linux/Mac, `testing`, `stable`, `next`. On Windows, the major
-version of the OS (e.g `36`) for Fedora 36. For all platforms you can
-alternatively specify a custom download URL to an image. Container engines
-translate URIs $OS and $ARCH to the native OS and ARCH. URI "https://example.com/$OS/$ARCH/foobar.ami" would become "https://example.com/linux/amd64/foobar.ami" on a Linux AMD machine.
-The default value
-is `testing` on Linux/Mac, and on Windows.
+Image used when creating a new VM using `podman machine init`.
+Can be specified as a registry with a bootable OCI artifact, download URL, or a local path.
+Registry target must be in the form of `docker://registry/repo/image:version`.
+Container engines translate URIs $OS and $ARCH to the native OS and ARCH.
+URI "https://example.com/$OS/$ARCH/foobar.ami" would become
+"https://example.com/linux/amd64/foobar.ami" on a Linux AMD machine.
+If unspecified, the default Podman machine image will be used.
 
 **memory**=2048
 

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -465,7 +465,7 @@ var _ = Describe("Config Local", func() {
 		// Given
 		config, err := New(nil)
 		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config.Machine.Image).To(gomega.Equal("testing"))
+		gomega.Expect(config.Machine.Image).To(gomega.Equal(""))
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -665,7 +665,7 @@ default_sysctls = [
 
 # Delay between retries in case pulling/pushing image fails.
 # If set, container engines will retry at the set interval,
-# otherwise they delay 2 seconds and then exponentially back off.  
+# otherwise they delay 2 seconds and then exponentially back off.
 #
 #retry_delay = "2s"
 
@@ -823,16 +823,15 @@ default_sysctls = [
 #
 #disk_size=10
 
-# Default image URI when creating a new VM using `podman machine init`.
-# Options: On Linux/Mac, `testing`, `stable`, `next`. On Windows, the major
-# version of the OS (e.g `36`) for Fedora 36. For all platforms you can
-# alternatively specify a custom download URL to an image. Container engines
-# translate URIs $OS and $ARCH to the native OS and ARCH. URI
-# "https://example.com/$OS/$ARCH/foobar.ami" becomes
+# Default Image used when creating a new VM using `podman machine init`.
+# Can be specified as registry with a bootable OCI artifact, download URL, or a local path.
+# Registry target must be in the form of `docker://registry/repo/image:version`.
+# Container engines translate URIs $OS and $ARCH to the native OS and ARCH.
+# URI "https://example.com/$OS/$ARCH/foobar.ami" would become
 # "https://example.com/linux/amd64/foobar.ami" on a Linux AMD machine.
-# The default value is `testing`.
+# If unspecified, the default Podman machine image will be used.
 #
-#image = "testing"
+#image = ""
 
 # Memory in MB a machine is created with.
 #

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -286,10 +286,13 @@ func defaultMachineConfig() MachineConfig {
 	return MachineConfig{
 		CPUs:     uint64(cpus),
 		DiskSize: 100,
-		Image:    getDefaultMachineImage(),
-		Memory:   2048,
-		User:     getDefaultMachineUser(),
-		Volumes:  attributedstring.NewSlice(getDefaultMachineVolumes()),
+		// TODO: Set machine image default here
+		// Currently the default is set in Podman as we need time to stabilize
+		// VM images and locations between different providers.
+		Image:   "",
+		Memory:  2048,
+		User:    getDefaultMachineUser(),
+		Volumes: attributedstring.NewSlice(getDefaultMachineVolumes()),
 	}
 }
 
@@ -675,12 +678,6 @@ func getDefaultSSHConfig() string {
 	}
 	dirname := homedir.Get()
 	return filepath.Join(dirname, ".ssh", "config")
-}
-
-// getDefaultImage returns the default machine image stream
-// On Windows this refers to the Fedora major release number
-func getDefaultMachineImage() string {
-	return "testing"
 }
 
 // getDefaultMachineUser returns the user to use for rootless podman


### PR DESCRIPTION
We no longer use `testing` as the default image from fcos for machine. Adjust default to "" temporarily, as we're still stablizing the location and images for machine images, but still allow the user to specify a custom image via containers.conf.



<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
