### PR TITLE
pkg/config: make EditConnectionConfig race free 

### DIFF
--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -64,28 +64,24 @@ type Farm struct {
 	ReadWrite bool
 }
 
-func readConnectionConf() (*ConnectionsFile, string, error) {
-	path, err := connectionsConfigFile()
-	if err != nil {
-		return nil, "", err
-	}
+func readConnectionConf(path string) (*ConnectionsFile, error) {
 	conf := new(ConnectionsFile)
 	f, err := os.Open(path)
 	if err != nil {
 		// return empty config if file does not exists
 		if errors.Is(err, fs.ErrNotExist) {
-			return conf, path, nil
+			return conf, nil
 		}
 
-		return nil, "", err
+		return nil, err
 	}
 	defer f.Close()
 
 	err = json.NewDecoder(f).Decode(conf)
 	if err != nil {
-		return nil, "", fmt.Errorf("parse %q: %w", path, err)
+		return nil, fmt.Errorf("parse %q: %w", path, err)
 	}
-	return conf, path, nil
+	return conf, nil
 }
 
 func writeConnectionConf(path string, conf *ConnectionsFile) error {
@@ -113,7 +109,11 @@ func writeConnectionConf(path string, conf *ConnectionsFile) error {
 // The function will read and write the file automatically and the
 // callback function just needs to modify the cfg as needed.
 func EditConnectionConfig(callback func(cfg *ConnectionsFile) error) error {
-	conf, path, err := readConnectionConf()
+	path, err := connectionsConfigFile()
+	if err != nil {
+		return err
+	}
+	conf, err := readConnectionConf(path)
 	if err != nil {
 		return fmt.Errorf("read connections file: %w", err)
 	}
@@ -139,7 +139,11 @@ func makeConnection(name string, dst Destination, def, readWrite bool) *Connecti
 
 // GetConnection return the connection for the given name or if def is set to true then return the default connection.
 func (c *Config) GetConnection(name string, def bool) (*Connection, error) {
-	conConf, _, err := readConnectionConf()
+	path, err := connectionsConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	conConf, err := readConnectionConf(path)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +171,11 @@ func (c *Config) GetConnection(name string, def bool) (*Connection, error) {
 
 // GetAllConnections return all configured connections
 func (c *Config) GetAllConnections() ([]Connection, error) {
-	conConf, _, err := readConnectionConf()
+	path, err := connectionsConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	conConf, err := readConnectionConf(path)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +230,11 @@ func (c *Config) GetDefaultFarmConnections() (string, []Connection, error) {
 // if def is true it will use the default farm instead of the name.
 // Returns the name of the farm and the connections for it.
 func (c *Config) getFarmConnections(name string, def bool) (string, []Connection, error) {
-	conConf, _, err := readConnectionConf()
+	path, err := connectionsConfigFile()
+	if err != nil {
+		return "", nil, err
+	}
+	conConf, err := readConnectionConf(path)
 	if err != nil {
 		return "", nil, err
 	}
@@ -259,7 +271,11 @@ func makeFarm(name string, cons []string, def, readWrite bool) Farm {
 
 // GetAllFarms returns all configured farms
 func (c *Config) GetAllFarms() ([]Farm, error) {
-	conConf, _, err := readConnectionConf()
+	path, err := connectionsConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	conConf, err := readConnectionConf(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/containers/storage/pkg/ioutils"
+	"github.com/containers/storage/pkg/lockfile"
 )
 
 const connectionsFile = "podman-connections.json"
@@ -113,6 +114,15 @@ func EditConnectionConfig(callback func(cfg *ConnectionsFile) error) error {
 	if err != nil {
 		return err
 	}
+
+	lockPath := path + ".lock"
+	lock, err := lockfile.GetLockFile(lockPath)
+	if err != nil {
+		return fmt.Errorf("obtain lock file: %w", err)
+	}
+	lock.Lock()
+	defer lock.Unlock()
+
 	conf, err := readConnectionConf(path)
 	if err != nil {
 		return fmt.Errorf("read connections file: %w", err)

--- a/pkg/config/connections_test.go
+++ b/pkg/config/connections_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -71,6 +73,43 @@ var _ = Describe("Connections conf", func() {
 		conf, err := readConnectionConf(path)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(conf).To(gomega.Equal(orgConf))
+	})
+
+	It("parallel EditConnectionConfig", func() {
+		// race test for EditConnectionConfig
+		// Basic idea spawn a bunch of goroutines and call EditConnectionConfig at the same time.
+		// We read a int from one field and then +1 one it each time so at the end we must have
+		// the number in the filed for how many times we called EditConnectionConfig. If it is
+		// less than it is racy.
+		count := 50
+		wg := sync.WaitGroup{}
+		wg.Add(count)
+		for i := 0; i < count; i++ {
+			go func() {
+				defer wg.Done()
+				err := EditConnectionConfig(func(cfg *ConnectionsFile) error {
+					if cfg.Connection.Default == "" {
+						cfg.Connection.Default = "1"
+						return nil
+					}
+					// basic idea just add 1
+					i, err := strconv.Atoi(cfg.Connection.Default)
+					if err != nil {
+						return err
+					}
+					i++
+					cfg.Connection.Default = strconv.Itoa(i)
+					return nil
+				})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			}()
+		}
+		wg.Wait()
+		path, err := connectionsConfigFile()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		conf, err := readConnectionConf(path)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(conf.Connection.Default).To(gomega.Equal("50"))
 	})
 
 	Context("GetConnection/Farm", func() {

--- a/pkg/config/connections_test.go
+++ b/pkg/config/connections_test.go
@@ -32,18 +32,22 @@ var _ = Describe("Connections conf", func() {
 	})
 
 	It("read non existent file", func() {
-		conf, path, err := readConnectionConf()
+		path, err := connectionsConfigFile()
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(path).To(gomega.Equal(connectionsConfFile))
+		conf, err := readConnectionConf(path)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(conf).To(gomega.Equal(&ConnectionsFile{}))
 	})
 
 	It("read empty file", func() {
 		err := os.WriteFile(connectionsConfFile, []byte("{}"), os.ModePerm)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		conf, path, err := readConnectionConf()
+		path, err := connectionsConfigFile()
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(path).To(gomega.Equal(connectionsConfFile))
+		conf, err := readConnectionConf(path)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(conf).To(gomega.Equal(&ConnectionsFile{}))
 	})
 
@@ -61,9 +65,11 @@ var _ = Describe("Connections conf", func() {
 		}}
 		err := writeConnectionConf(connectionsConfFile, orgConf)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		conf, path, err := readConnectionConf()
+		path, err := connectionsConfigFile()
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(path).To(gomega.Equal(connectionsConfFile))
+		conf, err := readConnectionConf(path)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(conf).To(gomega.Equal(orgConf))
 	})
 


### PR DESCRIPTION
Add a lock to EditConnectionConfig to make it race free for parallel
modification. It is possible that several podman system connection
commands are called simultaneously so we should read/file in a consistent
way to ensure no modifications are "silently dropped".

A test is added that reliably fails without the lock.
