### PR TITLE
Bump golint to v1.56.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ vendor:
 .PHONY: install.tools
 install.tools: build/golangci-lint .install.md2man
 
-build/golangci-lint: VERSION=v1.53.3
+build/golangci-lint: VERSION=v1.56.2
 build/golangci-lint:
 	curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/$(VERSION)/install.sh | sh -s -- -b ./build $(VERSION)
 


### PR DESCRIPTION
Bumping the golint version to the version c/image
uses to see if we can avoid errros for the dance.

[NO NEW TESTS NEEDED]
Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
