### PR TITLE
github: bump go version for lint to 1.22

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 2
     - uses: actions/setup-go@v5
       with:
-        go-version: 1.19
+        go-version: 1.22
     - name: install deps
       run: |
         sudo apt-get -qq update


### PR DESCRIPTION
1.19 is eol and likely no longer works to compile new code thus failing all lints jobs that uses go 1.20 or newer features.

To fix that lets update to the latest stable version go 1.22.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
