### PR TITLE
lint: enable ginkgolinter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,7 +41,6 @@ linters:
     - errorlint
     - exhaustive
     - exhaustivestruct
-    - ginkgolinter
     - gochecknoglobals
     - goerr113
     - gomnd

--- a/libnetwork/cni/config_test.go
+++ b/libnetwork/cni/config_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Config", func() {
 	Context("basic network config tests", func() {
 		It("check default network config exists", func() {
 			networks, err := libpodNet.NetworkList()
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(1))
 			Expect(networks[0].Name).To(Equal("podman"))
 			Expect(networks[0].Driver).To(Equal("bridge"))
@@ -75,7 +75,7 @@ var _ = Describe("Config", func() {
 			now := time.Now().Add(-500 * time.Millisecond)
 			network := types.Network{}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			path := filepath.Join(cniConfDir, network1.Name+".conflist")
 			Expect(path).To(BeARegularFile())
@@ -96,29 +96,29 @@ var _ = Describe("Config", func() {
 
 			// inspect by name
 			network2, err := libpodNet.NetworkInspect(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network2).To(Equal(network1))
 
 			// inspect by ID
 			network2, err = libpodNet.NetworkInspect(network1.ID)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network2).To(Equal(network1))
 
 			// inspect by partial ID
 			network2, err = libpodNet.NetworkInspect(network1.ID[:10])
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network2).To(Equal(network1))
 
 			// create a new interface to force a config load from disk
 			libpodNet, err = getNetworkInterface(cniConfDir)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			network2, err = libpodNet.NetworkInspect(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network2).To(Equal(network1))
 
 			err = libpodNet.NetworkRemove(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(path).ToNot(BeARegularFile())
 
 			_, err = libpodNet.NetworkInspect(network1.Name)
@@ -133,13 +133,13 @@ var _ = Describe("Config", func() {
 
 			network := types.Network{}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.Subnets).To(HaveLen(1))
 
 			network = types.Network{}
 			network2, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network2.Name).ToNot(Equal(network1.Name))
 			Expect(network2.ID).ToNot(Equal(network1.ID))
 			Expect(network2.NetworkInterface).ToNot(Equal(network1.NetworkInterface))
@@ -150,7 +150,7 @@ var _ = Describe("Config", func() {
 		It("fail when creating two networks with the same name", func() {
 			network := types.Network{}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.Subnets).To(HaveLen(1))
 
@@ -162,13 +162,13 @@ var _ = Describe("Config", func() {
 		It("return the same network when creating two networks with the same name and ignore", func() {
 			network := types.Network{}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.Subnets).To(HaveLen(1))
 
 			network = types.Network{Name: network1.Name}
 			network2, err := libpodNet.NetworkCreate(network, &types.NetworkCreateOptions{IgnoreIfExists: true})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network2).To(Equal(network1))
 		})
 
@@ -185,7 +185,7 @@ var _ = Describe("Config", func() {
 		It("create bridge config", func() {
 			network := types.Network{Driver: "bridge"}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(filepath.Join(cniConfDir, network1.Name+".conflist")).To(BeARegularFile())
 			Expect(network1.ID).ToNot(BeEmpty())
@@ -211,7 +211,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(filepath.Join(cniConfDir, network1.Name+".conflist")).To(BeARegularFile())
 			Expect(network1.ID).ToNot(BeEmpty())
@@ -238,19 +238,19 @@ var _ = Describe("Config", func() {
 				DNSEnabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.DNSEnabled).To(BeFalse())
 			Expect(network1.IPAMOptions).ToNot(BeEmpty())
 			Expect(network1.IPAMOptions).To(HaveKeyWithValue("driver", "none"))
-			Expect(network1.Subnets).To(HaveLen(0))
+			Expect(network1.Subnets).To(BeEmpty())
 
 			// reload configs from disk
 			libpodNet, err = getNetworkInterface(cniConfDir)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			network2, err := libpodNet.NetworkInspect(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network2).To(Equal(network1))
 		})
 
@@ -279,18 +279,18 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.IPAMOptions).ToNot(BeEmpty())
 			Expect(network1.IPAMOptions).To(HaveKeyWithValue("driver", "dhcp"))
-			Expect(network1.Subnets).To(HaveLen(0))
+			Expect(network1.Subnets).To(BeEmpty())
 
 			// reload configs from disk
 			libpodNet, err = getNetworkInterface(cniConfDir)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			network2, err := libpodNet.NetworkInspect(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network2).To(Equal(network1))
 		})
 
@@ -317,7 +317,7 @@ var _ = Describe("Config", func() {
 				NetworkInterface: "cni-podman2",
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).To(Equal("cni-podman2"))
@@ -331,7 +331,7 @@ var _ = Describe("Config", func() {
 		It("create macvlan config", func() {
 			network := types.Network{Driver: "macvlan"}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(filepath.Join(cniConfDir, network1.Name+".conflist")).To(BeARegularFile())
 			Expect(network1.ID).ToNot(BeEmpty())
@@ -340,7 +340,7 @@ var _ = Describe("Config", func() {
 			Expect(network1.Options).To(BeEmpty())
 			Expect(network1.IPAMOptions).ToNot(BeEmpty())
 			Expect(network1.IPAMOptions).To(HaveKeyWithValue("driver", "dhcp"))
-			Expect(network1.Subnets).To(HaveLen(0))
+			Expect(network1.Subnets).To(BeEmpty())
 			Expect(network1.DNSEnabled).To(BeFalse())
 			Expect(network1.Internal).To(BeFalse())
 		})
@@ -351,7 +351,7 @@ var _ = Describe("Config", func() {
 				NetworkInterface: "lo",
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			path := filepath.Join(cniConfDir, network1.Name+".conflist")
 			Expect(path).To(BeARegularFile())
@@ -359,7 +359,7 @@ var _ = Describe("Config", func() {
 			Expect(network1.Driver).To(Equal("macvlan"))
 			Expect(network1.Labels).To(BeEmpty())
 			Expect(network1.Options).To(BeEmpty())
-			Expect(network1.Subnets).To(HaveLen(0))
+			Expect(network1.Subnets).To(BeEmpty())
 			Expect(network1.DNSEnabled).To(BeFalse())
 			Expect(network1.Internal).To(BeFalse())
 			Expect(network1.IPAMOptions).To(HaveKeyWithValue("driver", "dhcp"))
@@ -378,7 +378,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			path := filepath.Join(cniConfDir, network1.Name+".conflist")
 			Expect(path).To(BeARegularFile())
@@ -407,7 +407,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			path := filepath.Join(cniConfDir, network1.Name+".conflist")
 			Expect(path).To(BeARegularFile())
@@ -430,7 +430,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			path := filepath.Join(cniConfDir, network1.Name+".conflist")
 			Expect(path).To(BeARegularFile())
@@ -457,7 +457,7 @@ var _ = Describe("Config", func() {
 					},
 				}
 				network1, err := libpodNet.NetworkCreate(network, nil)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(network1.Name).ToNot(BeEmpty())
 				path := filepath.Join(cniConfDir, network1.Name+".conflist")
 				Expect(path).To(BeARegularFile())
@@ -503,7 +503,7 @@ var _ = Describe("Config", func() {
 			}
 			net1, err := libpodNet.NetworkCreate(network, nil)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(net1.Internal).To(Equal(true))
+			Expect(net1.Internal).To(BeTrue())
 			path := filepath.Join(cniConfDir, net1.Name+".conflist")
 			Expect(path).To(BeARegularFile())
 			grepNotFile(path, `"0.0.0.0/0"`)
@@ -529,17 +529,17 @@ var _ = Describe("Config", func() {
 					},
 				}
 				network1, err := libpodNet.NetworkCreate(network, nil)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(network1.Driver).To(Equal(driver))
 				Expect(network1.IPAMOptions).To(HaveKeyWithValue("driver", "none"))
-				Expect(network1.Subnets).To(HaveLen(0))
+				Expect(network1.Subnets).To(BeEmpty())
 
 				// reload configs from disk
 				libpodNet, err = getNetworkInterface(cniConfDir)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				network2, err := libpodNet.NetworkInspect(network1.Name)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(network2).To(Equal(network1))
 			})
 		}
@@ -553,7 +553,7 @@ var _ = Describe("Config", func() {
 					},
 				}
 				network1, err := libpodNet.NetworkCreate(network, nil)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(network1.Name).ToNot(BeEmpty())
 				path := filepath.Join(cniConfDir, network1.Name+".conflist")
 				Expect(path).To(BeARegularFile())
@@ -565,10 +565,10 @@ var _ = Describe("Config", func() {
 
 				// reload configs from disk
 				libpodNet, err = getNetworkInterface(cniConfDir)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				network2, err := libpodNet.NetworkInspect(network1.Name)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(network2).To(Equal(network1))
 			}
 		})
@@ -596,7 +596,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -618,7 +618,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -631,10 +631,10 @@ var _ = Describe("Config", func() {
 
 			// reload configs from disk
 			libpodNet, err = getNetworkInterface(cniConfDir)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			// check the networks are identical
 			network2, err := libpodNet.NetworkInspect(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1).To(Equal(network2))
 		})
 
@@ -644,7 +644,7 @@ var _ = Describe("Config", func() {
 				IPv6Enabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -670,7 +670,7 @@ var _ = Describe("Config", func() {
 				IPv6Enabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -696,7 +696,7 @@ var _ = Describe("Config", func() {
 				IPv6Enabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -724,7 +724,7 @@ var _ = Describe("Config", func() {
 				IPv6Enabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -752,7 +752,7 @@ var _ = Describe("Config", func() {
 				IPv6Enabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -781,7 +781,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -821,7 +821,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -832,7 +832,7 @@ var _ = Describe("Config", func() {
 			Expect(network1.Subnets[0].LeaseRange.StartIP.String()).To(Equal(startIP))
 
 			err = libpodNet.NetworkRemove(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			endIP := "10.0.0.30"
 			network = types.Network{
@@ -844,7 +844,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err = libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(filepath.Join(cniConfDir, network1.Name+".conflist")).To(BeARegularFile())
 			Expect(network1.ID).ToNot(BeEmpty())
@@ -856,7 +856,7 @@ var _ = Describe("Config", func() {
 			Expect(network1.Subnets[0].LeaseRange.EndIP.String()).To(Equal(endIP))
 
 			err = libpodNet.NetworkRemove(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			network = types.Network{
 				Driver: "bridge",
@@ -868,7 +868,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err = libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -881,10 +881,10 @@ var _ = Describe("Config", func() {
 
 			// create a new interface to force a config load from disk
 			libpodNet, err = getNetworkInterface(cniConfDir)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			network1, err = libpodNet.NetworkInspect(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -944,7 +944,7 @@ var _ = Describe("Config", func() {
 				Name: name,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).To(Equal(name))
 			Expect(network1.NetworkInterface).ToNot(Equal(name))
 			Expect(network1.Driver).To(Equal("bridge"))
@@ -965,7 +965,7 @@ var _ = Describe("Config", func() {
 				Name: name,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).To(Equal(name))
 			Expect(network1.NetworkInterface).ToNot(Equal(name))
 			Expect(network1.Driver).To(Equal("bridge"))
@@ -986,7 +986,7 @@ var _ = Describe("Config", func() {
 				NetworkInterface: name,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(Equal(name))
 			Expect(network1.NetworkInterface).To(Equal(name))
 			Expect(network1.Driver).To(Equal("bridge"))
@@ -1029,7 +1029,7 @@ var _ = Describe("Config", func() {
 				DNSEnabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.DNSEnabled).To(BeTrue())
 			path := filepath.Join(cniConfDir, network1.Name+".conflist")
@@ -1043,7 +1043,7 @@ var _ = Describe("Config", func() {
 				Internal: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.Subnets).To(HaveLen(1))
 			Expect(network1.Subnets[0].Subnet.String()).ToNot(BeEmpty())
@@ -1061,7 +1061,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.Labels).ToNot(BeNil())
 			Expect(network1.Labels).To(ContainElement("value"))
@@ -1074,7 +1074,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.Options).ToNot(BeNil())
 			path := filepath.Join(cniConfDir, network1.Name+".conflist")
@@ -1110,7 +1110,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.Options).ToNot(BeNil())
 			path := filepath.Join(cniConfDir, network1.Name+".conflist")
@@ -1148,7 +1148,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("macvlan"))
 			Expect(network1.Options).ToNot(BeNil())
 			path := filepath.Join(cniConfDir, network1.Name+".conflist")
@@ -1164,7 +1164,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.Options).ToNot(BeNil())
 			path := filepath.Join(cniConfDir, network1.Name+".conflist")
@@ -1218,7 +1218,7 @@ var _ = Describe("Config", func() {
 				DNSEnabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.Subnets).To(HaveLen(1))
 			Expect(network1.Subnets[0].Subnet.String()).ToNot(BeEmpty())
@@ -1233,11 +1233,11 @@ var _ = Describe("Config", func() {
 		It("network inspect partial ID", func() {
 			network := types.Network{Name: "net4"}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.ID).To(Equal("b44b7426c006839e7fe6f15d1faf64db58079d5233cba09b43be2257c1652cf5"))
 			network = types.Network{Name: "net5"}
 			network1, err = libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.ID).To(Equal("b67e86fb039828ad686aa13667975b9e51f192eb617044faf06cded9d31602af"))
 
 			// Note ID is the sha256 from the name
@@ -1250,7 +1250,7 @@ var _ = Describe("Config", func() {
 		It("network create two with same name", func() {
 			network := types.Network{Name: "net"}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).To(Equal("net"))
 			network = types.Network{Name: "net"}
 			_, err = libpodNet.NetworkCreate(network, nil)
@@ -1264,7 +1264,7 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(Equal("default network podman cannot be removed"))
 
 			network, err := libpodNet.NetworkInspect("podman")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			err = libpodNet.NetworkRemove(network.ID)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("default network podman cannot be removed"))
@@ -1277,7 +1277,7 @@ var _ = Describe("Config", func() {
 			n2, _ := types.ParseCIDR(subnet2)
 			network := types.Network{Subnets: []types.Subnet{{Subnet: n}, {Subnet: n2}}}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Subnets).To(HaveLen(2))
 			network = types.Network{Subnets: []types.Subnet{{Subnet: n}}}
 			_, err = libpodNet.NetworkCreate(network, nil)
@@ -1361,7 +1361,7 @@ var _ = Describe("Config", func() {
 		It("load networks from disk", func() {
 			logrus.SetLevel(logrus.WarnLevel)
 			nets, err := libpodNet.NetworkList()
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(nets).To(HaveLen(numberOfConfigFiles))
 			// test the we do not show logrus warnings/errors
 			logString := logBuffer.String()
@@ -1371,7 +1371,7 @@ var _ = Describe("Config", func() {
 		It("load networks from disk with log level debug", func() {
 			logrus.SetLevel(logrus.DebugLevel)
 			nets, err := libpodNet.NetworkList()
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(nets).To(HaveLen(numberOfConfigFiles))
 			// check for the unsupported ipam plugin message
 			logString := logBuffer.String()
@@ -1381,27 +1381,27 @@ var _ = Describe("Config", func() {
 
 		It("change network struct fields should not affect network struct in the backend", func() {
 			nets, err := libpodNet.NetworkList()
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(nets).To(HaveLen(numberOfConfigFiles))
 
 			nets[0].Name = "myname"
 			nets, err = libpodNet.NetworkList()
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(nets).To(HaveLen(numberOfConfigFiles))
 			Expect(nets).ToNot(ContainElement(HaveNetworkName("myname")))
 
 			network, err := libpodNet.NetworkInspect("bridge")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			network.NetworkInterface = "abc"
 
 			network, err = libpodNet.NetworkInspect("bridge")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.NetworkInterface).ToNot(Equal("abc"))
 		})
 
 		It("bridge network", func() {
 			network, err := libpodNet.NetworkInspect("bridge")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("bridge"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.NetworkInterface).To(Equal("cni-podman9"))
@@ -1417,19 +1417,19 @@ var _ = Describe("Config", func() {
 
 		It("macvlan network", func() {
 			network, err := libpodNet.NetworkInspect("macvlan")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("macvlan"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.NetworkInterface).To(Equal("lo"))
 			Expect(network.Driver).To(Equal("macvlan"))
-			Expect(network.Subnets).To(HaveLen(0))
+			Expect(network.Subnets).To(BeEmpty())
 			// DHCP
 			Expect(network.IPAMOptions).To(HaveKeyWithValue("driver", "dhcp"))
 		})
 
 		It("internal network", func() {
 			network, err := libpodNet.NetworkInspect("internal")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("internal"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.NetworkInterface).To(Equal("cni-podman8"))
@@ -1442,7 +1442,7 @@ var _ = Describe("Config", func() {
 
 		It("bridge network with mtu", func() {
 			network, err := libpodNet.NetworkInspect("mtu")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("mtu"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.NetworkInterface).To(Equal("cni-podman13"))
@@ -1457,12 +1457,12 @@ var _ = Describe("Config", func() {
 
 		It("macvlan network with mtu", func() {
 			network, err := libpodNet.NetworkInspect("macvlan_mtu")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("macvlan_mtu"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.NetworkInterface).To(Equal("lo"))
 			Expect(network.Driver).To(Equal("macvlan"))
-			Expect(network.Subnets).To(HaveLen(0))
+			Expect(network.Subnets).To(BeEmpty())
 			Expect(network.Internal).To(BeFalse())
 			Expect(network.Options).To(HaveLen(1))
 			Expect(network.Options).To(HaveKeyWithValue("mtu", "1300"))
@@ -1472,7 +1472,7 @@ var _ = Describe("Config", func() {
 
 		It("bridge network with vlan", func() {
 			network, err := libpodNet.NetworkInspect("vlan")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("vlan"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.NetworkInterface).To(Equal("cni-podman14"))
@@ -1484,7 +1484,7 @@ var _ = Describe("Config", func() {
 
 		It("bridge network with labels", func() {
 			network, err := libpodNet.NetworkInspect("label")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("label"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.NetworkInterface).To(Equal("cni-podman15"))
@@ -1496,7 +1496,7 @@ var _ = Describe("Config", func() {
 
 		It("dual stack network", func() {
 			network, err := libpodNet.NetworkInspect("dualstack")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("dualstack"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.NetworkInterface).To(Equal("cni-podman21"))
@@ -1513,37 +1513,37 @@ var _ = Describe("Config", func() {
 
 		It("ipam static network", func() {
 			network, err := libpodNet.NetworkInspect("ipam-static")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("ipam-static"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.Driver).To(Equal("bridge"))
-			Expect(network.Subnets).To(HaveLen(0))
+			Expect(network.Subnets).To(BeEmpty())
 			Expect(network.IPAMOptions).To(HaveKeyWithValue("driver", "static"))
 		})
 
 		It("ipam none network", func() {
 			network, err := libpodNet.NetworkInspect("ipam-none")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("ipam-none"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.Driver).To(Equal("bridge"))
-			Expect(network.Subnets).To(HaveLen(0))
+			Expect(network.Subnets).To(BeEmpty())
 			Expect(network.IPAMOptions).To(HaveKeyWithValue("driver", "none"))
 		})
 
 		It("ipam empty network", func() {
 			network, err := libpodNet.NetworkInspect("ipam-empty")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("ipam-empty"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.Driver).To(Equal("bridge"))
-			Expect(network.Subnets).To(HaveLen(0))
+			Expect(network.Subnets).To(BeEmpty())
 			Expect(network.IPAMOptions).To(HaveKeyWithValue("driver", "none"))
 		})
 
 		It("bridge with isolate option", func() {
 			network, err := libpodNet.NetworkInspect("isolate")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("isolate"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.Driver).To(Equal("bridge"))
@@ -1555,10 +1555,10 @@ var _ = Describe("Config", func() {
 				"name": {"internal", "bridge"},
 			}
 			filterFuncs, err := util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(2))
 			Expect(networks).To(ConsistOf(HaveNetworkName("internal"), HaveNetworkName("bridge")))
 		})
@@ -1568,10 +1568,10 @@ var _ = Describe("Config", func() {
 				"name": {"inte", "bri"},
 			}
 			filterFuncs, err := util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(2))
 			Expect(networks).To(ConsistOf(HaveNetworkName("internal"), HaveNetworkName("bridge")))
 		})
@@ -1581,10 +1581,10 @@ var _ = Describe("Config", func() {
 				"id": {"3bed2cb3a3acf7b6a8ef408420cc682d5520e26976d354254f528c965612054f", "17f29b073143d8cd97b5bbe492bdeffec1c5fee55cc1fe2112c8b9335f8b6121"},
 			}
 			filterFuncs, err := util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(2))
 			Expect(networks).To(ConsistOf(HaveNetworkName("internal"), HaveNetworkName("bridge")))
 		})
@@ -1594,10 +1594,10 @@ var _ = Describe("Config", func() {
 				"id": {"3bed2cb3a3acf7b6a8ef408420cc682d5520e26976d354254f528c965612054f", "17f29b073143d8cd97b5bbe492bdeffec1c5fee55cc1fe2112c8b9335f8b6121"},
 			}
 			filterFuncs, err := util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(2))
 			Expect(networks).To(ConsistOf(HaveNetworkName("internal"), HaveNetworkName("bridge")))
 		})
@@ -1607,10 +1607,10 @@ var _ = Describe("Config", func() {
 				"id": {"3bed2cb3a3acf7b6a8ef408420", "17f29b073143d8cd97b5bbe492bde"},
 			}
 			filterFuncs, err := util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(2))
 			Expect(networks).To(ConsistOf(HaveNetworkName("internal"), HaveNetworkName("bridge")))
 		})
@@ -1620,10 +1620,10 @@ var _ = Describe("Config", func() {
 				"driver": {"bridge", "macvlan"},
 			}
 			filterFuncs, err := util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(numberOfConfigFiles))
 			Expect(networks).To(ConsistOf(HaveNetworkName("internal"), HaveNetworkName("bridge"),
 				HaveNetworkName("mtu"), HaveNetworkName("vlan"), HaveNetworkName("podman"),
@@ -1637,10 +1637,10 @@ var _ = Describe("Config", func() {
 				"label": {"mykey"},
 			}
 			filterFuncs, err := util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(1))
 			Expect(networks).To(ConsistOf(HaveNetworkName("label")))
 
@@ -1648,10 +1648,10 @@ var _ = Describe("Config", func() {
 				"label": {"mykey=value"},
 			}
 			filterFuncs, err = util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err = libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(1))
 			Expect(networks).To(ConsistOf(HaveNetworkName("label")))
 		})
@@ -1662,11 +1662,11 @@ var _ = Describe("Config", func() {
 				"label":  {"mykey"},
 			}
 			filterFuncs, err := util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(filterFuncs).To(HaveLen(2))
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(1))
 			Expect(networks).To(ConsistOf(HaveNetworkName("label")))
 
@@ -1675,11 +1675,11 @@ var _ = Describe("Config", func() {
 				"label":  {"mykey"},
 			}
 			filterFuncs, err = util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err = libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
-			Expect(networks).To(HaveLen(0))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(networks).To(BeEmpty())
 		})
 
 		It("create bridge network with used interface name", func() {
@@ -1714,7 +1714,7 @@ var _ = Describe("Config", func() {
 
 		It("load invalid networks from disk", func() {
 			nets, err := libpodNet.NetworkList()
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(nets).To(HaveLen(2))
 			logString := logBuffer.String()
 			Expect(logString).To(ContainSubstring("noname.conflist: error parsing configuration list: no name"))
@@ -1737,7 +1737,7 @@ func grepNotFile(path, match string) {
 
 func grepFile(not bool, path, match string) {
 	data, err := os.ReadFile(path)
-	ExpectWithOffset(1, err).To(BeNil())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	matcher := ContainSubstring(match)
 	if not {
 		matcher = Not(matcher)

--- a/libnetwork/cni/run_test.go
+++ b/libnetwork/cni/run_test.go
@@ -51,18 +51,18 @@ var _ = Describe("run CNI", func() {
 		_ = netNSTest.Do(func(_ ns.NetNS) error {
 			defer GinkgoRecover()
 			err := os.MkdirAll(cniVarDir, 0o755)
-			Expect(err).To(BeNil(), "Failed to create cniVarDir")
+			Expect(err).ToNot(HaveOccurred(), "Failed to create cniVarDir")
 			err = unix.Unshare(unix.CLONE_NEWNS)
-			Expect(err).To(BeNil(), "Failed to create new mounts")
+			Expect(err).ToNot(HaveOccurred(), "Failed to create new mounts")
 			err = unix.Mount("tmpfs", cniVarDir, "tmpfs", unix.MS_NOEXEC|unix.MS_NOSUID|unix.MS_NODEV, "")
-			Expect(err).To(BeNil(), "Failed to mount tmpfs for cniVarDir")
+			Expect(err).ToNot(HaveOccurred(), "Failed to mount tmpfs for cniVarDir")
 			defer unix.Unmount(cniVarDir, 0) //nolint:errcheck
 
 			// we have to setup the loopback adapter in this netns to use port forwarding
 			link, err := netlink.LinkByName("lo")
-			Expect(err).To(BeNil(), "Failed to get loopback adapter")
+			Expect(err).ToNot(HaveOccurred(), "Failed to get loopback adapter")
 			err = netlink.LinkSetUp(link)
-			Expect(err).To(BeNil(), "Failed to set loopback adapter up")
+			Expect(err).ToNot(HaveOccurred(), "Failed to set loopback adapter up")
 			run()
 			return nil
 		})
@@ -129,7 +129,7 @@ var _ = Describe("run CNI", func() {
 					},
 				}
 				res, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(HaveLen(1))
 				Expect(res).To(HaveKey(defNet))
 				Expect(res[defNet].Interfaces).To(HaveKey(intName))
@@ -142,10 +142,10 @@ var _ = Describe("run CNI", func() {
 
 				// reload the interface so the networks are reload from disk
 				libpodNet, err := getNetworkInterface(cniConfDir)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				err = libpodNet.Teardown(netNSContainer.Path(), types.TeardownOptions(setupOpts))
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
@@ -166,7 +166,7 @@ var _ = Describe("run CNI", func() {
 					},
 				}
 				res, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(HaveLen(1))
 				Expect(res).To(HaveKey(defNet))
 				Expect(res[defNet].Interfaces).To(HaveKey(intName))
@@ -178,7 +178,7 @@ var _ = Describe("run CNI", func() {
 				Expect(res[defNet].DNSSearchDomains).To(BeEmpty())
 
 				err = libpodNet.Teardown(netNSContainer.Path(), types.TeardownOptions(setupOpts))
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
@@ -205,7 +205,7 @@ var _ = Describe("run CNI", func() {
 						},
 					}
 					res, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(res).To(HaveLen(1))
 					Expect(res).To(HaveKey(defNet))
 					Expect(res[defNet].Interfaces).To(HaveKey(intName))
@@ -223,19 +223,19 @@ var _ = Describe("run CNI", func() {
 						runNetListener(&wg, protocol, "0.0.0.0", 5000, testdata)
 						return nil
 					})
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 
 					conn, err := net.Dial(protocol, "127.0.0.1:5000")
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					_, err = conn.Write([]byte(testdata))
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					conn.Close()
 
 					// wait for the listener to finish
 					wg.Wait()
 
 					err = libpodNet.Teardown(netNSContainer.Path(), types.TeardownOptions(setupOpts))
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 				})
 			})
 
@@ -259,7 +259,7 @@ var _ = Describe("run CNI", func() {
 						},
 					}
 					res, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(res).To(HaveLen(1))
 					Expect(res).To(HaveKey(defNet))
 					Expect(res[defNet].Interfaces).To(HaveKey(intName))
@@ -283,12 +283,12 @@ var _ = Describe("run CNI", func() {
 							runNetListener(&wg, protocol, containerIP, port-1, testdata)
 							return nil
 						})
-						Expect(err).To(BeNil())
+						Expect(err).ToNot(HaveOccurred())
 
 						conn, err := net.Dial(protocol, net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
-						Expect(err).To(BeNil())
+						Expect(err).ToNot(HaveOccurred())
 						_, err = conn.Write([]byte(testdata))
-						Expect(err).To(BeNil())
+						Expect(err).ToNot(HaveOccurred())
 						conn.Close()
 
 						// wait for the listener to finish
@@ -296,7 +296,7 @@ var _ = Describe("run CNI", func() {
 					}
 
 					err = libpodNet.Teardown(netNSContainer.Path(), types.TeardownOptions(setupOpts))
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 				})
 			})
 		}
@@ -320,7 +320,7 @@ var _ = Describe("run CNI", func() {
 					},
 				}
 				res, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(HaveLen(1))
 				Expect(res).To(HaveKey(defNet))
 				Expect(res[defNet].Interfaces).To(HaveKey(intName))
@@ -341,12 +341,12 @@ var _ = Describe("run CNI", func() {
 						runNetListener(&wg, protocol, "0.0.0.0", 5000, testdata)
 						return nil
 					})
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 
 					conn, err := net.Dial(protocol, "127.0.0.1:5000")
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					_, err = conn.Write([]byte(testdata))
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					conn.Close()
 
 					// wait for the listener to finish
@@ -354,7 +354,7 @@ var _ = Describe("run CNI", func() {
 				}
 
 				err = libpodNet.Teardown(netNSContainer.Path(), types.TeardownOptions(setupOpts))
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
@@ -362,7 +362,7 @@ var _ = Describe("run CNI", func() {
 			runTest(func() {
 				network := types.Network{}
 				network1, err := libpodNet.NetworkCreate(network, nil)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				intName1 := "eth0"
 				netName1 := network1.Name
@@ -381,7 +381,7 @@ var _ = Describe("run CNI", func() {
 				}
 
 				res, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(HaveLen(1))
 
 				Expect(res).To(HaveKey(netName1))
@@ -396,11 +396,11 @@ var _ = Describe("run CNI", func() {
 				err = netNSContainer.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 					i, err := net.InterfaceByName(intName1)
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal(intName1))
 					Expect(i.HardwareAddr).To(Equal(net.HardwareAddr(macInt1)))
 					addrs, err := i.Addrs()
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					subnet := &net.IPNet{
 						IP:   ipInt1,
 						Mask: net.CIDRMask(24, 32),
@@ -409,17 +409,17 @@ var _ = Describe("run CNI", func() {
 
 					// check loopback adapter
 					i, err = net.InterfaceByName("lo")
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal("lo"))
 					Expect(i.Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
 					Expect(i.Flags&net.FlagUp).To(Equal(net.FlagUp), "Loopback adapter should be up")
 					return nil
 				})
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				network = types.Network{}
 				network2, err := libpodNet.NetworkCreate(network, nil)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				intName2 := "eth1"
 				netName2 := network2.Name
@@ -431,7 +431,7 @@ var _ = Describe("run CNI", func() {
 				}
 
 				res, err = libpodNet.Setup(netNSContainer.Path(), setupOpts)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(HaveLen(1))
 
 				Expect(res).To(HaveKey(netName2))
@@ -446,11 +446,11 @@ var _ = Describe("run CNI", func() {
 				err = netNSContainer.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 					i, err := net.InterfaceByName(intName1)
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal(intName1))
 					Expect(i.HardwareAddr).To(Equal(net.HardwareAddr(macInt1)))
 					addrs, err := i.Addrs()
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					subnet := &net.IPNet{
 						IP:   ipInt1,
 						Mask: net.CIDRMask(24, 32),
@@ -458,11 +458,11 @@ var _ = Describe("run CNI", func() {
 					Expect(addrs).To(ContainElements(subnet))
 
 					i, err = net.InterfaceByName(intName2)
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal(intName2))
 					Expect(i.HardwareAddr).To(Equal(net.HardwareAddr(macInt2)))
 					addrs, err = i.Addrs()
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					subnet = &net.IPNet{
 						IP:   ipInt2,
 						Mask: net.CIDRMask(24, 32),
@@ -471,13 +471,13 @@ var _ = Describe("run CNI", func() {
 
 					// check loopback adapter
 					i, err = net.InterfaceByName("lo")
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal("lo"))
 					Expect(i.Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
 					Expect(i.Flags&net.FlagUp).To(Equal(net.FlagUp), "Loopback adapter should be up")
 					return nil
 				})
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				teatdownOpts := types.TeardownOptions{
 					NetworkOptions: types.NetworkOptions{
@@ -494,7 +494,7 @@ var _ = Describe("run CNI", func() {
 				}
 
 				err = libpodNet.Teardown(netNSContainer.Path(), teatdownOpts)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				logString := logBuffer.String()
 				Expect(logString).To(BeEmpty())
 
@@ -508,7 +508,7 @@ var _ = Describe("run CNI", func() {
 
 					// check that only the loopback adapter is left
 					ints, err := net.Interfaces()
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(ints).To(HaveLen(1))
 					Expect(ints[0].Name).To(Equal("lo"))
 					Expect(ints[0].Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
@@ -516,12 +516,12 @@ var _ = Describe("run CNI", func() {
 
 					return nil
 				})
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				err = libpodNet.NetworkRemove(netName1)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				err = libpodNet.NetworkRemove(netName2)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				// check that the interfaces are removed in the host ns
 				_, err = net.InterfaceByName(network1.NetworkInterface)
@@ -541,7 +541,7 @@ var _ = Describe("run CNI", func() {
 					},
 				}
 				network1, err := libpodNet.NetworkCreate(network, nil)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				network = types.Network{
 					Subnets: []types.Subnet{
@@ -549,7 +549,7 @@ var _ = Describe("run CNI", func() {
 					},
 				}
 				network2, err := libpodNet.NetworkCreate(network, nil)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				intName1 := "eth0"
 				intName2 := "eth1"
@@ -571,7 +571,7 @@ var _ = Describe("run CNI", func() {
 				}
 
 				res, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(HaveLen(2))
 
 				Expect(res).To(HaveKey(netName1))
@@ -598,11 +598,11 @@ var _ = Describe("run CNI", func() {
 				err = netNSContainer.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 					i, err := net.InterfaceByName(intName1)
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal(intName1))
 					Expect(i.HardwareAddr).To(Equal(net.HardwareAddr(macInt1)))
 					addrs, err := i.Addrs()
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					subnet := &net.IPNet{
 						IP:   ipInt1,
 						Mask: net.CIDRMask(24, 32),
@@ -610,11 +610,11 @@ var _ = Describe("run CNI", func() {
 					Expect(addrs).To(ContainElements(subnet))
 
 					i, err = net.InterfaceByName(intName2)
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal(intName2))
 					Expect(i.HardwareAddr).To(Equal(net.HardwareAddr(macInt2)))
 					addrs, err = i.Addrs()
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					subnet = &net.IPNet{
 						IP:   ipInt2,
 						Mask: net.CIDRMask(24, 32),
@@ -623,16 +623,16 @@ var _ = Describe("run CNI", func() {
 
 					// check loopback adapter
 					i, err = net.InterfaceByName("lo")
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal("lo"))
 					Expect(i.Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
 					Expect(i.Flags&net.FlagUp).To(Equal(net.FlagUp), "Loopback adapter should be up")
 					return nil
 				})
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				err = libpodNet.Teardown(netNSContainer.Path(), types.TeardownOptions(setupOpts))
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				logString := logBuffer.String()
 				Expect(logString).To(BeEmpty())
 
@@ -646,7 +646,7 @@ var _ = Describe("run CNI", func() {
 
 					// check that only the loopback adapter is left
 					ints, err := net.Interfaces()
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(ints).To(HaveLen(1))
 					Expect(ints[0].Name).To(Equal("lo"))
 					Expect(ints[0].Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
@@ -654,7 +654,7 @@ var _ = Describe("run CNI", func() {
 
 					return nil
 				})
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
@@ -672,7 +672,7 @@ var _ = Describe("run CNI", func() {
 					},
 				}
 				network1, err := libpodNet.NetworkCreate(network, nil)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				mac, _ := net.ParseMAC("40:15:2f:d8:42:36")
 				interfaceName := "eth0"
@@ -696,7 +696,7 @@ var _ = Describe("run CNI", func() {
 				}
 
 				res, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(HaveLen(1))
 				Expect(res).To(HaveKey(netName))
 				Expect(res[netName].Interfaces).To(HaveKey(interfaceName))
@@ -716,11 +716,11 @@ var _ = Describe("run CNI", func() {
 				err = netNSContainer.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 					i, err := net.InterfaceByName(interfaceName)
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal(interfaceName))
 					Expect(i.HardwareAddr).To(Equal(mac))
 					addrs, err := i.Addrs()
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					subnet1 := &net.IPNet{
 						IP:   ip1,
 						Mask: net.CIDRMask(24, 32),
@@ -733,16 +733,16 @@ var _ = Describe("run CNI", func() {
 
 					// check loopback adapter
 					i, err = net.InterfaceByName("lo")
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal("lo"))
 					Expect(i.Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
 					Expect(i.Flags&net.FlagUp).To(Equal(net.FlagUp), "Loopback adapter should be up")
 					return nil
 				})
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				err = libpodNet.Teardown(netNSContainer.Path(), types.TeardownOptions(setupOpts))
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				logString := logBuffer.String()
 				Expect(logString).To(BeEmpty())
 
@@ -754,7 +754,7 @@ var _ = Describe("run CNI", func() {
 
 					// check that only the loopback adapter is left
 					ints, err := net.Interfaces()
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(ints).To(HaveLen(1))
 					Expect(ints[0].Name).To(Equal("lo"))
 					Expect(ints[0].Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
@@ -762,7 +762,7 @@ var _ = Describe("run CNI", func() {
 
 					return nil
 				})
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
@@ -776,7 +776,7 @@ var _ = Describe("run CNI", func() {
 					},
 				}
 				network1, err := libpodNet.NetworkCreate(network, nil)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				netName := network1.Name
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
@@ -794,7 +794,7 @@ var _ = Describe("run CNI", func() {
 				defer os.Unsetenv("CNI_ARGS")
 
 				res, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(HaveLen(1))
 				Expect(res).To(HaveKey(netName))
 				Expect(res[netName].Interfaces).To(HaveKey(intName))
@@ -806,10 +806,10 @@ var _ = Describe("run CNI", func() {
 				err = netNSContainer.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 					i, err := net.InterfaceByName(intName)
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal(intName))
 					addrs, err := i.Addrs()
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					subnet := &net.IPNet{
 						IP:   net.ParseIP(ip),
 						Mask: net.CIDRMask(24, 32),
@@ -818,13 +818,13 @@ var _ = Describe("run CNI", func() {
 
 					// check loopback adapter
 					i, err = net.InterfaceByName("lo")
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal("lo"))
 					Expect(i.Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
 					Expect(i.Flags&net.FlagUp).To(Equal(net.FlagUp), "Loopback adapter should be up")
 					return nil
 				})
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
@@ -837,7 +837,7 @@ var _ = Describe("run CNI", func() {
 					DNSEnabled: true,
 				}
 				network1, err := libpodNet.NetworkCreate(network, nil)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				intName1 := "eth0"
 				netName1 := network1.Name
@@ -854,12 +854,12 @@ var _ = Describe("run CNI", func() {
 				}
 
 				res, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(HaveLen(1))
 
 				Expect(res).To(HaveKey(netName1))
 				Expect(res[netName1].Interfaces).To(HaveKey(intName1))
-				Expect(res[netName1].Interfaces[intName1].Subnets).To(HaveLen(0))
+				Expect(res[netName1].Interfaces[intName1].Subnets).To(BeEmpty())
 				macInt1 := res[netName1].Interfaces[intName1].MacAddress
 				Expect(macInt1).To(HaveLen(6))
 
@@ -867,11 +867,11 @@ var _ = Describe("run CNI", func() {
 				err = netNSContainer.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 					i, err := net.InterfaceByName(intName1)
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal(intName1))
 					Expect(i.HardwareAddr).To(Equal(net.HardwareAddr(macInt1)))
 					addrs, err := i.Addrs()
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					// we still have the ipv6 link local address
 					Expect(addrs).To(HaveLen(1))
 					addr, ok := addrs[0].(*net.IPNet)
@@ -881,16 +881,16 @@ var _ = Describe("run CNI", func() {
 
 					// check loopback adapter
 					i, err = net.InterfaceByName("lo")
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal("lo"))
 					Expect(i.Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
 					Expect(i.Flags&net.FlagUp).To(Equal(net.FlagUp), "Loopback adapter should be up")
 					return nil
 				})
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				err = libpodNet.Teardown(netNSContainer.Path(), types.TeardownOptions(setupOpts))
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				logString := logBuffer.String()
 				Expect(logString).To(BeEmpty())
 
@@ -902,7 +902,7 @@ var _ = Describe("run CNI", func() {
 
 					// check that only the loopback adapter is left
 					ints, err := net.Interfaces()
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(ints).To(HaveLen(1))
 					Expect(ints[0].Name).To(Equal("lo"))
 					Expect(ints[0].Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
@@ -910,7 +910,7 @@ var _ = Describe("run CNI", func() {
 
 					return nil
 				})
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -966,7 +966,7 @@ var _ = Describe("run CNI", func() {
 				}
 
 				network, err := libpodNet.NetworkInspect(netName)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(network.Name).To(Equal(netName))
 				Expect(network.DNSEnabled).To(BeTrue())
 				Expect(network.Subnets).To(HaveLen(2))
@@ -982,7 +982,7 @@ var _ = Describe("run CNI", func() {
 				// because this net has dns we should always teardown otherwise we leak a dnsmasq process
 				defer libpodNet.Teardown(netNSContainer.Path(), types.TeardownOptions(setupOpts)) //nolint:errcheck
 				res, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(HaveLen(1))
 				Expect(res).To(HaveKey(netName))
 				Expect(res[netName].Interfaces).To(HaveKey(interfaceName))
@@ -1000,10 +1000,10 @@ var _ = Describe("run CNI", func() {
 				err = netNSContainer.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 					i, err := net.InterfaceByName(interfaceName)
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal(interfaceName))
 					addrs, err := i.Addrs()
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					subnet1 := &net.IPNet{
 						IP:   ip1,
 						Mask: net.CIDRMask(64, 128),
@@ -1016,17 +1016,17 @@ var _ = Describe("run CNI", func() {
 
 					// check loopback adapter
 					i, err = net.InterfaceByName("lo")
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal("lo"))
 					Expect(i.Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
 					Expect(i.Flags&net.FlagUp).To(Equal(net.FlagUp), "Loopback adapter should be up")
 
 					return nil
 				})
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				err = libpodNet.Teardown(netNSContainer.Path(), types.TeardownOptions(setupOpts))
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				logString := logBuffer.String()
 				Expect(logString).To(BeEmpty())
 
@@ -1038,7 +1038,7 @@ var _ = Describe("run CNI", func() {
 
 					// check that only the loopback adapter is left
 					ints, err := net.Interfaces()
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(ints).To(HaveLen(1))
 					Expect(ints[0].Name).To(Equal("lo"))
 					Expect(ints[0].Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
@@ -1046,7 +1046,7 @@ var _ = Describe("run CNI", func() {
 
 					return nil
 				})
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
@@ -1195,7 +1195,7 @@ var _ = Describe("run CNI", func() {
 					},
 				}
 				network1, err := libpodNet.NetworkCreate(network, nil)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				subnet2, _ := types.ParseCIDR("192.168.1.0/31")
 				network = types.Network{
@@ -1204,7 +1204,7 @@ var _ = Describe("run CNI", func() {
 					},
 				}
 				network2, err := libpodNet.NetworkCreate(network, nil)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				intName1 := "eth0"
 				intName2 := "eth1"
@@ -1242,13 +1242,13 @@ var _ = Describe("run CNI", func() {
 
 					// check loopback adapter
 					i, err := net.InterfaceByName("lo")
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(i.Name).To(Equal("lo"))
 					Expect(i.Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
 					Expect(i.Flags&net.FlagUp).To(Equal(net.FlagUp), "Loopback adapter should be up")
 					return nil
 				})
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
@@ -1345,7 +1345,7 @@ var _ = Describe("run CNI", func() {
 			runTest(func() {
 				network := types.Network{}
 				network1, err := libpodNet.NetworkCreate(network, nil)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				interfaceName := "eth0"
 				netName := network1.Name
@@ -1362,7 +1362,7 @@ var _ = Describe("run CNI", func() {
 
 				// Most CNI plugins do not error on teardown when there is nothing to do.
 				err = libpodNet.Teardown(netNSContainer.Path(), teardownOpts)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				logString := logBuffer.String()
 				Expect(logString).To(ContainSubstring("Failed to load cached network config"))
 			})
@@ -1374,17 +1374,17 @@ func runNetListener(wg *sync.WaitGroup, protocol, ip string, port int, expectedD
 	switch protocol {
 	case "tcp":
 		ln, err := net.Listen(protocol, net.JoinHostPort(ip, strconv.Itoa(port)))
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		// make sure to read in a separate goroutine to not block
 		go func() {
 			defer GinkgoRecover()
 			defer wg.Done()
 			conn, err := ln.Accept()
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			err = conn.SetDeadline(time.Now().Add(1 * time.Second))
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			data, err := io.ReadAll(conn)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(string(data)).To(Equal(expectedData))
 			conn.Close()
 			ln.Close()
@@ -1394,15 +1394,15 @@ func runNetListener(wg *sync.WaitGroup, protocol, ip string, port int, expectedD
 			IP:   net.ParseIP(ip),
 			Port: port,
 		})
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		err = conn.SetDeadline(time.Now().Add(1 * time.Second))
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		go func() {
 			defer GinkgoRecover()
 			defer wg.Done()
 			data := make([]byte, len(expectedData))
 			i, err := conn.Read(data)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(i).To(Equal(len(expectedData)))
 			Expect(string(data)).To(Equal(expectedData))
 			conn.Close()

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Config", func() {
 	Context("basic network config tests", func() {
 		It("check default network config exists", func() {
 			networks, err := libpodNet.NetworkList()
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(1))
 			Expect(networks[0].Name).To(Equal("podman"))
 			Expect(networks[0].Driver).To(Equal("bridge"))
@@ -75,7 +75,7 @@ var _ = Describe("Config", func() {
 			now := time.Now().Add(-500 * time.Millisecond)
 			network := types.Network{}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			path := filepath.Join(networkConfDir, network1.Name+".json")
 			Expect(path).To(BeARegularFile())
@@ -96,29 +96,29 @@ var _ = Describe("Config", func() {
 
 			// inspect by name
 			network2, err := libpodNet.NetworkInspect(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			EqualNetwork(network2, network1)
 
 			// inspect by ID
 			network2, err = libpodNet.NetworkInspect(network1.ID)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			EqualNetwork(network2, network1)
 
 			// inspect by partial ID
 			network2, err = libpodNet.NetworkInspect(network1.ID[:10])
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			EqualNetwork(network2, network1)
 
 			// create a new interface to force a config load from disk
 			libpodNet, err = getNetworkInterface(networkConfDir)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			network2, err = libpodNet.NetworkInspect(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			EqualNetwork(network2, network1)
 
 			err = libpodNet.NetworkRemove(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(path).ToNot(BeARegularFile())
 
 			_, err = libpodNet.NetworkInspect(network1.Name)
@@ -129,13 +129,13 @@ var _ = Describe("Config", func() {
 		It("create two networks", func() {
 			network := types.Network{}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.Subnets).To(HaveLen(1))
 
 			network = types.Network{}
 			network2, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network2.Name).ToNot(Equal(network1.Name))
 			Expect(network2.ID).ToNot(Equal(network1.ID))
 			Expect(network2.NetworkInterface).ToNot(Equal(network1.NetworkInterface))
@@ -146,7 +146,7 @@ var _ = Describe("Config", func() {
 		It("fail when creating two networks with the same name", func() {
 			network := types.Network{}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.Subnets).To(HaveLen(1))
 
@@ -158,20 +158,20 @@ var _ = Describe("Config", func() {
 		It("return the same network when creating two networks with the same name and ignore", func() {
 			network := types.Network{}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.Subnets).To(HaveLen(1))
 
 			network = types.Network{Name: network1.Name}
 			network2, err := libpodNet.NetworkCreate(network, &types.NetworkCreateOptions{IgnoreIfExists: true})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			EqualNetwork(network2, network1)
 		})
 
 		It("create bridge config", func() {
 			network := types.Network{Driver: "bridge"}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(filepath.Join(networkConfDir, network1.Name+".json")).To(BeARegularFile())
 			Expect(network1.ID).ToNot(BeEmpty())
@@ -197,7 +197,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(filepath.Join(networkConfDir, network1.Name+".json")).To(BeARegularFile())
 			Expect(network1.ID).ToNot(BeEmpty())
@@ -221,7 +221,7 @@ var _ = Describe("Config", func() {
 				NetworkInterface: "podman2",
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).To(Equal("podman2"))
@@ -243,7 +243,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -265,7 +265,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -278,10 +278,10 @@ var _ = Describe("Config", func() {
 
 			// reload configs from disk
 			libpodNet, err = getNetworkInterface(networkConfDir)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			// check the networks are identical
 			network2, err := libpodNet.NetworkInspect(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			EqualNetwork(network2, network1)
 		})
 
@@ -291,7 +291,7 @@ var _ = Describe("Config", func() {
 				IPv6Enabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -317,7 +317,7 @@ var _ = Describe("Config", func() {
 				IPv6Enabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -343,7 +343,7 @@ var _ = Describe("Config", func() {
 				IPv6Enabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -371,7 +371,7 @@ var _ = Describe("Config", func() {
 				IPv6Enabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -399,7 +399,7 @@ var _ = Describe("Config", func() {
 				IPv6Enabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -428,7 +428,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -468,7 +468,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -479,7 +479,7 @@ var _ = Describe("Config", func() {
 			Expect(network1.Subnets[0].LeaseRange.StartIP.String()).To(Equal(startIP))
 
 			err = libpodNet.NetworkRemove(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			endIP := "10.0.0.10"
 			network = types.Network{
@@ -491,7 +491,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err = libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(filepath.Join(networkConfDir, network1.Name+".json")).To(BeARegularFile())
 			Expect(network1.ID).ToNot(BeEmpty())
@@ -503,7 +503,7 @@ var _ = Describe("Config", func() {
 			Expect(network1.Subnets[0].LeaseRange.EndIP.String()).To(Equal(endIP))
 
 			err = libpodNet.NetworkRemove(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			network = types.Network{
 				Driver: "bridge",
@@ -515,7 +515,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err = libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.NetworkInterface).ToNot(BeEmpty())
@@ -575,7 +575,7 @@ var _ = Describe("Config", func() {
 				Name: name,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).To(Equal(name))
 			Expect(network1.NetworkInterface).ToNot(Equal(name))
 			Expect(network1.Driver).To(Equal("bridge"))
@@ -608,7 +608,7 @@ var _ = Describe("Config", func() {
 				Name: name,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).To(Equal(name))
 			Expect(network1.NetworkInterface).ToNot(Equal(name))
 			Expect(network1.Driver).To(Equal("bridge"))
@@ -629,7 +629,7 @@ var _ = Describe("Config", func() {
 				NetworkInterface: name,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(Equal(name))
 			Expect(network1.NetworkInterface).To(Equal(name))
 			Expect(network1.Driver).To(Equal("bridge"))
@@ -660,7 +660,7 @@ var _ = Describe("Config", func() {
 				DNSEnabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.DNSEnabled).To(BeTrue())
 			path := filepath.Join(networkConfDir, network1.Name+".json")
@@ -674,7 +674,7 @@ var _ = Describe("Config", func() {
 				Internal: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.Subnets).To(HaveLen(1))
 			Expect(network1.Subnets[0].Subnet.String()).ToNot(BeEmpty())
@@ -698,12 +698,12 @@ var _ = Describe("Config", func() {
 				Name:              "test-network",
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.NetworkDNSServers).To(Equal([]string{"8.8.8.8", "3.3.3.3"}))
 			err = libpodNet.NetworkUpdate("test-network", types.NetworkUpdateOptions{AddDNSServers: []string{"8.8.8.8", "3.3.3.3", "7.7.7.7"}})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			testNetwork, err := libpodNet.NetworkInspect("test-network")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(testNetwork.NetworkDNSServers).To(Equal([]string{"8.8.8.8", "3.3.3.3", "7.7.7.7"}))
 			err = libpodNet.NetworkUpdate("test-network", types.NetworkUpdateOptions{AddDNSServers: []string{"fake"}})
 			Expect(err).To(HaveOccurred())
@@ -725,12 +725,12 @@ var _ = Describe("Config", func() {
 				Name:              "test-network",
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.NetworkDNSServers).To(Equal([]string{"8.8.8.8", "3.3.3.3"}))
 			err = libpodNet.NetworkUpdate("test-network", types.NetworkUpdateOptions{RemoveDNSServers: []string{"3.3.3.3"}})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			testNetwork, err := libpodNet.NetworkInspect("test-network")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(testNetwork.NetworkDNSServers).To(Equal([]string{"8.8.8.8"}))
 			err = libpodNet.NetworkUpdate("test-network", types.NetworkUpdateOptions{RemoveDNSServers: []string{"fake"}})
 			Expect(err).To(HaveOccurred())
@@ -752,12 +752,12 @@ var _ = Describe("Config", func() {
 				Name:              "test-network",
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.NetworkDNSServers).To(Equal([]string{"8.8.8.8", "3.3.3.3"}))
 			err = libpodNet.NetworkUpdate("test-network", types.NetworkUpdateOptions{RemoveDNSServers: []string{"3.3.3.3"}, AddDNSServers: []string{"7.7.7.7"}})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			testNetwork, err := libpodNet.NetworkInspect("test-network")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(testNetwork.NetworkDNSServers).To(Equal([]string{"8.8.8.8", "7.7.7.7"}))
 		})
 
@@ -767,7 +767,7 @@ var _ = Describe("Config", func() {
 				DNSEnabled:        true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.NetworkDNSServers).To(Equal([]string{"8.8.8.8", "3.3.3.3"}))
 		})
 
@@ -798,7 +798,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.Labels).ToNot(BeNil())
 			Expect(network1.Labels).To(ContainElement("value"))
@@ -811,7 +811,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.Options).ToNot(BeNil())
 			path := filepath.Join(networkConfDir, network1.Name+".json")
@@ -847,7 +847,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.Options).ToNot(BeNil())
 			path := filepath.Join(networkConfDir, network1.Name+".json")
@@ -884,7 +884,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.Options).ToNot(BeNil())
 			path := filepath.Join(networkConfDir, network1.Name+".json")
@@ -920,7 +920,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.Options).ToNot(BeNil())
 			path := filepath.Join(networkConfDir, network1.Name+".json")
@@ -956,14 +956,14 @@ var _ = Describe("Config", func() {
 			network1, err := libpodNet.NetworkCreate(network, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
-			Expect(network1.Internal).To(Equal(true))
-			Expect(network1.DNSEnabled).To(Equal(true))
+			Expect(network1.Internal).To(BeTrue())
+			Expect(network1.DNSEnabled).To(BeTrue())
 		})
 
 		It("network inspect partial ID", func() {
 			network := types.Network{Name: "net4"}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.ID).To(HaveLen(64))
 
 			network2, err := libpodNet.NetworkInspect(network1.ID[:10])
@@ -974,7 +974,7 @@ var _ = Describe("Config", func() {
 		It("network create two with same name", func() {
 			network := types.Network{Name: "net"}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).To(Equal("net"))
 			network = types.Network{Name: "net"}
 			_, err = libpodNet.NetworkCreate(network, nil)
@@ -988,7 +988,7 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(Equal("default network podman cannot be removed"))
 
 			network, err := libpodNet.NetworkInspect("podman")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			err = libpodNet.NetworkRemove(network.ID)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("default network podman cannot be removed"))
@@ -1001,7 +1001,7 @@ var _ = Describe("Config", func() {
 			n2, _ := types.ParseCIDR(subnet2)
 			network := types.Network{Subnets: []types.Subnet{{Subnet: n}, {Subnet: n2}}}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Subnets).To(HaveLen(2))
 			network = types.Network{Subnets: []types.Subnet{{Subnet: n}}}
 			_, err = libpodNet.NetworkCreate(network, nil)
@@ -1053,7 +1053,7 @@ var _ = Describe("Config", func() {
 			}
 			net1, err := libpodNet.NetworkCreate(network, nil)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(net1.Internal).To(Equal(true))
+			Expect(net1.Internal).To(BeTrue())
 		})
 
 		It("create macvlan config with subnet", func() {
@@ -1066,7 +1066,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			path := filepath.Join(networkConfDir, network1.Name+".json")
 			Expect(path).To(BeARegularFile())
@@ -1095,7 +1095,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())
 			Expect(network1.Driver).To(Equal("macvlan"))
@@ -1116,7 +1116,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			path := filepath.Join(networkConfDir, network1.Name+".json")
 			Expect(path).To(BeARegularFile())
@@ -1209,7 +1209,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.Options).To(HaveKeyWithValue("mode", "private"))
 		})
@@ -1261,7 +1261,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.Options).To(HaveKeyWithValue("mtu", "9000"))
 		})
@@ -1274,18 +1274,18 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.IPAMOptions).ToNot(BeEmpty())
 			Expect(network1.IPAMOptions).To(HaveKeyWithValue("driver", "none"))
-			Expect(network1.Subnets).To(HaveLen(0))
+			Expect(network1.Subnets).To(BeEmpty())
 
 			// reload configs from disk
 			libpodNet, err = getNetworkInterface(networkConfDir)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			network2, err := libpodNet.NetworkInspect(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			EqualNetwork(network2, network1)
 		})
 
@@ -1315,19 +1315,19 @@ var _ = Describe("Config", func() {
 				DNSEnabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("macvlan"))
 			Expect(network1.DNSEnabled).To(BeFalse())
 			Expect(network1.IPAMOptions).ToNot(BeEmpty())
 			Expect(network1.IPAMOptions).To(HaveKeyWithValue("driver", "none"))
-			Expect(network1.Subnets).To(HaveLen(0))
+			Expect(network1.Subnets).To(BeEmpty())
 
 			// reload configs from disk
 			libpodNet, err = getNetworkInterface(networkConfDir)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			network2, err := libpodNet.NetworkInspect(network1.Name)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			EqualNetwork(network2, network1)
 		})
 
@@ -1358,7 +1358,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			path := filepath.Join(networkConfDir, network1.Name+".json")
 			Expect(path).To(BeARegularFile())
@@ -1399,7 +1399,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.Options).To(HaveKeyWithValue("mode", "l2"))
 		})
@@ -1429,7 +1429,7 @@ var _ = Describe("Config", func() {
 					},
 				}
 				network1, err := libpodNet.NetworkCreate(network, nil)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(network1.Driver).To(Equal("bridge"))
 				Expect(network1.Options).ToNot(BeNil())
 				path := filepath.Join(networkConfDir, network1.Name+".json")
@@ -1446,7 +1446,7 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network1.Driver).To(Equal("bridge"))
 			Expect(network1.Options).ToNot(BeNil())
 			path := filepath.Join(networkConfDir, network1.Name+".json")
@@ -1478,7 +1478,7 @@ var _ = Describe("Config", func() {
 			},
 		}
 		network1, err := libpodNet.NetworkCreate(network, nil)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(network1.Name).ToNot(BeEmpty())
 		Expect(network1.Routes).To(HaveLen(1))
 		Expect(network1.Routes[0].Destination.String()).To(Equal(dest))
@@ -1497,7 +1497,7 @@ var _ = Describe("Config", func() {
 			},
 		}
 		network1, err := libpodNet.NetworkCreate(network, nil)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(network1.Name).ToNot(BeEmpty())
 		Expect(network1.Routes).To(HaveLen(1))
 		Expect(network1.Routes[0].Destination.String()).To(Equal(dest))
@@ -1522,7 +1522,7 @@ var _ = Describe("Config", func() {
 		}
 
 		network1, err := libpodNet.NetworkCreate(network, nil)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(network1.Name).ToNot(BeEmpty())
 		Expect(network1.Routes).To(HaveLen(1))
 		Expect(network1.Routes[0].Destination.String()).To(Equal(dest))
@@ -1541,7 +1541,7 @@ var _ = Describe("Config", func() {
 			},
 		}
 		network1, err := libpodNet.NetworkCreate(network, nil)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(network1.Name).ToNot(BeEmpty())
 		Expect(network1.Routes).To(HaveLen(1))
 		Expect(network1.Routes[0].Destination.String()).To(Equal(dest))
@@ -1560,7 +1560,7 @@ var _ = Describe("Config", func() {
 			},
 		}
 		network1, err := libpodNet.NetworkCreate(network, nil)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(network1.Name).ToNot(BeEmpty())
 		Expect(network1.Routes).To(HaveLen(1))
 		Expect(network1.Routes[0].Destination.String()).To(Equal(dest))
@@ -1584,7 +1584,7 @@ var _ = Describe("Config", func() {
 			},
 		}
 		network1, err := libpodNet.NetworkCreate(network, nil)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(network1.Name).ToNot(BeEmpty())
 		Expect(network1.Routes).To(HaveLen(1))
 		Expect(network1.Routes[0].Destination.String()).To(Equal(dest))
@@ -1758,7 +1758,7 @@ var _ = Describe("Config", func() {
 			},
 		}
 		network1, err := libpodNet.NetworkCreate(network, nil)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(network1.Options).To(HaveLen(1))
 		Expect(network1.Options["no_default_route"]).To(Equal("true"))
 	})
@@ -1771,7 +1771,7 @@ var _ = Describe("Config", func() {
 			},
 		}
 		network1, err := libpodNet.NetworkCreate(network, nil)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(network1.Options).To(HaveLen(1))
 		Expect(network1.Options["no_default_route"]).To(Equal("true"))
 	})
@@ -1789,7 +1789,7 @@ var _ = Describe("Config", func() {
 			},
 		}
 		network1, err := libpodNet.NetworkCreate(network, nil)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(network1.Options).To(HaveLen(1))
 		Expect(network1.Options["no_default_route"]).To(Equal("true"))
 	})
@@ -1857,7 +1857,7 @@ var _ = Describe("Config", func() {
 
 		It("load networks from disk", func() {
 			nets, err := libpodNet.NetworkList()
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(nets).To(HaveLen(9))
 			// test the we do not show logrus warnings/errors
 			logString := logBuffer.String()
@@ -1866,27 +1866,27 @@ var _ = Describe("Config", func() {
 
 		It("change network struct fields should not affect network struct in the backend", func() {
 			nets, err := libpodNet.NetworkList()
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(nets).To(HaveLen(9))
 
 			nets[0].Name = "myname"
 			nets, err = libpodNet.NetworkList()
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(nets).To(HaveLen(9))
 			Expect(nets).ToNot(ContainElement(HaveNetworkName("myname")))
 
 			network, err := libpodNet.NetworkInspect("bridge")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			network.NetworkInterface = "abc"
 
 			network, err = libpodNet.NetworkInspect("bridge")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.NetworkInterface).ToNot(Equal("abc"))
 		})
 
 		It("bridge network", func() {
 			network, err := libpodNet.NetworkInspect("bridge")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("bridge"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.NetworkInterface).To(Equal("podman9"))
@@ -1902,7 +1902,7 @@ var _ = Describe("Config", func() {
 
 		It("internal network", func() {
 			network, err := libpodNet.NetworkInspect("internal")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("internal"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.NetworkInterface).To(Equal("podman8"))
@@ -1915,7 +1915,7 @@ var _ = Describe("Config", func() {
 
 		It("bridge network with mtu", func() {
 			network, err := libpodNet.NetworkInspect("mtu")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("mtu"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.NetworkInterface).To(Equal("podman13"))
@@ -1930,7 +1930,7 @@ var _ = Describe("Config", func() {
 
 		It("bridge network with vlan", func() {
 			network, err := libpodNet.NetworkInspect("vlan")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("vlan"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.NetworkInterface).To(Equal("podman14"))
@@ -1942,7 +1942,7 @@ var _ = Describe("Config", func() {
 
 		It("bridge network with labels", func() {
 			network, err := libpodNet.NetworkInspect("label")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("label"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.NetworkInterface).To(Equal("podman15"))
@@ -1954,7 +1954,7 @@ var _ = Describe("Config", func() {
 
 		It("bridge network with route metric", func() {
 			network, err := libpodNet.NetworkInspect("metric")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("metric"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.NetworkInterface).To(Equal("podman100"))
@@ -1966,7 +1966,7 @@ var _ = Describe("Config", func() {
 
 		It("dual stack network", func() {
 			network, err := libpodNet.NetworkInspect("dualstack")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("dualstack"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.NetworkInterface).To(Equal("podman21"))
@@ -1983,7 +1983,7 @@ var _ = Describe("Config", func() {
 
 		It("bridge network with vrf", func() {
 			network, err := libpodNet.NetworkInspect("vrf")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(network.Name).To(Equal("vrf"))
 			Expect(network.ID).To(HaveLen(64))
 			Expect(network.NetworkInterface).To(Equal("podman16"))
@@ -1998,10 +1998,10 @@ var _ = Describe("Config", func() {
 				"name": {"internal", "bridge"},
 			}
 			filterFuncs, err := util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(2))
 			Expect(networks).To(ConsistOf(HaveNetworkName("internal"), HaveNetworkName("bridge")))
 		})
@@ -2011,10 +2011,10 @@ var _ = Describe("Config", func() {
 				"name": {"inte", "bri"},
 			}
 			filterFuncs, err := util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(2))
 			Expect(networks).To(ConsistOf(HaveNetworkName("internal"), HaveNetworkName("bridge")))
 		})
@@ -2024,10 +2024,10 @@ var _ = Describe("Config", func() {
 				"id": {"3bed2cb3a3acf7b6a8ef408420cc682d5520e26976d354254f528c965612054f", "17f29b073143d8cd97b5bbe492bdeffec1c5fee55cc1fe2112c8b9335f8b6121"},
 			}
 			filterFuncs, err := util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(2))
 			Expect(networks).To(ConsistOf(HaveNetworkName("internal"), HaveNetworkName("bridge")))
 		})
@@ -2037,10 +2037,10 @@ var _ = Describe("Config", func() {
 				"id": {"3bed2cb3a3acf7b6a8ef40.*", "17f29b073143d8cd97b5bbe492bdeffec1c5fee55cc1fe2112c8b9335f8b6121"},
 			}
 			filterFuncs, err := util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(2))
 			Expect(networks).To(ConsistOf(HaveNetworkName("internal"), HaveNetworkName("bridge")))
 		})
@@ -2050,10 +2050,10 @@ var _ = Describe("Config", func() {
 				"id": {"3bed2cb3a3acf7b6a8ef408420", "17f29b073143d8cd97b5bbe492bde"},
 			}
 			filterFuncs, err := util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(2))
 			Expect(networks).To(ConsistOf(HaveNetworkName("internal"), HaveNetworkName("bridge")))
 		})
@@ -2063,10 +2063,10 @@ var _ = Describe("Config", func() {
 				"driver": {"bridge"},
 			}
 			filterFuncs, err := util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(9))
 			Expect(networks).To(ConsistOf(HaveNetworkName("internal"), HaveNetworkName("bridge"),
 				HaveNetworkName("mtu"), HaveNetworkName("vlan"), HaveNetworkName("podman"),
@@ -2079,10 +2079,10 @@ var _ = Describe("Config", func() {
 				"label": {"mykey"},
 			}
 			filterFuncs, err := util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(1))
 			Expect(networks).To(ConsistOf(HaveNetworkName("label")))
 
@@ -2090,10 +2090,10 @@ var _ = Describe("Config", func() {
 				"label": {"mykey=value"},
 			}
 			filterFuncs, err = util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err = libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(1))
 			Expect(networks).To(ConsistOf(HaveNetworkName("label")))
 		})
@@ -2104,11 +2104,11 @@ var _ = Describe("Config", func() {
 				"label":  {"mykey"},
 			}
 			filterFuncs, err := util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(filterFuncs).To(HaveLen(2))
 
 			networks, err := libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(networks).To(HaveLen(1))
 			Expect(networks).To(ConsistOf(HaveNetworkName("label")))
 
@@ -2117,11 +2117,11 @@ var _ = Describe("Config", func() {
 				"label":  {"mykey"},
 			}
 			filterFuncs, err = util.GenerateNetworkFilters(filters)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			networks, err = libpodNet.NetworkList(filterFuncs...)
-			Expect(err).To(BeNil())
-			Expect(networks).To(HaveLen(0))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(networks).To(BeEmpty())
 		})
 
 		It("create bridge network with used interface name", func() {
@@ -2156,7 +2156,7 @@ var _ = Describe("Config", func() {
 
 		It("load invalid networks from disk", func() {
 			nets, err := libpodNet.NetworkList()
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(nets).To(HaveLen(1))
 			logString := logBuffer.String()
 			Expect(logString).To(ContainSubstring("Error reading network config file \\\"%s/broken.json\\\": unexpected EOF", networkConfDir))
@@ -2170,7 +2170,7 @@ var _ = Describe("Config", func() {
 
 func grepInFile(path, match string) {
 	data, err := os.ReadFile(path)
-	ExpectWithOffset(1, err).To(BeNil())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	ExpectWithOffset(1, string(data)).To(ContainSubstring(match))
 }
 

--- a/libnetwork/netavark/ipam_test.go
+++ b/libnetwork/netavark/ipam_test.go
@@ -45,7 +45,7 @@ var _ = Describe("IPAM", func() {
 		networkInterface = libpodNet.(*netavarkNetwork) //nolint:errcheck // It is always *netavarkNetwork here.
 		// run network list to force a network load
 		_, err = networkInterface.NetworkList()
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -440,12 +440,12 @@ var _ = Describe("IPAM", func() {
 		err = networkInterface.allocIPs(opts)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(opts.Networks).To(HaveKey(netName))
-		Expect(opts.Networks[netName].StaticIPs).To(HaveLen(0))
+		Expect(opts.Networks[netName].StaticIPs).To(BeEmpty())
 
 		err = networkInterface.getAssignedIPs(opts)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(opts.Networks).To(HaveKey(netName))
-		Expect(opts.Networks[netName].StaticIPs).To(HaveLen(0))
+		Expect(opts.Networks[netName].StaticIPs).To(BeEmpty())
 
 		// dealloc the ip
 		err = networkInterface.deallocIPs(opts)

--- a/libnetwork/netavark/plugin_test.go
+++ b/libnetwork/netavark/plugin_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Plugins", func() {
 	It("create plugin network", func() {
 		network := types.Network{Driver: pluginName}
 		network1, err := libpodNet.NetworkCreate(network, nil)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(network1.Name).ToNot(BeEmpty())
 		Expect(network1.ID).ToNot(BeEmpty())
 		Expect(filepath.Join(networkConfDir, network1.Name+".json")).To(BeARegularFile())
@@ -57,7 +57,7 @@ var _ = Describe("Plugins", func() {
 		name := "test123"
 		network := types.Network{Driver: pluginName, Name: name}
 		network1, err := libpodNet.NetworkCreate(network, nil)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(network1.Name).To(Equal(name))
 		Expect(network1.ID).ToNot(BeEmpty())
 		Expect(filepath.Join(networkConfDir, network1.Name+".json")).To(BeARegularFile())

--- a/libnetwork/netavark/run_test.go
+++ b/libnetwork/netavark/run_test.go
@@ -48,9 +48,9 @@ var _ = Describe("run netavark", func() {
 			defer GinkgoRecover()
 			// we have to setup the loopback adapter in this netns to use port forwarding
 			link, err := netlink.LinkByName("lo")
-			Expect(err).To(BeNil(), "Failed to get loopback adapter")
+			Expect(err).ToNot(HaveOccurred(), "Failed to get loopback adapter")
 			err = netlink.LinkSetUp(link)
-			Expect(err).To(BeNil(), "Failed to set loopback adapter up")
+			Expect(err).ToNot(HaveOccurred(), "Failed to set loopback adapter up")
 			run()
 			return nil
 		})
@@ -154,11 +154,11 @@ var _ = Describe("run netavark", func() {
 			err = netNSContainer.Do(func(_ ns.NetNS) error {
 				defer GinkgoRecover()
 				i, err := net.InterfaceByName(intName)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(i.Name).To(Equal(intName))
 				Expect(i.HardwareAddr).To(Equal(net.HardwareAddr(macAddress)))
 				addrs, err := i.Addrs()
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				subnet := &net.IPNet{
 					IP:   ip,
 					Mask: net.CIDRMask(16, 32),
@@ -167,13 +167,13 @@ var _ = Describe("run netavark", func() {
 
 				// check loopback adapter
 				i, err = net.InterfaceByName("lo")
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(i.Name).To(Equal("lo"))
 				Expect(i.Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
 				Expect(i.Flags&net.FlagUp).To(Equal(net.FlagUp), "Loopback adapter should be up")
 				return nil
 			})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			// default bridge name
 			bridgeName := "podman0"
@@ -201,9 +201,9 @@ var _ = Describe("run netavark", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			conn, err := net.Dial("tcp", ip.String()+":5000")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			_, err = conn.Write([]byte(expected))
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			conn.Close()
 
 			err = libpodNet.Teardown(netNSContainer.Path(), types.TeardownOptions(opts))
@@ -243,12 +243,12 @@ var _ = Describe("run netavark", func() {
 			err = netNSContainer.Do(func(_ ns.NetNS) error {
 				defer GinkgoRecover()
 				i, err := net.InterfaceByName(intName)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(i.Name).To(Equal(intName))
 				Expect(i.HardwareAddr).To(Equal(net.HardwareAddr(macAddress)))
 				return nil
 			})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
@@ -533,7 +533,7 @@ var _ = Describe("run netavark", func() {
 					},
 				}
 				res, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(HaveLen(1))
 				Expect(res).To(HaveKey(defNet))
 				Expect(res[defNet].Interfaces).To(HaveKey(intName))
@@ -551,19 +551,19 @@ var _ = Describe("run netavark", func() {
 					runNetListener(&wg, protocol, "0.0.0.0", 5000, testdata)
 					return nil
 				})
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				conn, err := net.Dial(protocol, "127.0.0.1:5000")
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				_, err = conn.Write([]byte(testdata))
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				conn.Close()
 
 				// wait for the listener to finish
 				wg.Wait()
 
 				err = libpodNet.Teardown(netNSContainer.Path(), types.TeardownOptions(setupOpts))
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
@@ -587,7 +587,7 @@ var _ = Describe("run netavark", func() {
 					},
 				}
 				res, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(HaveLen(1))
 				Expect(res).To(HaveKey(defNet))
 				Expect(res[defNet].Interfaces).To(HaveKey(intName))
@@ -611,12 +611,12 @@ var _ = Describe("run netavark", func() {
 						runNetListener(&wg, protocol, containerIP, port-1, testdata)
 						return nil
 					})
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 
 					conn, err := net.Dial(protocol, net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					_, err = conn.Write([]byte(testdata))
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					conn.Close()
 
 					// wait for the listener to finish
@@ -624,7 +624,7 @@ var _ = Describe("run netavark", func() {
 				}
 
 				err = libpodNet.Teardown(netNSContainer.Path(), types.TeardownOptions(setupOpts))
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 	}
@@ -716,7 +716,7 @@ var _ = Describe("run netavark", func() {
 				DNSEnabled: true,
 			}
 			network1, err := libpodNet.NetworkCreate(network, nil)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			intName1 := "eth0"
 			netName1 := network1.Name
@@ -733,12 +733,12 @@ var _ = Describe("run netavark", func() {
 			}
 
 			res, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(HaveLen(1))
 
 			Expect(res).To(HaveKey(netName1))
 			Expect(res[netName1].Interfaces).To(HaveKey(intName1))
-			Expect(res[netName1].Interfaces[intName1].Subnets).To(HaveLen(0))
+			Expect(res[netName1].Interfaces[intName1].Subnets).To(BeEmpty())
 			macInt1 := res[netName1].Interfaces[intName1].MacAddress
 			Expect(macInt1).To(HaveLen(6))
 
@@ -746,11 +746,11 @@ var _ = Describe("run netavark", func() {
 			err = netNSContainer.Do(func(_ ns.NetNS) error {
 				defer GinkgoRecover()
 				i, err := net.InterfaceByName(intName1)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(i.Name).To(Equal(intName1))
 				Expect(i.HardwareAddr).To(Equal(net.HardwareAddr(macInt1)))
 				addrs, err := i.Addrs()
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				// we still have the ipv6 link local address
 				Expect(addrs).To(HaveLen(1))
 				addr, ok := addrs[0].(*net.IPNet)
@@ -760,16 +760,16 @@ var _ = Describe("run netavark", func() {
 
 				// check loopback adapter
 				i, err = net.InterfaceByName("lo")
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(i.Name).To(Equal("lo"))
 				Expect(i.Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
 				Expect(i.Flags&net.FlagUp).To(Equal(net.FlagUp), "Loopback adapter should be up")
 				return nil
 			})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			err = libpodNet.Teardown(netNSContainer.Path(), types.TeardownOptions(setupOpts))
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			// check in the container namespace that the interface is removed
 			err = netNSContainer.Do(func(_ ns.NetNS) error {
@@ -779,7 +779,7 @@ var _ = Describe("run netavark", func() {
 
 				// check that only the loopback adapter is left
 				ints, err := net.Interfaces()
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(ints).To(HaveLen(1))
 				Expect(ints[0].Name).To(Equal("lo"))
 				Expect(ints[0].Flags & net.FlagLoopback).To(Equal(net.FlagLoopback))
@@ -787,7 +787,7 @@ var _ = Describe("run netavark", func() {
 
 				return nil
 			})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })
@@ -796,19 +796,19 @@ func runNetListener(wg *sync.WaitGroup, protocol, ip string, port int, expectedD
 	switch protocol {
 	case "tcp":
 		ln, err := net.Listen(protocol, net.JoinHostPort(ip, strconv.Itoa(port)))
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		// make sure to read in a separate goroutine to not block
 		go func() {
 			defer GinkgoRecover()
 			defer wg.Done()
 			defer ln.Close()
 			conn, err := ln.Accept()
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			defer conn.Close()
 			err = conn.SetDeadline(time.Now().Add(1 * time.Second))
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			data, err := io.ReadAll(conn)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(string(data)).To(Equal(expectedData))
 		}()
 	case "udp":
@@ -816,16 +816,16 @@ func runNetListener(wg *sync.WaitGroup, protocol, ip string, port int, expectedD
 			IP:   net.ParseIP(ip),
 			Port: port,
 		})
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		err = conn.SetDeadline(time.Now().Add(1 * time.Second))
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		go func() {
 			defer GinkgoRecover()
 			defer wg.Done()
 			defer conn.Close()
 			data := make([]byte, len(expectedData))
 			i, err := conn.Read(data)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(i).To(Equal(len(expectedData)))
 			Expect(string(data)).To(Equal(expectedData))
 		}()

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -49,19 +49,19 @@ var _ = Describe("Config", func() {
 		// When			// When
 		err := CheckAuthFile("")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		conf, _ := os.CreateTemp("", "authfile")
 		defer os.Remove(conf.Name())
 		// When			// When
 		err = CheckAuthFile(conf.Name())
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		// When			// When
 		err = CheckAuthFile(conf.Name() + "missing")
 		// Then
-		gomega.Expect(err).ShouldNot(gomega.BeNil())
+		gomega.Expect(err).Should(gomega.HaveOccurred())
 	})
 })
 

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -17,13 +17,13 @@ import (
 var _ = Describe("Config Local", func() {
 	It("should not fail on invalid NetworkConfigDir", func() {
 		defConf, err := defaultConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 		// Given
 		tmpfile := path.Join(os.TempDir(), "wrong-file")
 		file, err := os.Create(tmpfile)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		file.Close()
 		defer os.Remove(tmpfile)
 		defConf.Network.NetworkConfigDir = tmpfile
@@ -33,12 +33,12 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Network.Validate()
 
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	})
 
 	It("should not fail on invalid CNIPluginDirs", func() {
 		defConf, err := defaultConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 		validDirPath, err := os.MkdirTemp("", "config-empty")
@@ -55,12 +55,12 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Network.Validate()
 
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	})
 
 	It("should fail on invalid subnet pool", func() {
 		defConf, err := defaultConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 		validDirPath, err := os.MkdirTemp("", "config-empty")
@@ -81,7 +81,7 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Network.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 
 		defConf.Network.DefaultSubnetPools = []SubnetPool{
 			{Base: &net, Size: 33},
@@ -91,13 +91,13 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Network.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
 	It("parse network subnet pool", func() {
 		config, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		net1, _ := types.ParseCIDR("10.89.0.0/16")
 		net2, _ := types.ParseCIDR("10.90.0.0/15")
 		gomega.Expect(config.Network.DefaultSubnetPools).To(gomega.Equal(
@@ -114,54 +114,54 @@ var _ = Describe("Config Local", func() {
 	It("parse dns port", func() {
 		// Given
 		config, err := New(nil)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Network.DNSBindPort).To(gomega.Equal(uint16(0)))
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config2.Network.DNSBindPort).To(gomega.Equal(uint16(1153)))
 	})
 
 	It("test firewall", func() {
 		// Given
 		config, err := New(nil)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Network.FirewallDriver).To(gomega.Equal(string("")))
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config2.Network.FirewallDriver).To(gomega.Equal("none"))
 	})
 
 	It("parse pasta_options", func() {
 		// Given
 		config, err := New(nil)
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config.Network.PastaOptions.Get()).To(gomega.HaveLen(0))
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(config.Network.PastaOptions.Get()).To(gomega.BeEmpty())
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config2.Network.PastaOptions.Get()).To(gomega.Equal([]string{"-t", "auto"}))
 	})
 
 	It("parse default_rootless_network_cmd", func() {
 		// Given
 		config, err := NewConfig("")
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Network.DefaultRootlessNetworkCmd).To(gomega.Equal("pasta"))
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config2.Network.DefaultRootlessNetworkCmd).To(gomega.Equal("slirp4netns"))
 	})
 
 	It("should fail on invalid device mode", func() {
 		defConf, err := defaultConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 		// Given
@@ -171,12 +171,12 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
 	It("should fail on invalid first device", func() {
 		defConf, err := defaultConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 		// Given
@@ -186,12 +186,12 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
 	It("should fail on invalid second device", func() {
 		defConf, err := defaultConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 		// Given
@@ -201,12 +201,12 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
 	It("should fail on invalid device", func() {
 		defConf, err := defaultConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 		// Given
@@ -216,12 +216,12 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
 	It("should fail on wrong invalid device specification", func() {
 		defConf, err := defaultConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 		// Given
@@ -231,12 +231,12 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
 	It("should fail on invalid interface_name", func() {
 		defConf, err := defaultConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 		// Given
@@ -246,12 +246,12 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
 	It("should succeed on good interface_name", func() {
 		defConf, err := defaultConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 		// Given
@@ -261,12 +261,12 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	})
 
 	It("should succeed on default interface_name", func() {
 		defConf, err := defaultConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 		// Given
@@ -276,12 +276,12 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	})
 
 	It("should fail on bad timezone", func() {
 		defConf, err := defaultConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 		// Given
@@ -291,12 +291,12 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
 	It("should succeed on good timezone", func() {
 		defConf, err := defaultConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 		// Given
@@ -306,12 +306,12 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	})
 
 	It("should succeed on local timezone", func() {
 		defConf, err := defaultConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 		// Given
@@ -321,12 +321,12 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	})
 
 	It("should fail on wrong DefaultUlimits", func() {
 		defConf, err := defaultConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 		// Given
@@ -336,7 +336,7 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
 	It("should return containers engine env", func() {
@@ -345,7 +345,7 @@ var _ = Describe("Config Local", func() {
 		// When
 		config, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Engine.Env.Get()).To(gomega.BeEquivalentTo(expectedEnv))
 		gomega.Expect(os.Getenv("super")).To(gomega.BeEquivalentTo("duper"))
 		gomega.Expect(os.Getenv("foo")).To(gomega.BeEquivalentTo("bar"))
@@ -356,7 +356,7 @@ var _ = Describe("Config Local", func() {
 		// When
 		config, err := New(nil)
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Engine.Remote).To(gomega.BeFalse())
 	})
 
@@ -378,7 +378,7 @@ var _ = Describe("Config Local", func() {
 			os.Unsetenv(containersConfEnv)
 		}
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.GetDefaultEnv()).To(gomega.BeEquivalentTo(envs))
 		config.Containers.HTTPProxy = true
 		gomega.Expect(config.GetDefaultEnv()).To(gomega.BeEquivalentTo(envs))
@@ -399,7 +399,7 @@ var _ = Describe("Config Local", func() {
 		// When
 		config, err := New(nil)
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Containers.Umask).To(gomega.Equal("0022"))
 	})
 	It("Set Umask", func() {
@@ -407,12 +407,12 @@ var _ = Describe("Config Local", func() {
 		// When
 		config, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Containers.Umask).To(gomega.Equal("0002"))
 	})
 	It("Should fail on bad Umask", func() {
 		defConf, err := defaultConfig()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 		// Given
@@ -422,18 +422,18 @@ var _ = Describe("Config Local", func() {
 		err = defConf.Containers.Validate()
 
 		// Then
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
 	It("default netns", func() {
 		// Given
 		config, err := New(nil)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Containers.NetNS).To(gomega.Equal("private"))
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config2.Containers.NetNS).To(gomega.Equal("bridge"))
 	})
 
@@ -442,7 +442,7 @@ var _ = Describe("Config Local", func() {
 		path := ""
 		// When
 		config, err := NewConfig(path)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		// Then
 		gomega.Expect(config.Secrets.Driver).To(gomega.Equal("file"))
 	})
@@ -452,7 +452,7 @@ var _ = Describe("Config Local", func() {
 		path := "testdata/containers_override.conf"
 		// When
 		config, err := NewConfig(path)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		// Then
 		gomega.Expect(config.Secrets.Driver).To(gomega.Equal("pass"))
 		gomega.Expect(config.Secrets.Opts).To(gomega.Equal(map[string]string{
@@ -464,12 +464,12 @@ var _ = Describe("Config Local", func() {
 	It("Set machine image path", func() {
 		// Given
 		config, err := New(nil)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Machine.Image).To(gomega.Equal(""))
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		path := "https://example.com/$OS/$ARCH/foobar.ami"
 		gomega.Expect(config2.Machine.Image).To(gomega.Equal(path))
 		val := fmt.Sprintf("https://example.com/%s/%s/foobar.ami", runtime.GOOS, runtime.GOARCH)
@@ -479,60 +479,60 @@ var _ = Describe("Config Local", func() {
 	It("CompatAPIEnforceDockerHub", func() {
 		// Given
 		config, err := New(nil)
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config.Engine.CompatAPIEnforceDockerHub).To(gomega.Equal(true))
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(config.Engine.CompatAPIEnforceDockerHub).To(gomega.BeTrue())
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config2.Engine.CompatAPIEnforceDockerHub).To(gomega.Equal(false))
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(config2.Engine.CompatAPIEnforceDockerHub).To(gomega.BeFalse())
 	})
 
 	It("ComposeProviders", func() {
 		// Given
 		config, err := New(nil)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Engine.ComposeProviders.Get()).To(gomega.Equal(getDefaultComposeProviders())) // no hard-coding to work on all platforms
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config2.Engine.ComposeProviders.Get()).To(gomega.Equal([]string{"/some/thing/else", "/than/before"}))
 	})
 
 	It("AddCompression", func() {
 		// Given
 		config, err := New(nil)
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config.Engine.AddCompression.Get()).To(gomega.HaveLen(0)) // no hard-coding to work on all platforms
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(config.Engine.AddCompression.Get()).To(gomega.BeEmpty()) // no hard-coding to work on all platforms
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config2.Engine.AddCompression.Get()).To(gomega.Equal([]string{"zstd", "zstd:chunked"}))
 	})
 
 	It("ComposeWarningLogs", func() {
 		// Given
 		config, err := New(nil)
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config.Engine.ComposeWarningLogs).To(gomega.Equal(true))
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(config.Engine.ComposeWarningLogs).To(gomega.BeTrue())
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(config2.Engine.ComposeWarningLogs).To(gomega.Equal(false))
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(config2.Engine.ComposeWarningLogs).To(gomega.BeFalse())
 	})
 
 	It("Set machine disk", func() {
 		// Given
 		config, err := New(nil)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Machine.DiskSize).To(gomega.Equal(uint64(100)))
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config2.Machine.DiskSize).To(gomega.Equal(uint64(20)))
 	})
 	It("Set machine CPUs", func() {
@@ -543,34 +543,34 @@ var _ = Describe("Config Local", func() {
 		}
 
 		config, err := New(nil)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Machine.CPUs).To(gomega.Equal(uint64(cpus)))
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config2.Machine.CPUs).To(gomega.Equal(uint64(1)))
 	})
 	It("Set machine memory", func() {
 		// Given
 		config, err := New(nil)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Machine.Memory).To(gomega.Equal(uint64(2048)))
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config2.Machine.Memory).To(gomega.Equal(uint64(1024)))
 	})
 	It("Get Rosetta value", func() {
 		// Given
 		config, err := New(nil)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Machine.Rosetta).To(gomega.BeTrue())
 		// When
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config2.Machine.Rosetta).To(gomega.BeFalse())
 	})
 })

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Config", func() {
 			defaultConfig, err := NewConfig("")
 
 			// Then
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(defaultConfig.Containers.ApparmorProfile).To(gomega.Equal(apparmor.Profile))
 			gomega.Expect(defaultConfig.Containers.BaseHostsFile).To(gomega.Equal(""))
 			gomega.Expect(defaultConfig.Containers.InterfaceName).To(gomega.Equal(""))
@@ -42,10 +42,10 @@ var _ = Describe("Config", func() {
 			gomega.Expect(defaultConfig.Engine.EventsContainerCreateInspectData).To(gomega.BeFalse())
 			gomega.Expect(defaultConfig.Engine.DBBackend).To(gomega.Equal(""))
 			gomega.Expect(defaultConfig.Engine.PodmanshTimeout).To(gomega.BeEquivalentTo(30))
-			gomega.Expect(defaultConfig.Engine.AddCompression.Get()).To(gomega.HaveLen(0))
+			gomega.Expect(defaultConfig.Engine.AddCompression.Get()).To(gomega.BeEmpty())
 
 			path, err := defaultConfig.ImageCopyTmpDir()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(path).To(gomega.BeEquivalentTo("/var/tmp"))
 			gomega.Expect(defaultConfig.Engine.Retry).To(gomega.BeEquivalentTo(3))
 			gomega.Expect(defaultConfig.Engine.RetryDelay).To(gomega.Equal(""))
@@ -53,7 +53,7 @@ var _ = Describe("Config", func() {
 
 		It("should succeed with devices", func() {
 			defConf, err := defaultConfig()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 			// Given
@@ -68,12 +68,12 @@ var _ = Describe("Config", func() {
 			err = defConf.Containers.Validate()
 
 			// Then
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
 
 		It("should fail wrong max log size", func() {
 			defConf, err := defaultConfig()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 			// Given
@@ -83,12 +83,12 @@ var _ = Describe("Config", func() {
 			err = defConf.Validate()
 
 			// Then
-			gomega.Expect(err).NotTo(gomega.BeNil())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 		})
 
 		It("should succeed with valid shm size", func() {
 			defConf, err := defaultConfig()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 			// Given
@@ -98,7 +98,7 @@ var _ = Describe("Config", func() {
 			err = defConf.Validate()
 
 			// Then
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// Given
 			defConf.Containers.ShmSize = "64m"
@@ -107,12 +107,12 @@ var _ = Describe("Config", func() {
 			err = defConf.Validate()
 
 			// Then
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
 
 		It("should fail wrong shm size", func() {
 			defConf, err := defaultConfig()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 			// Given
@@ -122,7 +122,7 @@ var _ = Describe("Config", func() {
 			err = defConf.Validate()
 
 			// Then
-			gomega.Expect(err).NotTo(gomega.BeNil())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 		})
 
 		It("Check SELinux settings", func() {
@@ -136,7 +136,7 @@ var _ = Describe("Config", func() {
 	Describe("ValidateNetworkConfig", func() {
 		It("should succeed with default config", func() {
 			defConf, err := defaultConfig()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 			// Given
@@ -144,7 +144,7 @@ var _ = Describe("Config", func() {
 			err = defConf.Network.Validate()
 
 			// Then
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
 	})
 
@@ -156,18 +156,18 @@ var _ = Describe("Config", func() {
 image_copy_tmp_dir="storage"`
 			err := os.WriteFile(testFile, []byte(content), os.ModePerm)
 			// Then
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			defer os.Remove(testFile)
 
 			config, _ := NewConfig(testFile)
 			path, err := config.ImageCopyTmpDir()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(path).To(gomega.ContainSubstring("containers/storage/tmp"))
 			// Given we do
 			oldTMPDIR, set := os.LookupEnv("TMPDIR")
 			os.Setenv("TMPDIR", "/var/tmp/foobar")
 			path, err = config.ImageCopyTmpDir()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(path).To(gomega.BeEquivalentTo("/var/tmp/foobar"))
 			if set {
 				os.Setenv("TMPDIR", oldTMPDIR)
@@ -183,7 +183,7 @@ image_copy_tmp_dir="storage"`
 			// When
 			defaultConfig, _ := defaultConfig()
 			// prior to reading local config, shows hard coded defaults
-			gomega.Expect(defaultConfig.Containers.HTTPProxy).To(gomega.Equal(true))
+			gomega.Expect(defaultConfig.Containers.HTTPProxy).To(gomega.BeTrue())
 
 			err := readConfigFromFile("testdata/containers_default.conf", defaultConfig, false)
 
@@ -289,7 +289,7 @@ image_copy_tmp_dir="storage"`
 			}
 
 			// Then
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(defaultConfig.Engine.CgroupManager).To(gomega.Equal("systemd"))
 			gomega.Expect(defaultConfig.Containers.Env.Get()).To(gomega.BeEquivalentTo(envs))
 			gomega.Expect(defaultConfig.Containers.Mounts.Get()).To(gomega.BeEquivalentTo(mounts))
@@ -299,8 +299,8 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(defaultConfig.Engine.NumLocks).To(gomega.BeEquivalentTo(2048))
 			gomega.Expect(defaultConfig.Engine.OCIRuntimes).To(gomega.Equal(OCIRuntimeMap))
 			gomega.Expect(defaultConfig.Engine.PlatformToOCIRuntime).To(gomega.Equal(PlatformToOCIRuntimeMap))
-			gomega.Expect(defaultConfig.Containers.HTTPProxy).To(gomega.Equal(false))
-			gomega.Expect(defaultConfig.Engine.NetworkCmdOptions.Get()).To(gomega.HaveLen(0))
+			gomega.Expect(defaultConfig.Containers.HTTPProxy).To(gomega.BeFalse())
+			gomega.Expect(defaultConfig.Engine.NetworkCmdOptions.Get()).To(gomega.BeEmpty())
 			gomega.Expect(defaultConfig.Engine.HelperBinariesDir.Get()).To(gomega.Equal(helperDirs))
 			gomega.Expect(defaultConfig.Engine.ServiceTimeout).To(gomega.BeEquivalentTo(300))
 			gomega.Expect(defaultConfig.Engine.InfraImage).To(gomega.BeEquivalentTo("k8s.gcr.io/pause:3.4.1"))
@@ -311,7 +311,7 @@ image_copy_tmp_dir="storage"`
 				// $HOME is not set
 				gomega.Expect(err).To(gomega.HaveOccurred())
 			} else {
-				gomega.Expect(err).To(gomega.BeNil())
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				gomega.Expect(newV).To(gomega.BeEquivalentTo(newVolumes))
 			}
 			gomega.Expect(defaultConfig.Engine.Retry).To(gomega.BeEquivalentTo(5))
@@ -353,7 +353,7 @@ image_copy_tmp_dir="storage"`
 			err := readConfigFromFile("testdata/containers_comment.conf", &conf, false)
 
 			// Then
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
 
 		It("should fail when file does not exist", func() {
@@ -363,7 +363,7 @@ image_copy_tmp_dir="storage"`
 			err := readConfigFromFile("/invalid/file", &conf, false)
 
 			// Then
-			gomega.Expect(err).NotTo(gomega.BeNil())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 		})
 
 		It("should fail when toml decode fails", func() {
@@ -373,7 +373,7 @@ image_copy_tmp_dir="storage"`
 			err := readConfigFromFile("config.go", &conf, false)
 
 			// Then
-			gomega.Expect(err).NotTo(gomega.BeNil())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 		})
 	})
 
@@ -432,7 +432,7 @@ image_copy_tmp_dir="storage"`
 				os.Unsetenv(containersConfEnv)
 			}
 			// Then
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal(apparmor.Profile))
 			gomega.Expect(config.Containers.PidsLimit).To(gomega.BeEquivalentTo(2048))
 			gomega.Expect(config.Containers.Env.Get()).To(gomega.BeEquivalentTo(envs))
@@ -441,7 +441,7 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(config.Network.NetavarkPluginDirs.Get()).To(gomega.Equal(DefaultNetavarkPluginDirs))
 			gomega.Expect(config.Engine.NumLocks).To(gomega.BeEquivalentTo(2048))
 			gomega.Expect(config.Engine.OCIRuntimes["runc"]).To(gomega.Equal(OCIRuntimeMap["runc"]))
-			gomega.Expect(config.Containers.CgroupConf.Get()).To(gomega.HaveLen(0))
+			gomega.Expect(config.Containers.CgroupConf.Get()).To(gomega.BeEmpty())
 
 			caps, _ := config.Capabilities("", nil, nil)
 			gomega.Expect(caps).Should(gomega.Equal(defCaps))
@@ -472,7 +472,7 @@ image_copy_tmp_dir="storage"`
 			cgroupConf := []string{
 				"memory.high=1073741824",
 			}
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal("container-default"))
 			gomega.Expect(config.Containers.PidsLimit).To(gomega.BeEquivalentTo(2048))
 			gomega.Expect(config.Containers.BaseHostsFile).To(gomega.BeEquivalentTo("/etc/hosts2"))
@@ -512,7 +512,7 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(runtimes).To(gomega.Equal(crunWasm))
 
 			// Then
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(config).ToNot(gomega.BeNil())
 			gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal("overridden-default"))
 			gomega.Expect(config.Containers.LogDriver).To(gomega.Equal("journald"))
@@ -527,7 +527,7 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(config.Engine.EventsLogFilePath).To(gomega.BeEquivalentTo("/tmp/events.log"))
 			gomega.Expect(config.Engine.EventsContainerCreateInspectData).To(gomega.BeTrue())
 			path, err := config.ImageCopyTmpDir()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(path).To(gomega.BeEquivalentTo("/tmp/foobar"))
 			gomega.Expect(uint64(config.Engine.EventsLogFileMaxSize)).To(gomega.Equal(uint64(500)))
 			gomega.Expect(config.Engine.PodExitPolicy).To(gomega.BeEquivalentTo(PodExitPolicyStop))
@@ -538,7 +538,7 @@ image_copy_tmp_dir="storage"`
 			// When
 			config, err := NewConfig("testdata/containers_invalid.conf")
 			// Then
-			gomega.Expect(err).ToNot(gomega.BeNil())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(config).To(gomega.BeNil())
 		})
 
@@ -550,10 +550,10 @@ image_copy_tmp_dir="storage"`
 			// When
 			config, err := NewConfig("")
 			// Then
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			var addcaps, dropcaps []string
 			caps, err := config.Capabilities("0", addcaps, dropcaps)
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			sort.Strings(caps)
 			defaultCaps := config.Containers.DefaultCapabilities.Get()
 			sort.Strings(defaultCaps)
@@ -562,16 +562,16 @@ image_copy_tmp_dir="storage"`
 			// Add all caps
 			addcaps = []string{"all"}
 			caps, err = config.Capabilities("root", addcaps, dropcaps)
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			sort.Strings(caps)
 			boundingSet, err := capabilities.BoundingSet()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(caps).To(gomega.BeEquivalentTo(boundingSet))
 
 			// Drop all caps
 			dropcaps = []string{"all"}
 			caps, err = config.Capabilities("", boundingSet, dropcaps)
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			sort.Strings(caps)
 			gomega.Expect(caps).ToNot(gomega.BeEquivalentTo([]string{}))
 
@@ -593,61 +593,61 @@ image_copy_tmp_dir="storage"`
 			addcaps = []string{"CAP_NET_ADMIN", "CAP_SYS_ADMIN"}
 			dropcaps = []string{"CAP_FOWNER", "CAP_CHOWN"}
 			caps, err = config.Capabilities("", addcaps, dropcaps)
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			sort.Strings(caps)
 			gomega.Expect(caps).To(gomega.BeEquivalentTo(expectedCaps))
 
 			addcaps = []string{"NET_ADMIN", "cap_sys_admin"}
 			dropcaps = []string{"FOWNER", "chown"}
 			caps, err = config.Capabilities("", addcaps, dropcaps)
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			sort.Strings(caps)
 			gomega.Expect(caps).To(gomega.BeEquivalentTo(expectedCaps))
 
 			expectedCaps = []string{"CAP_NET_ADMIN", "CAP_SYS_ADMIN"}
 			caps, err = config.Capabilities("notroot", addcaps, dropcaps)
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			sort.Strings(caps)
 			gomega.Expect(caps).To(gomega.BeEquivalentTo(expectedCaps))
 		})
 
 		It("should succeed with default pull_policy", func() {
 			defConf, err := defaultConfig()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 			err = defConf.Engine.Validate()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(defConf.Engine.PullPolicy).To(gomega.Equal("missing"))
 
 			defConf.Engine.PullPolicy = DefaultPullPolicy
 			err = defConf.Engine.Validate()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
 
 		It("should succeed case-insensitive", func() {
 			defConf, err := defaultConfig()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 			defConf.Engine.PullPolicy = "NeVer"
 			err = defConf.Engine.Validate()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
 
 		It("should fail with invalid pull_policy", func() {
 			defConf, err := defaultConfig()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 			defConf.Engine.PullPolicy = "invalidPullPolicy"
 			err = defConf.Engine.Validate()
-			gomega.Expect(err).ToNot(gomega.BeNil())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 		})
 
 		It("should fail with invalid database_backend", func() {
 			defConf, err := defaultConfig()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(defConf).NotTo(gomega.BeNil())
 
 			defConf.Engine.DBBackend = "blah"
@@ -725,7 +725,7 @@ image_copy_tmp_dir="storage"`
 			logrus.SetOutput(content)
 			logrus.SetLevel(logrus.DebugLevel)
 			err := readConfigFromFile("testdata/containers_broken.conf", &conf, false)
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(conf.Containers.NetNS).To(gomega.Equal("bridge"))
 			gomega.Expect(conf.Containers.Umask).To(gomega.Equal("0002"))
 			gomega.Expect(content).To(gomega.ContainSubstring("Failed to decode the keys [\\\"foo\\\" \\\"containers.image_default_transport\\\"] from \\\"testdata/containers_broken.conf\\\""))
@@ -737,7 +737,7 @@ image_copy_tmp_dir="storage"`
 			content := bytes.NewBufferString("")
 			logrus.SetOutput(content)
 			err := readConfigFromFile("containers.conf", &conf, false)
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(content.String()).To(gomega.Equal(""))
 			logrus.SetOutput(os.Stderr)
 		})
@@ -750,7 +750,7 @@ image_copy_tmp_dir="storage"`
 			oldEnv, set := os.LookupEnv(containersConfEnv)
 			os.Setenv(containersConfEnv, defaultTestFile)
 			cfg, err := Default()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			if set {
 				os.Setenv(containersConfEnv, oldEnv)
 			} else {
@@ -763,13 +763,13 @@ image_copy_tmp_dir="storage"`
 env=["foo=bar"]`
 			err = os.WriteFile(testFile, []byte(content), os.ModePerm)
 			defer os.Remove(testFile)
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			oldEnv, set = os.LookupEnv(containersConfEnv)
 			os.Setenv(containersConfEnv, testFile)
 			_, err = Reload()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			newCfg, err := Default()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			if set {
 				os.Setenv(containersConfEnv, oldEnv)
 			} else {
@@ -782,7 +782,7 @@ env=["foo=bar"]`
 			gomega.Expect(newCfg.Containers.Env.Get()).To(gomega.Equal(expectNewEnv))
 			// Reload change back to default global configuration
 			_, err = Reload()
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
 	})
 

--- a/pkg/config/modules_test.go
+++ b/pkg/config/modules_test.go
@@ -42,7 +42,7 @@ func testSetModulePaths() (func(), error) {
 var _ = Describe("Config Modules", func() {
 	It("module directories", func() {
 		dirs, err := ModuleDirectories()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(dirs).NotTo(gomega.BeNil())
 
 		if unshare.IsRootless() {
@@ -56,11 +56,11 @@ var _ = Describe("Config Modules", func() {
 		// This test makes sure that the correct module is being
 		// returned.
 		cleanUp, err := testSetModulePaths()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		defer cleanUp()
 
 		dirs, err := ModuleDirectories()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		if unshare.IsRootless() {
 			gomega.Expect(dirs).To(gomega.HaveLen(3))
@@ -97,36 +97,36 @@ var _ = Describe("Config Modules", func() {
 			}
 			result, err := resolveModule(test.input, dirs)
 			if test.mustFail {
-				gomega.Expect(err).NotTo(gomega.BeNil())
+				gomega.Expect(err).To(gomega.HaveOccurred())
 				continue
 			}
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(result).To(gomega.HaveSuffix(filepath.Join(test.expectedDir, moduleSubdir, test.input)))
 		}
 	})
 
 	It("new config with modules", func() {
 		cleanUp, err := testSetModulePaths()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		defer cleanUp()
 
 		wd, err := os.Getwd()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		options := &Options{Modules: []string{"none.conf"}}
 		_, err = New(options)
-		gomega.Expect(err).NotTo(gomega.BeNil()) // must error out
+		gomega.Expect(err).To(gomega.HaveOccurred()) // must error out
 
 		options = &Options{}
 		c, err := New(options)
-		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(options.additionalConfigs).To(gomega.HaveLen(0)) // no module is getting loaded!
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(options.additionalConfigs).To(gomega.BeEmpty()) // no module is getting loaded!
 		gomega.Expect(c).NotTo(gomega.BeNil())
-		gomega.Expect(c.LoadedModules()).To(gomega.HaveLen(0))
+		gomega.Expect(c.LoadedModules()).To(gomega.BeEmpty())
 
 		options = &Options{Modules: []string{"fourth.conf"}}
 		c, err = New(options)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(options.additionalConfigs).To(gomega.HaveLen(1)) // 1 module is getting loaded!
 		gomega.Expect(c.Containers.InitPath).To(gomega.Equal("etc four"))
 		gomega.Expect(c.LoadedModules()).To(gomega.HaveLen(1))
@@ -135,14 +135,14 @@ var _ = Describe("Config Modules", func() {
 
 		options = &Options{Modules: []string{"fourth.conf"}}
 		c, err = New(options)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(options.additionalConfigs).To(gomega.HaveLen(1)) // 1 module is getting loaded!
 		gomega.Expect(c.Containers.InitPath).To(gomega.Equal("etc four"))
 		gomega.Expect(c.LoadedModules()).To(gomega.HaveLen(1))
 
 		options = &Options{Modules: []string{"fourth.conf", "sub/share-only.conf", "sub/etc-only.conf"}}
 		c, err = New(options)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(options.additionalConfigs).To(gomega.HaveLen(3)) // 3 modules are getting loaded!
 		gomega.Expect(c.Containers.InitPath).To(gomega.Equal("etc four"))
 		gomega.Expect(c.Containers.Env.Get()).To(gomega.Equal([]string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "usr share only"}))
@@ -151,7 +151,7 @@ var _ = Describe("Config Modules", func() {
 
 		options = &Options{Modules: []string{"third.conf"}}
 		c, err = New(options)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(options.additionalConfigs).To(gomega.HaveLen(1)) // 1 module is getting loaded!
 		gomega.Expect(c.LoadedModules()).To(gomega.HaveLen(1))
 		if unshare.IsRootless() {
@@ -163,7 +163,7 @@ var _ = Describe("Config Modules", func() {
 
 	It("new config with modules and env variables", func() {
 		cleanUp, err := testSetModulePaths()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		defer cleanUp()
 
 		oldOverride := os.Getenv(containersConfOverrideEnv)
@@ -172,16 +172,16 @@ var _ = Describe("Config Modules", func() {
 		}()
 
 		err = os.Setenv(containersConfOverrideEnv, "testdata/modules/override.conf")
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		// Also make sure that absolute paths are loaded as is.
 		wd, err := os.Getwd()
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		absConf := filepath.Join(wd, "testdata/modules/home/.config/containers/containers.conf.modules/second.conf")
 
 		options := &Options{Modules: []string{"fourth.conf", "sub/share-only.conf", absConf}}
 		c, err := New(options)
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(options.additionalConfigs).To(gomega.HaveLen(4)) // 2 modules + abs path + override conf are getting loaded!
 		gomega.Expect(c.Containers.InitPath).To(gomega.Equal("etc four"))
 		gomega.Expect(c.Containers.Env.Get()).To(gomega.Equal([]string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "usr share only", "override conf always wins"}))


### PR DESCRIPTION
This linter creates better assertions in ginkgo tests. Fixes were made with `ginkgolinter -fix ./...`.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
