### PR TITLE
Cirrus-CI: Give success a name

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -86,6 +86,10 @@ meta_task:
 # set of tasks all passed, and allows confirming that based on the status
 # of this task.
 success_task:
+    # N/B: The prow merge-bot (tide) is sensitized to this exact name, DO NOT CHANGE IT.
+    # Ref: https://github.com/openshift/release/pull/49820
+    name: "Total Success"
+    alias: success
 
     depends_on:
         - "testing"


### PR DESCRIPTION
This and the referenced openshift/release PR will make `prow` (via the `tide` bot) block merges unless the success aggregation task is green. This must be configured independently from branch-protection rules which tide does/can not manage due to write-only access.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
