### PR TITLE
[release-0.52] [crio-1.25] Cherry-pick changes from containers/common/pull#1437

### DIFF
--- a/pkg/subscriptions/subscriptions_test.go
+++ b/pkg/subscriptions/subscriptions_test.go
@@ -1,0 +1,32 @@
+package subscriptions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadAllAndSaveTo(t *testing.T) {
+	const testMode = os.FileMode(0o700)
+
+	rootDir := t.TempDir()
+	childDir := filepath.Join(rootDir, "child")
+	err := os.Mkdir(childDir, testMode)
+	assert.NoError(t, err, "mkdir child")
+
+	filePath := "child/file"
+	err = os.WriteFile(filepath.Join(rootDir, filePath), []byte("test"), testMode)
+	assert.NoError(t, err, "write file")
+
+	data, err := readAll(rootDir, "", testMode)
+	assert.NoError(t, err, "readAll")
+	assert.Len(t, data, 1, "readAll should return one result")
+
+	tmpDir := t.TempDir()
+	err = data[0].saveTo(tmpDir)
+	assert.NoError(t, err, "saveTo()")
+
+	assert.FileExists(t, filepath.Join(tmpDir, filePath), "file exists at correct location")
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/assign kwilczynski

#### What this PR does / why we need it:

Manually cherry-pick changes from https://github.com/containers/common/pull/1437 as these changes contain a fix that needs to be backported to CRI-O release 1.25, part of OpenShift 4.12 release.

Related:

- https://github.com/containers/common/pull/1421
- https://github.com/containers/common/pull/1437

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```