### PR TITLE
manifests: preserve Annotations when adding from indexes

### DIFF
--- a/libimage/manifest_list_test.go
+++ b/libimage/manifest_list_test.go
@@ -98,7 +98,8 @@ func TestInspectManifestListWithAnnotations(t *testing.T) {
 	inspectReport, err = list.Inspect()
 	require.NoError(t, err)
 	// verify annotation
-	require.Equal(t, inspectReport.Manifests[0].Annotations, annotations)
+	require.Contains(t, inspectReport.Manifests[0].Annotations, "hello")
+	require.Equal(t, inspectReport.Manifests[0].Annotations["hello"], annotations["hello"])
 	require.Equal(t, inspectReport.Annotations, indexAnnotations)
 	require.Equal(t, inspectReport.Subject.MediaType, imgspecv1.MediaTypeImageManifest)
 }

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/containers/common/internal"
 	"github.com/containers/image/v5/manifest"
@@ -80,10 +81,18 @@ func Create() List {
 	}
 }
 
+func sliceToMap(s []string) map[string]string {
+	m := make(map[string]string, len(s))
+	for _, spec := range s {
+		key, value, _ := strings.Cut(spec, "=")
+		m[key] = value
+	}
+	return m
+}
+
 // AddInstance adds an entry for the specified manifest digest, with assorted
 // additional information specified in parameters, to the list or index.
 func (l *list) AddInstance(manifestDigest digest.Digest, manifestSize int64, manifestType, osName, architecture, osVersion string, osFeatures []string, variant string, features, annotations []string) error { // nolint:revive
-	// FIXME: the annotations argument is currently ignored
 	if err := l.Remove(manifestDigest); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
@@ -116,10 +125,11 @@ func (l *list) AddInstance(manifestDigest digest.Digest, manifestSize int64, man
 		ociv1platform = nil
 	}
 	l.oci.Manifests = append(l.oci.Manifests, v1.Descriptor{
-		MediaType: manifestType,
-		Size:      manifestSize,
-		Digest:    manifestDigest,
-		Platform:  ociv1platform,
+		MediaType:   manifestType,
+		Size:        manifestSize,
+		Digest:      manifestDigest,
+		Platform:    ociv1platform,
+		Annotations: sliceToMap(annotations),
 	})
 
 	return nil


### PR DESCRIPTION
When adding items from one index into another, preserve the annotations and URLs which are set in the descriptors in the source index.