### PR TITLE
manifest add: check for local images last

### DIFF
--- a/libimage/manifest_list_test.go
+++ b/libimage/manifest_list_test.go
@@ -115,8 +115,20 @@ func TestCreateAndTagManifestList(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, list)
 
+	_, err = runtime.Load(ctx, "testdata/oci-unnamed.tar.gz", nil)
+	require.NoError(t, err)
+
+	// add a remote reference
 	manifestListOpts := &ManifestListAddOptions{All: true}
 	_, err = list.Add(ctx, "docker://busybox", manifestListOpts)
+	require.NoError(t, err)
+
+	// add a remote reference where we have to figure out that it's remote
+	_, err = list.Add(ctx, "busybox", manifestListOpts)
+	require.NoError(t, err)
+
+	// add using a local image's ID
+	_, err = list.Add(ctx, "5c8aca8137ac47e84c69ae93ce650ce967917cc001ba7aad5494073fac75b8b6", manifestListOpts)
 	require.NoError(t, err)
 
 	list, err = runtime.LookupManifestList(listName)

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -355,25 +355,25 @@ var _ = Describe("Config Local", func() {
 		// Given
 		config1, err := New(nil)
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config1.Engine.CdiSpecDirs.Get()).To(gomega.Equal([]string{"/etc/cdi"}))
 
 		// Given default just get default
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config2.Engine.CdiSpecDirs.Get()).To(gomega.Equal([]string{"/etc/cdi"}))
 
 		// Given override just get override
 		config3, err := NewConfig("testdata/containers_override.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config3.Engine.CdiSpecDirs.Get()).To(gomega.Equal([]string{"/somepath"}))
 
 		// Given override just get override
 		config4, err := NewConfig("testdata/containers_override2.conf")
 		// Then
-		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config4.Engine.CdiSpecDirs.Get()).To(gomega.Equal([]string{"/somepath", "/some_other_path"}))
 	})
 


### PR DESCRIPTION
When adding a reference to a manifest list or image index, if we are guessing that it's a reference to an image in a registry, check if we can read something from that location instead of assuming it's correct, and if we can't, check for a local image.  This will let use use local image IDs to refer to items that we want to add to a list or index.

This would at least provide more of a workaround for https://github.com/containers/common/issues/1896, in that specifying the desired image using only its ID would start working.