### PR TITLE
Add a libimage.Runtime.LoadReference for loading images

### DIFF
--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -240,6 +240,15 @@ func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference,
 	// Figure out a name for the storage destination.
 	var storageName, imageName string
 	switch ref.Transport().Name() {
+	case registryTransport.Transport.Name():
+		// Normalize to docker.io if needed (see containers/podman/issues/10998).
+		named, err := reference.ParseNormalizedNamed(strings.TrimLeft(ref.StringWithinTransport(), ":/"))
+		if err != nil {
+			return nil, err
+		}
+		imageName = named.String()
+		storageName = imageName
+
 	case dockerDaemonTransport.Transport.Name():
 		// Normalize to docker.io if needed (see containers/podman/issues/10998).
 		named, err := reference.ParseNormalizedNamed(ref.StringWithinTransport())


### PR DESCRIPTION
Add a `LoadReference()` method, for when we already know what format the local image should be treated as, and we don't have the patience for `Load()`'s guessing at it.