### PR TITLE
[v0.57 backport] containers.conf: add crun-vm as a runtime

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -753,7 +753,7 @@ Indicates whether the application should be running in remote mode. This flag mo
 
 Default OCI specific runtime in runtimes that will be used by default. Must
 refer to a member of the runtimes table. Default runtime will be searched for
-on the system using the priority: "crun", "crun-vm", "runc", "kata".
+on the system using the priority: "crun", "runc", "runj", "kata", "runsc", "ocijail"
 
 **runtime_supports_json**=["crun", "crun-vm", "runc", "kata", "runsc", "youki", "krun"]
 

--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -753,9 +753,9 @@ Indicates whether the application should be running in remote mode. This flag mo
 
 Default OCI specific runtime in runtimes that will be used by default. Must
 refer to a member of the runtimes table. Default runtime will be searched for
-on the system using the priority: "crun", "runc", "kata".
+on the system using the priority: "crun", "crun-vm", "runc", "kata".
 
-**runtime_supports_json**=["crun", "runc", "kata", "runsc", "youki", "krun"]
+**runtime_supports_json**=["crun", "crun-vm", "runc", "kata", "runsc", "youki", "krun"]
 
 The list of the OCI runtimes that support `--format=json`.
 
@@ -763,7 +763,7 @@ The list of the OCI runtimes that support `--format=json`.
 
 The list of OCI runtimes that support running containers with KVM separation.
 
-**runtime_supports_nocgroups**=["crun", "krun"]
+**runtime_supports_nocgroups**=["crun", "crun-vm", "krun"]
 
 The list of OCI runtimes that support running containers without CGroups.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -759,7 +759,7 @@ func (m *MachineConfig) URI() string {
 }
 
 func (c *EngineConfig) findRuntime() string {
-	// Search for crun first followed by runc, kata, runsc
+	// Search for crun first followed by runc, runj, kata, runsc, ocijail
 	for _, name := range []string{"crun", "runc", "runj", "kata", "runsc", "ocijail"} {
 		for _, v := range c.OCIRuntimes[name] {
 			if _, err := os.Stat(v); err == nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -223,6 +223,14 @@ image_copy_tmp_dir="storage"`
 					"/usr/bin/crun",
 					"/usr/local/bin/crun",
 				},
+				"crun-vm": {
+					"/usr/bin/crun-vm",
+					"/usr/local/bin/crun-vm",
+					"/usr/local/sbin/crun-vm",
+					"/sbin/crun-vm",
+					"/bin/crun-vm",
+					"/run/current-system/sw/bin/crun-vm",
+				},
 				"crun-wasm": {
 					"/usr/bin/crun-wasm",
 					"/usr/sbin/crun-wasm",

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -729,6 +729,15 @@ default_sysctls = [
 #  "/run/current-system/sw/bin/crun",
 #]
 
+#crun-vm = [
+#  "/usr/bin/crun-vm",
+#  "/usr/local/bin/crun-vm",
+#  "/usr/local/sbin/crun-vm",
+#  "/sbin/crun-vm",
+#  "/bin/crun-vm",
+#  "/run/current-system/sw/bin/crun-vm",
+#]
+
 #kata = [
 #  "/usr/bin/kata-runtime",
 #  "/usr/sbin/kata-runtime",

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -363,6 +363,14 @@ func defaultEngineConfig() (*EngineConfig, error) {
 			"/bin/crun",
 			"/run/current-system/sw/bin/crun",
 		},
+		"crun-vm": {
+			"/usr/bin/crun-vm",
+			"/usr/local/bin/crun-vm",
+			"/usr/local/sbin/crun-vm",
+			"/sbin/crun-vm",
+			"/bin/crun-vm",
+			"/run/current-system/sw/bin/crun-vm",
+		},
 		"crun-wasm": {
 			"/usr/bin/crun-wasm",
 			"/usr/sbin/crun-wasm",


### PR DESCRIPTION
This is required for podman v4.9 to use crun-vm on F38/39.
(cherry picked from commit 7b056a0cab69cbcc2426aca628b7767f529b2d9f)

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->


@rhatdan @TomSweeneyRedHat @Luap99 @mheon PTAL
cc @albertofaria