### PR TITLE
libnetwork/netavark: remove ipam bucket on network rm

### DIFF
--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -376,6 +376,11 @@ func (n *netavarkNetwork) NetworkRemove(nameOrID string) error {
 		return fmt.Errorf("default network %s cannot be removed", n.defaultNetwork)
 	}
 
+	// remove the ipam bucket for this network
+	if err := n.removeNetworkIPAMBucket(network); err != nil {
+		return err
+	}
+
 	file := filepath.Join(n.networkConfigDir, network.Name+".json")
 	// make sure to not error for ErrNotExist
 	if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
This is good to prevent any leaks but more important here there is a bug because we cache the last assigned ip. However when a network is removed the recreated with a different LeaseRange that ip might be very well outside the expected range and the logic seems to handle this correctly. I could fix it there but deleting the full bucket seems best as it avoid other issues and leaking the bucket forever.

Fixes containers/podman#22034

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
