### PR TITLE
pkg/config: add new healthcheck_events field

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -603,6 +603,17 @@ Valid values are: `file`, `journald`, and `none`.
 Creates a more verbose container-create event which includes a JSON payload
 with detailed information about the container.  Set to false by default.
 
+**healthcheck_events**=true|false
+
+Whenever Podman should log healthcheck events.
+With many running healthcheck on short interval Podman will spam the event
+log a lot as it generates a event for each single healthcheck run. Because
+this event is optional and only useful to external consumers that may want
+to know when a healthcheck is run or failed allow users to turn it off by
+setting it to false.
+
+Default is true.
+
 **helper_binaries_dir**=["/usr/libexec/podman", ...]
 
 A is a list of directories which are used to search for helper binaries.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -318,6 +318,13 @@ type EngineConfig struct {
 	// graphRoot internal stores the location of the graphroot
 	graphRoot string
 
+	// HealthcheckEvents is set to indicate whenever podman should log healthcheck events.
+	// With many running healthcheck on short interval Podman will spam the event log a lot.
+	// Because this event is optional and only useful to external consumers that may want to
+	// know when a healthcheck is run or failed allow users to turn it off by setting it to false.
+	// Default is true.
+	HealthcheckEvents bool `toml:"healthcheck_events,omitempty"`
+
 	// HelperBinariesDir is a list of directories which are used to search for
 	// helper binaries.
 	HelperBinariesDir attributedstring.Slice `toml:"helper_binaries_dir,omitempty"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -253,8 +253,6 @@ type EngineConfig struct {
 	// and "systemd".
 	CgroupManager string `toml:"cgroup_manager,omitempty"`
 
-	// NOTE: when changing this struct, make sure to update (*Config).Merge().
-
 	// ConmonEnvVars are environment variables to pass to the Conmon binary
 	// when it is launched.
 	ConmonEnvVars attributedstring.Slice `toml:"conmon_env_vars,omitempty"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -184,6 +184,7 @@ image_copy_tmp_dir="storage"`
 			defaultConfig, _ := defaultConfig()
 			// prior to reading local config, shows hard coded defaults
 			gomega.Expect(defaultConfig.Containers.HTTPProxy).To(gomega.BeTrue())
+			gomega.Expect(defaultConfig.Engine.HealthcheckEvents).To(gomega.BeTrue())
 
 			err := readConfigFromFile("testdata/containers_default.conf", defaultConfig, false)
 
@@ -306,6 +307,7 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(defaultConfig.Engine.InfraImage).To(gomega.BeEquivalentTo("k8s.gcr.io/pause:3.4.1"))
 			gomega.Expect(defaultConfig.Machine.Volumes.Get()).To(gomega.BeEquivalentTo(volumes))
 			gomega.Expect(defaultConfig.Engine.PodmanshTimeout).To(gomega.BeEquivalentTo(300))
+			gomega.Expect(defaultConfig.Engine.HealthcheckEvents).To(gomega.BeFalse())
 			newV, err := defaultConfig.MachineVolumes()
 			if newVolumes[0] == ":" {
 				// $HOME is not set

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -529,6 +529,15 @@ default_sysctls = [
 # with detailed information about the container.
 #events_container_create_inspect_data = false
 
+# Whenever Podman should log healthcheck events.
+# With many running healthcheck on short interval Podman will spam the event
+# log a lot as it generates a event for each single healthcheck run. Because
+# this event is optional and only useful to external consumers that may want
+# to know when a healthcheck is run or failed allow users to turn it off by
+# setting it to false. The default is true.
+#
+#healthcheck_events = true
+
 # A is a list of directories which are used to search for helper binaries.
 #
 #helper_binaries_dir = [

--- a/pkg/config/containers.conf-freebsd
+++ b/pkg/config/containers.conf-freebsd
@@ -399,6 +399,15 @@ default_sysctls = [
 #
 #events_logger = "file"
 
+# Whenever Podman should log healthcheck events.
+# With many running healthcheck on short interval Podman will spam the event
+# log a lot as it generates a event for each single healthcheck run. Because
+# this event is optional and only useful to external consumers that may want
+# to know when a healthcheck is run or failed allow users to turn it off by
+# setting it to false. The default is true.
+#
+#healthcheck_events = true
+
 # A is a list of directories which are used to search for helper binaries.
 #
 #helper_binaries_dir = [

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -344,6 +344,7 @@ func defaultEngineConfig() (*EngineConfig, error) {
 	c.VolumePluginTimeout = DefaultVolumePluginTimeout
 	c.CompressionFormat = "gzip"
 
+	c.HealthcheckEvents = true
 	c.HelperBinariesDir.Set(defaultHelperBinariesDir)
 	if additionalHelperBinariesDir != "" {
 		// Prioritize additionalHelperBinariesDir over defaults.

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -212,6 +212,8 @@ no_pivot_root = false
 # namespace is set, all containers and pods are visible.
 #namespace = ""
 
+healthcheck_events = false
+
 # A is a list of directories which are used to search for helper binaries.
 #
 helper_binaries_dir = [


### PR DESCRIPTION
Some users wish to turn of healthcheck events in Podman so add a config
option to allow that. The actual logic must live in Podman.

Link: https://issues.redhat.com/browse/RHEL-18987