### PR TITLE
[skip-ci] Packit: New workflow for downstream Fedora and CentOS Stream 10

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -5,7 +5,7 @@
 skip = ./vendor,./.git #,bin,vendor,.git,go.sum,changelog.txt,.cirrus.yml,"RELEASE_NOTES.md,*.xz,*.gz,*.tar,*.tgz,bin2img,*ico,*.png,*.1,*.5,copyimg,*.orig,apidoc.go"
 
 # Comma separated list of words to be ignored. Words must be lowercased.
-ignore-words-list = clos,creat,ro,hastable,shouldnot,mountns
+ignore-words-list = clos,creat,ro,hastable,shouldnot,mountns,passt
 
 # Custom dictionary file that contains spelling corrections.
 # Run with option '--dictionary=-' to include also default dictionary.

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,82 @@
+---
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+downstream_package_name: containers-common
+upstream_tag_template: v{version}
+
+packages:
+  containers-common-fedora:
+    pkg_tool: fedpkg
+    specfile_path: rpm/containers-common.spec
+  containers-common-centos:
+    pkg_tool: centpkg
+    specfile_path: rpm/containers-common.spec
+
+actions:
+  pre-sync: "bash rpm/update-lib-versions.sh"
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    packages: [containers-common-fedora]
+    notifications: &ephemeral_build_failure_notification
+      failure_comment:
+        message: "Ephemeral COPR build failed. @containers/packit-build please check."
+    enable_net: true
+    targets:
+      fedora-development: {}
+      fedora-latest: {}
+      fedora-eln:
+        # Need this to fetch go-md2man which is present in koji envs but not by
+        # default on copr envs. Also helps to avoid bundling go-md2man in
+        # c/common.
+        additional_repos:
+          - https://kojipkgs.fedoraproject.org/repos/eln-build/latest/x86_64/
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [containers-common-centos]
+    notifications: *ephemeral_build_failure_notification
+    enable_net: true
+    targets:
+      - epel-9
+      - centos-stream-10
+
+  # Run on commit to main branch
+  - job: copr_build
+    trigger: commit
+    notifications:
+      failure_comment:
+        message: "containers-common-next COPR build failed. @containers/packit-build please check."
+    branch: main
+    owner: rhcontainerbot
+    project: containers-common-next
+    enable_net: true
+
+  - job: propose_downstream
+    trigger: release
+    update_release: false
+    packages: [containers-common-fedora]
+    dist_git_branches:
+      - fedora-development
+      - fedora-latest
+
+  - job: propose_downstream
+    trigger: release
+    update_release: false
+    packages: [containers-common-centos]
+    dist_git_branches:
+      - c10s
+
+  - job: koji_build
+    trigger: commit
+    packages: [containers-common-fedora]
+    dist_git_branches:
+      - fedora-all
+
+  - job: bodhi_update
+    trigger: commit
+    packages: [containers-common-fedora]
+    dist_git_branches:
+      - fedora-branched # rawhide updates are created automatically

--- a/contrib/redhat/registry.access.redhat.com.yaml
+++ b/contrib/redhat/registry.access.redhat.com.yaml
@@ -1,0 +1,3 @@
+docker:
+     registry.access.redhat.com:
+         sigstore: https://access.redhat.com/webassets/docker/content/sigstore

--- a/contrib/redhat/registry.redhat.io.yaml
+++ b/contrib/redhat/registry.redhat.io.yaml
@@ -1,0 +1,3 @@
+docker:
+     registry.redhat.io:
+         sigstore: https://registry.redhat.io/containers/sigstore

--- a/rpm/containers-common.spec
+++ b/rpm/containers-common.spec
@@ -1,0 +1,204 @@
+# Below definitions are used to deliver config files from a particular branch
+# of c/image, c/storage  and c/shortnames vendored in all of Buildah, Podman and Skopeo.
+# These vendored components must have the same version. If it is not the case,
+# pick the oldest version on c/image, c/storage and c/shortnames vendored in
+# Buildah/Podman/Skopeo.
+
+# Packit will automatically update the image and storage versions on Fedora and
+# CentOS Stream dist-git PRs.
+%global image_branch main
+%global storage_branch main
+%global shortnames_branch main
+
+%global github_containers https://raw.githubusercontent.com/containers
+
+%if %{defined copr_username}
+%define copr_build 1
+%endif
+
+Name: containers-common
+%if %{defined copr_build}
+Epoch: 102
+%else
+Epoch: 5
+%endif
+# DO NOT TOUCH the Version string!
+# The TRUE source of this specfile is:
+# https://github.com/containers/common/blob/main/rpm/containers-common.spec
+# If that's what you're reading, Version must be 0, and will be updated by Packit for
+# copr and koji builds.
+# If you're reading this on dist-git, the version is automatically filled in by Packit.
+Version: 0
+Release: %autorelease
+License: Apache-2.0
+BuildArch: noarch
+# for BuildRequires: go-md2man
+ExclusiveArch: %{golang_arches} noarch
+Summary: Common configuration and documentation for containers
+BuildRequires: git-core
+BuildRequires: go-md2man
+Provides: skopeo-containers = %{epoch}:%{version}-%{release}
+Requires: (container-selinux >= 2:2.162.1 if selinux-policy)
+Suggests: fuse-overlayfs
+Source0: %{git0}/archive/v%{version_no_tilde}.tar.gz
+Source1: %{github_containers}/image/%{image_branch}/docs/containers-auth.json.5.md
+Source2: %{github_containers}/image/%{image_branch}/docs/containers-certs.d.5.md
+Source3: %{github_containers}/image/%{image_branch}/docs/containers-policy.json.5.md
+Source4: %{github_containers}/image/%{image_branch}/docs/containers-registries.conf.5.md
+Source5: %{github_containers}/image/%{image_branch}/docs/containers-registries.conf.d.5.md
+Source6: %{github_containers}/image/%{image_branch}/docs/containers-registries.d.5.md
+Source7: %{github_containers}/image/%{image_branch}/docs/containers-signature.5.md
+Source8: %{github_containers}/image/%{image_branch}/docs/containers-transports.5.md
+Source9: %{github_containers}/storage/%{storage_branch}/docs/containers-storage.conf.5.md
+Source10: %{github_containers}/shortnames/%{shortnames_branch}/shortnames.conf
+Source11: %{github_containers}/image/%{image_branch}/default.yaml
+Source12: %{github_containers}/image/%{image_branch}/default-policy.json
+Source13: %{github_containers}/image/%{image_branch}/registries.conf
+Source14: %{github_containers}/storage/%{storage_branch}/storage.conf
+# Fetch RPM-GPG-KEY-redhat-release from the authoritative source instead of storing
+# a copy in repo or dist-git. Depending on distribution-gpg-keys rpm is also
+# not an option because that package doesn't exist on CentOS Stream.
+Source15: https://access.redhat.com/security/data/fd431d51.txt
+
+%description
+This package contains common configuration files and documentation for container
+tools ecosystem, such as Podman, Buildah and Skopeo.
+
+It is required because the most of configuration files and docs come from projects
+which are vendored into Podman, Buildah, Skopeo, etc. but they are not packaged
+separately.
+
+%package extra
+Summary: Extra dependencies for Podman and Buildah
+Requires: %{name} = %{epoch}:%{version}-%{release}
+Requires: container-network-stack
+Requires: oci-runtime
+Conflicts: podman < 5:5.0.0~rc4-1
+Recommends: composefs
+Recommends: crun
+Requires: (crun if fedora-release-identity-server)
+Requires: netavark >= 1.10.3-1
+Suggests: slirp4netns
+Requires: passt
+Requires: iptables
+Requires: nftables
+Recommends: qemu-user-static
+Requires: (qemu-user-static-aarch64 if fedora-release-identity-server)
+Requires: (qemu-user-static-arm if fedora-release-identity-server)
+Requires: (qemu-user-static-x86 if fedora-release-identity-server)
+
+%description extra
+This subpackage will handle dependencies common to Podman and Buildah which are
+not required by Skopeo.
+
+%prep
+%autosetup -Sgit %{name}-%{version_no_tilde}
+
+# Fine-grain distro- and release-specific tuning of config files,
+# e.g., seccomp, composefs, registries on different RHEL/Fedora versions
+bash rpm/update-config-files.sh
+
+%build
+mv %{SOURCE1} docs/.
+mv %{SOURCE2} docs/.
+mv %{SOURCE3} docs/.
+mv %{SOURCE4} docs/.
+mv %{SOURCE5} docs/.
+mv %{SOURCE6} docs/.
+mv %{SOURCE7} docs/.
+mv %{SOURCE8} docs/.
+mv %{SOURCE9} docs/.
+
+mkdir -p man5
+for i in docs/*.5.md; do
+    go-md2man -in $i -out man5/$(basename $i .md)
+done
+
+%install
+# install config and policy files for registries
+install -dp %{buildroot}%{_sysconfdir}/containers/{certs.d,oci/hooks.d,systemd}
+install -dp %{buildroot}%{_sharedstatedir}/containers/sigstore
+install -dp %{buildroot}%{_datadir}/containers/systemd
+install -dp %{buildroot}%{_prefix}/lib/containers/storage
+install -dp -m 700 %{buildroot}%{_prefix}/lib/containers/storage/overlay-images
+touch %{buildroot}%{_prefix}/lib/containers/storage/overlay-images/images.lock
+install -dp -m 700 %{buildroot}%{_prefix}/lib/containers/storage/overlay-layers
+touch %{buildroot}%{_prefix}/lib/containers/storage/overlay-layers/layers.lock
+
+install -Dp -m0644 %{SOURCE10} %{buildroot}%{_sysconfdir}/containers/registries.conf.d/000-shortnames.conf
+install -Dp -m0644 %{SOURCE11} %{buildroot}%{_sysconfdir}/containers/registries.d/default.yaml
+install -Dp -m0644 %{SOURCE12} %{buildroot}%{_sysconfdir}/containers/policy.json
+install -Dp -m0644 %{SOURCE13} %{buildroot}%{_sysconfdir}/containers/registries.conf
+install -Dp -m0644 %{SOURCE14} %{buildroot}%{_datadir}/containers/storage.conf
+
+# RPM-GPG-KEY-redhat-release already exists on rhel envs, install only on
+# fedora and centos
+%if %{defined fedora} || %{defined centos}
+install -Dp -m0644 %{SOURCE15} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+%endif
+
+install -Dp -m0644 contrib/redhat/registry.access.redhat.com.yaml -t %{buildroot}%{_sysconfdir}/containers/registries.d
+install -Dp -m0644 contrib/redhat/registry.redhat.io.yaml -t %{buildroot}%{_sysconfdir}/containers/registries.d
+
+# install manpages
+install -dp %{buildroot}%{_mandir}/man5
+for i in man5/*.5; do
+   install -Dp -m0644 $i -t %{buildroot}%{_mandir}/man5
+done
+ln -s containerignore.5 %{buildroot}%{_mandir}/man5/.containerignore.5
+
+# install config files for mounts, containers and seccomp
+install -m0644 pkg/subscriptions/mounts.conf %{buildroot}%{_datadir}/containers/mounts.conf
+install -m0644 pkg/seccomp/seccomp.json %{buildroot}%{_datadir}/containers/seccomp.json
+install -m0644 pkg/config/containers.conf %{buildroot}%{_datadir}/containers/containers.conf
+
+# install secrets patch directory
+install -d -p -m 755 %{buildroot}/%{_datadir}/rhel/secrets
+# rhbz#1110876 - update symlinks for subscription management
+ln -s ../../../..%{_sysconfdir}/pki/entitlement %{buildroot}%{_datadir}/rhel/secrets/etc-pki-entitlement
+ln -s ../../../..%{_sysconfdir}/rhsm %{buildroot}%{_datadir}/rhel/secrets/rhsm
+ln -s ../../../..%{_sysconfdir}/yum.repos.d/redhat.repo %{buildroot}%{_datadir}/rhel/secrets/redhat.repo
+
+%files
+%dir %{_sysconfdir}/containers
+%dir %{_sysconfdir}/containers/certs.d
+%dir %{_sysconfdir}/containers/oci
+%dir %{_sysconfdir}/containers/oci/hooks.d
+%dir %{_sysconfdir}/containers/registries.conf.d
+%dir %{_sysconfdir}/containers/registries.d
+%dir %{_sysconfdir}/containers/systemd
+%dir %{_prefix}/lib/containers/storage
+%dir %{_prefix}/lib/containers/storage/overlay-images
+%dir %{_prefix}/lib/containers/storage/overlay-layers
+%{_prefix}/lib/containers/storage/overlay-images/images.lock
+%{_prefix}/lib/containers/storage/overlay-layers/layers.lock
+
+%config(noreplace) %{_sysconfdir}/containers/policy.json
+%config(noreplace) %{_sysconfdir}/containers/registries.conf
+%config(noreplace) %{_sysconfdir}/containers/registries.conf.d/000-shortnames.conf
+%if 0%{?fedora} || 0%{?centos}
+%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+%endif
+%config(noreplace) %{_sysconfdir}/containers/registries.d/default.yaml
+%{_sysconfdir}/containers/registries.d/registry.redhat.io.yaml
+%{_sysconfdir}/containers/registries.d/registry.access.redhat.com.yaml
+%ghost %{_sysconfdir}/containers/storage.conf
+%ghost %{_sysconfdir}/containers/containers.conf
+%dir %{_sharedstatedir}/containers/sigstore
+%{_mandir}/man5/Containerfile.5.gz
+%{_mandir}/man5/containerignore.5.gz
+%{_mandir}/man5/.containerignore.5.gz
+%{_mandir}/man5/containers*.5.gz
+%dir %{_datadir}/containers
+%dir %{_datadir}/containers/systemd
+%{_datadir}/containers/storage.conf
+%{_datadir}/containers/containers.conf
+%{_datadir}/containers/mounts.conf
+%{_datadir}/containers/seccomp.json
+%dir %{_datadir}/rhel/secrets
+%{_datadir}/rhel/secrets/*
+
+%files extra
+
+%changelog
+%autochangelog

--- a/rpm/update-config-files.sh
+++ b/rpm/update-config-files.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# This script delivers current documentation/configs and assures it has the intended
+# settings for a particular branch/release.
+
+set -exo pipefail
+
+ensure() {
+  if grep ^$2[[:blank:]].*= $1 > /dev/null
+  then
+    sed -i "s;^$2[[:blank:]]=.*;$2 = $3;" $1
+  else
+    if grep ^\#.*$2[[:blank:]].*= $1 > /dev/null
+    then
+      sed -i "/^#.*$2[[:blank:]].*=/a \
+$2 = $3" $1
+    else
+      echo "$2 = $3" >> $1
+    fi
+  fi
+}
+
+# Common options enabled across all fedora, centos, rhel
+# TBD: Can these be enabled by default upstream?
+ensure registries.conf              short-name-mode     \"enforcing\"
+
+ensure storage.conf                 driver              \"overlay\"
+ensure storage.conf                 mountopt            \"nodev,metacopy=on\"
+
+ensure pkg/config/containers.conf   runtime             \"crun\"
+ensure pkg/config/containers.conf   log_driver          \"journald\"
+ensure pkg/config/containers.conf   compression_format  \"zstd:chunked\"
+
+# Enable seccomp support keyctl and socketcall
+grep -q \"keyctl\", pkg/seccomp/seccomp.json || sed -i '/\"kill\",/i \
+    "keyctl",' pkg/seccomp/seccomp.json
+grep -q \"socket\", pkg/seccomp/seccomp.json || sed -i '/\"socketcall\",/i \
+    "socket",' pkg/seccomp/seccomp.json
+
+FEDORA=$(rpm --eval '%{?fedora}')
+RHEL=$(rpm --eval '%{?rhel}')
+COPR=$(rpm --eval '%{?copr_username}')
+
+# Set search registries
+if [[ -n "$FEDORA" ]]; then
+    ensure registries.conf unqualified-search-registries [\"registry.fedoraproject.org\",\ \"registry.access.redhat.com\",\ \"docker.io\"]
+else
+    ensure registries.conf unqualified-search-registries [\"registry.access.redhat.com\",\ \"registry.redhat.io\",\ \"docker.io\"]
+fi
+
+# Set these on all Fedora and RHEL 10+
+if [[ -n "$FEDORA" ]] || [[ "$RHEL" -ge 10 ]]; then
+    sed -i -e '/^additionalimagestores\ =\ \[/a "\/usr\/lib\/containers\/storage",' storage.conf
+fi
+
+# Set these on Fedora Rawhide (41+), RHEL 10+, and on all COPR builds
+# regardless of distro
+if [[ -n "$COPR" ]] || [[ "$FEDORA" -gt 40 ]] || [[ "$RHEL" -ge 10 ]]; then
+    ensure storage.conf pull_options    \{enable_partial_images\ =\ \"true\",\ use_hard_links\ =\ \"false\",\ ostree_repos=\"\",\ convert_images\ =\ \"false\"\}
+    # Leave composefs disabled
+    ensure storage.conf use_composefs   \"false\"
+fi

--- a/rpm/update-lib-versions.sh
+++ b/rpm/update-lib-versions.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+SPECFILE=rpm/containers-common.spec
+
+# Fetch versions from go.mod
+IMAGE_VERSION=$(awk '/github.com\/containers\/image/ {print $2}' go.mod)
+STORAGE_VERSION=$(awk '/github.com\/containers\/storage/ {print $2}' go.mod)
+
+# Update versions in rpm spec
+sed -i "s/^%global image_branch main/%global image_branch $IMAGE_VERSION/" $SPECFILE
+sed -i "s/^%global storage_branch main/%global storage_branch $STORAGE_VERSION/" $SPECFILE


### PR DESCRIPTION
This commit enables:
- upstream copr build jobs on PRs
- rpm builds on podman-next copr after every commit to main
- Fedora and CentOS Stream 10 downstream update jobs on every upstream
  release
- Fetch RPM-GPG-KEY-redhat-release from https://access.redhat.com/security/data/fd431d51.txt
- Config file patching during rpm build is managed via `rpm/update-config-files.sh`,
  modified from the original script at
  https://gitlab.com/redhat/centos-stream/rpms/containers-common/-/blob/c9s/update.sh
  and modified to include Fedora and RHEL-10


<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
