### PR TITLE
CI VMs: bump to new versions with tmpfs /tmp

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,7 +19,7 @@ env:
     #### image names to test with (double-quotes around names are critical)
     ####
     FEDORA_NAME: "fedora-39"
-    IMAGE_SUFFIX: "c20240320t153921z-f39f38d13"
+    IMAGE_SUFFIX: "c20240411t124913z-f39f38d13"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,7 +35,7 @@ jobs:
     - name: install deps
       run: |
         sudo apt-get -qq update
-        sudo apt-get -qq install libseccomp-dev libdevmapper-dev
+        sudo apt-get -qq install libseccomp-dev
     - name: lint
       uses: golangci/golangci-lint-action@v4
       with:


### PR DESCRIPTION
For the last long time, Fedora CI VMs have had a disk /tmp. Real-world setups typically have tmpfs /tmp. This switches to CI VMs that reflect the real world.

See https://github.com/containers/automation_images/pull/340