### PR TITLE
libnetwork/pasta: fix --map-gw parsing

### DIFF
--- a/libnetwork/pasta/pasta_linux.go
+++ b/libnetwork/pasta/pasta_linux.go
@@ -128,7 +128,7 @@ func createPastaArgs(opts *SetupOptions) ([]string, []string, error) {
 	noUDPInitPorts := true
 	noTCPNamespacePorts := true
 	noUDPNamespacePorts := true
-	noMapGW := true
+	noMapGWIndex := -1
 
 	cmdArgs := []string{"--config-net"}
 
@@ -176,9 +176,7 @@ func createPastaArgs(opts *SetupOptions) ([]string, []string, error) {
 		case "-U", "--udp-ns":
 			noUDPNamespacePorts = false
 		case "--map-gw":
-			noMapGW = false
-			// not an actual pasta(1) option
-			cmdArgs = append(cmdArgs[:i], cmdArgs[i+1:]...)
+			noMapGWIndex = i
 		case dnsForwardOpt:
 			// if there is no arg after it pasta will likely error out anyway due invalid cli args
 			if len(cmdArgs) > i+1 {
@@ -205,8 +203,11 @@ func createPastaArgs(opts *SetupOptions) ([]string, []string, error) {
 	if noUDPNamespacePorts {
 		cmdArgs = append(cmdArgs, "-U", "none")
 	}
-	if noMapGW {
+	if noMapGWIndex < 0 {
 		cmdArgs = append(cmdArgs, "--no-map-gw")
+	} else {
+		// not an actual pasta(1) option so we have to trim it out
+		cmdArgs = append(cmdArgs[:noMapGWIndex], cmdArgs[noMapGWIndex+1:]...)
 	}
 
 	// always pass --quiet to silence the info output from pasta

--- a/libnetwork/pasta/pasta_linux.go
+++ b/libnetwork/pasta/pasta_linux.go
@@ -124,11 +124,11 @@ func Setup2(opts *SetupOptions) (*SetupResult, error) {
 
 // createPastaArgs creates the pasta arguments, it returns the args to be passed to pasta(1) and as second arg the dns forward ips used.
 func createPastaArgs(opts *SetupOptions) ([]string, []string, error) {
-	NoTCPInitPorts := true
-	NoUDPInitPorts := true
-	NoTCPNamespacePorts := true
-	NoUDPNamespacePorts := true
-	NoMapGW := true
+	noTCPInitPorts := true
+	noUDPInitPorts := true
+	noTCPNamespacePorts := true
+	noUDPNamespacePorts := true
+	noMapGW := true
 
 	cmdArgs := []string{"--config-net"}
 
@@ -168,15 +168,15 @@ func createPastaArgs(opts *SetupOptions) ([]string, []string, error) {
 	for i, opt := range cmdArgs {
 		switch opt {
 		case "-t", "--tcp-ports":
-			NoTCPInitPorts = false
+			noTCPInitPorts = false
 		case "-u", "--udp-ports":
-			NoUDPInitPorts = false
+			noUDPInitPorts = false
 		case "-T", "--tcp-ns":
-			NoTCPNamespacePorts = false
+			noTCPNamespacePorts = false
 		case "-U", "--udp-ns":
-			NoUDPNamespacePorts = false
+			noUDPNamespacePorts = false
 		case "--map-gw":
-			NoMapGW = false
+			noMapGW = false
 			// not an actual pasta(1) option
 			cmdArgs = append(cmdArgs[:i], cmdArgs[i+1:]...)
 		case dnsForwardOpt:
@@ -193,19 +193,19 @@ func createPastaArgs(opts *SetupOptions) ([]string, []string, error) {
 		dnsForwardIPs = append(dnsForwardIPs, dnsForwardIpv4)
 	}
 
-	if NoTCPInitPorts {
+	if noTCPInitPorts {
 		cmdArgs = append(cmdArgs, "-t", "none")
 	}
-	if NoUDPInitPorts {
+	if noUDPInitPorts {
 		cmdArgs = append(cmdArgs, "-u", "none")
 	}
-	if NoTCPNamespacePorts {
+	if noTCPNamespacePorts {
 		cmdArgs = append(cmdArgs, "-T", "none")
 	}
-	if NoUDPNamespacePorts {
+	if noUDPNamespacePorts {
 		cmdArgs = append(cmdArgs, "-U", "none")
 	}
-	if NoMapGW {
+	if noMapGW {
 		cmdArgs = append(cmdArgs, "--no-map-gw")
 	}
 

--- a/libnetwork/pasta/pasta_linux_test.go
+++ b/libnetwork/pasta/pasta_linux_test.go
@@ -1,0 +1,228 @@
+package pasta
+
+import (
+	"testing"
+
+	"github.com/containers/common/internal/attributedstring"
+	"github.com/containers/common/libnetwork/types"
+	"github.com/containers/common/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeSetupOptions(configArgs, extraArgs []string, ports []types.PortMapping) *SetupOptions {
+	return &SetupOptions{
+		Config:       &config.Config{Network: config.NetworkConfig{PastaOptions: attributedstring.NewSlice(configArgs)}},
+		Netns:        "netns123",
+		ExtraOptions: extraArgs,
+		Ports:        ports,
+	}
+}
+
+func Test_createPastaArgs(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          *SetupOptions
+		wantArgs       []string
+		wantDnsForward []string
+		wantErr        string
+	}{
+		{
+			name: "default options",
+			input: makeSetupOptions(
+				nil,
+				nil,
+				nil,
+			),
+			wantArgs: []string{
+				"--config-net", "--dns-forward", dnsForwardIpv4, "-t", "none", "-u", "none",
+				"-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
+			},
+			wantDnsForward: []string{dnsForwardIpv4},
+		},
+		{
+			name: "basic port",
+			input: makeSetupOptions(
+				nil,
+				nil,
+				[]types.PortMapping{{HostPort: 80, ContainerPort: 80, Protocol: "tcp", Range: 1}},
+			),
+			wantArgs: []string{
+				"--config-net", "-t", "80-80:80-80", "--dns-forward", dnsForwardIpv4, "-u", "none",
+				"-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
+			},
+			wantDnsForward: []string{dnsForwardIpv4},
+		},
+		{
+			name: "port range",
+			input: makeSetupOptions(
+				nil,
+				nil,
+				[]types.PortMapping{{HostPort: 80, ContainerPort: 80, Protocol: "tcp", Range: 3}},
+			),
+			wantArgs: []string{
+				"--config-net", "-t", "80-82:80-82", "--dns-forward", dnsForwardIpv4, "-u", "none",
+				"-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
+			},
+			wantDnsForward: []string{dnsForwardIpv4},
+		},
+		{
+			name: "different host and container port",
+			input: makeSetupOptions(
+				nil,
+				nil,
+				[]types.PortMapping{{HostPort: 80, ContainerPort: 60, Protocol: "tcp", Range: 1}},
+			),
+			wantArgs: []string{
+				"--config-net", "-t", "80-80:60-60", "--dns-forward", dnsForwardIpv4, "-u", "none",
+				"-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
+			},
+			wantDnsForward: []string{dnsForwardIpv4},
+		},
+		{
+			name: "tcp and udp port",
+			input: makeSetupOptions(
+				nil,
+				nil,
+				[]types.PortMapping{
+					{HostPort: 80, ContainerPort: 60, Protocol: "tcp", Range: 1},
+					{HostPort: 100, ContainerPort: 100, Protocol: "udp", Range: 1},
+				},
+			),
+			wantArgs: []string{
+				"--config-net", "-t", "80-80:60-60", "-u", "100-100:100-100", "--dns-forward",
+				dnsForwardIpv4, "-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
+			},
+			wantDnsForward: []string{dnsForwardIpv4},
+		},
+		{
+			name: "two tcp ports",
+			input: makeSetupOptions(
+				nil,
+				nil,
+				[]types.PortMapping{
+					{HostPort: 80, ContainerPort: 60, Protocol: "tcp", Range: 1},
+					{HostPort: 100, ContainerPort: 100, Protocol: "tcp", Range: 1},
+				},
+			),
+			wantArgs: []string{
+				"--config-net", "-t", "80-80:60-60", "-t", "100-100:100-100", "--dns-forward",
+				dnsForwardIpv4, "-u", "none", "-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
+			},
+			wantDnsForward: []string{dnsForwardIpv4},
+		},
+		{
+			name: "invalid port",
+			input: makeSetupOptions(
+				nil,
+				nil,
+				[]types.PortMapping{
+					{HostPort: 80, ContainerPort: 60, Protocol: "sctp", Range: 1},
+				},
+			),
+			wantErr: "can't forward protocol: sctp",
+		},
+		{
+			name: "config options before extra options",
+			input: makeSetupOptions(
+				[]string{"-i", "eth0"},
+				[]string{"-n", "24"},
+				nil,
+			),
+			wantArgs: []string{
+				"--config-net", "-i", "eth0", "-n", "24", "--dns-forward", dnsForwardIpv4,
+				"-t", "none", "-u", "none", "-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
+			},
+			wantDnsForward: []string{dnsForwardIpv4},
+		},
+		{
+			name: "config options before extra options",
+			input: makeSetupOptions(
+				[]string{"-i", "eth0"},
+				[]string{"-n", "24"},
+				nil,
+			),
+			wantArgs: []string{
+				"--config-net", "-i", "eth0", "-n", "24", "--dns-forward", dnsForwardIpv4,
+				"-t", "none", "-u", "none", "-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
+			},
+			wantDnsForward: []string{dnsForwardIpv4},
+		},
+		{
+			name: "-T option",
+			input: makeSetupOptions(
+				nil,
+				[]string{"-T", "80"},
+				nil,
+			),
+			wantArgs: []string{
+				"--config-net", "-T", "80", "--dns-forward", dnsForwardIpv4,
+				"-t", "none", "-u", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
+			},
+			wantDnsForward: []string{dnsForwardIpv4},
+		},
+		{
+			name: "--tcp-ns option",
+			input: makeSetupOptions(
+				nil,
+				[]string{"--tcp-ns", "80"},
+				nil,
+			),
+			wantArgs: []string{
+				"--config-net", "--tcp-ns", "80", "--dns-forward", dnsForwardIpv4,
+				"-t", "none", "-u", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
+			},
+			wantDnsForward: []string{dnsForwardIpv4},
+		},
+		{
+			name: "--map-gw option",
+			input: makeSetupOptions(
+				nil,
+				[]string{"--map-gw"},
+				nil,
+			),
+			wantArgs: []string{
+				"--config-net", "--dns-forward", dnsForwardIpv4, "-t", "none",
+				"-u", "none", "-T", "none", "-U", "none", "--quiet", "--netns", "netns123",
+			},
+			wantDnsForward: []string{dnsForwardIpv4},
+		},
+		{
+			name: "--dns-forward option",
+			input: makeSetupOptions(
+				nil,
+				[]string{"--dns-forward", "192.168.255.255"},
+				nil,
+			),
+			wantArgs: []string{
+				"--config-net", "--dns-forward", "192.168.255.255", "-t", "none",
+				"-u", "none", "-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
+			},
+			wantDnsForward: []string{"192.168.255.255"},
+		},
+		{
+			name: "two --dns-forward options",
+			input: makeSetupOptions(
+				nil,
+				[]string{"--dns-forward", "192.168.255.255", "--dns-forward", "::1"},
+				nil,
+			),
+			wantArgs: []string{
+				"--config-net", "--dns-forward", "192.168.255.255", "--dns-forward", "::1", "-t", "none",
+				"-u", "none", "-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
+			},
+			wantDnsForward: []string{"192.168.255.255", "::1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args, dnsForward, err := createPastaArgs(tt.input)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr, "createPastaArgs error")
+				return
+			}
+			assert.NoError(t, err, "expect no createPastaArgs error")
+			assert.Equal(t, tt.wantArgs, args, "check arguments")
+			assert.Equal(t, tt.wantDnsForward, dnsForward, "check dns forward")
+		})
+	}
+}

--- a/libnetwork/pasta/pasta_linux_test.go
+++ b/libnetwork/pasta/pasta_linux_test.go
@@ -187,6 +187,19 @@ func Test_createPastaArgs(t *testing.T) {
 			wantDnsForward: []string{dnsForwardIpv4},
 		},
 		{
+			// https://github.com/containers/podman/issues/22477
+			name: "--map-gw with port directly after",
+			input: makeSetupOptions(nil,
+				[]string{"--map-gw", "-T", "80"},
+				nil,
+			),
+			wantArgs: []string{
+				"--config-net", "-T", "80", "--dns-forward", dnsForwardIpv4,
+				"-t", "none", "-u", "none", "-U", "none", "--quiet", "--netns", "netns123",
+			},
+			wantDnsForward: []string{dnsForwardIpv4},
+		},
+		{
 			name: "--dns-forward option",
 			input: makeSetupOptions(
 				nil,


### PR DESCRIPTION
likely best to look at commit by commit, first two are just preparation/cleanup and unit tests, third one is the important one to fix the bug.

libnetwork/pasta: fix --map-gw parsing

If a port option was given after --map-gw then parsing failed as the
next arg was always skipped due the modification of the slice.

Modifing the slice inside the loop is bad and does not do what some
might think. Append here basically creates a new slice (thus you always
have to assign the result to the variable) with the same pointer to the
same underlying array of data[1]. The loop however will still continue to
loop over the slice as it saw it at the begining of the loop.

So in the bug case the underlying array would look like this:
{"--config-net", "--map-gw", "-T", "80"}
and after the append call to remove --map-gw like this:
{"--config-net", "-T", "80", "80"}

The loop iterator has no idea this happen and just moves to the next
index 2 ("80") and thus we never passed "-T" causing this bug.

[1] https://go.dev/blog/slices-intro

Fixes https://github.com/containers/podman/issues/22477