### PR TITLE
libimage: Add input to error context when normalizing

### DIFF
--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -115,7 +115,7 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 		// off and entirely ignored.  The digest is the sole source of truth.
 		normalizedName, _, normalizeError := normalizeTaggedDigestedString(name)
 		if normalizeError != nil {
-			return nil, normalizeError
+			return nil, fmt.Errorf(`parsing reference %q: %w`, name, normalizeError)
 		}
 		name = normalizedName
 

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -250,7 +250,7 @@ func (r *Runtime) LookupImage(name string, options *LookupImageOptions) (*Image,
 	// off and entirely ignored.  The digest is the sole source of truth.
 	normalizedName, possiblyUnqualifiedNamedReference, err := normalizeTaggedDigestedString(name)
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf(`parsing reference %q: %w`, name, err)
 	}
 	name = normalizedName
 


### PR DESCRIPTION
Before, here's what happens if you forget a `-v` in your bind mount for example:

```
$ podman run /dev:/dev docker.io/busybox echo hello
Error: invalid reference format
$
```

After:

```
$ podman run /dev:/dev docker.io/busybox echo hello
Error: parsing reference "/dev:/dev": invalid reference format
```

This error prefixing is common in other callers.

```release-note
None
```

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
