### PR TITLE
Support system-wide containers config folder on windows

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,9 +21,6 @@ import (
 )
 
 const (
-	// _configPath is the path to the containers/containers.conf
-	// inside a given config directory.
-	_configPath = "containers/containers.conf"
 	// UserOverrideContainersConfig holds the containers config path overridden by the rootless user
 	UserOverrideContainersConfig = ".config/" + _configPath
 	// Token prefix for looking for helper binary under $BINDIR

--- a/pkg/config/config_unix.go
+++ b/pkg/config/config_unix.go
@@ -9,6 +9,10 @@ import (
 	"github.com/containers/storage/pkg/unshare"
 )
 
+// _configPath is the path to the containers/containers.conf
+// inside a given config directory.
+const _configPath = "containers/containers.conf"
+
 // userConfigPath returns the path to the users local config that is
 // not shared with other users. It uses $XDG_CONFIG_HOME/containers...
 // if set or $HOME/.config/containers... if not.
@@ -22,4 +26,10 @@ func userConfigPath() (string, error) {
 	}
 
 	return filepath.Join(home, UserOverrideContainersConfig), nil
+}
+
+// overrideContainersConfigPath returns the default config path overridden
+// by the root user
+func overrideContainersConfigPath() (string, error) {
+	return OverrideContainersConfig, nil
 }

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -3,11 +3,12 @@ package config
 import "os"
 
 const (
-	// OverrideContainersConfig holds the default config path overridden by the root user
-	OverrideContainersConfig = "/etc/" + _configPath
+	// _configPath is the path to the containers/containers.conf
+	// inside a given config directory.
+	_configPath = "containers\\containers.conf"
 
 	// DefaultContainersConfig holds the default containers config path
-	DefaultContainersConfig = "/usr/share/" + _configPath
+	DefaultContainersConfig = ""
 
 	// DefaultSignaturePolicyPath is the default value for the
 	// policy.json file.
@@ -20,7 +21,13 @@ const (
 // userConfigPath returns the path to the users local config that is
 // not shared with other users. It uses $APPDATA/containers...
 func userConfigPath() (string, error) {
-	return os.Getenv("APPDATA") + "\\containers\\containers.conf", nil
+	return os.Getenv("APPDATA") + _configPath, nil
+}
+
+// overrideContainersConfigPath returns the path to the system wide
+// containers config folder. It users $PROGRAMDATA/containers...
+func overrideContainersConfigPath() (string, error) {
+	return os.Getenv("ProgramData") + _configPath, nil
 }
 
 var defaultHelperBinariesDir = []string{

--- a/pkg/config/new.go
+++ b/pkg/config/new.go
@@ -158,16 +158,22 @@ func systemConfigs() (configs []string, finalErr error) {
 		}
 		return append(configs, path), nil
 	}
+
 	configs = append(configs, DefaultContainersConfig)
-	configs = append(configs, OverrideContainersConfig)
 
 	var err error
-	configs, err = addConfigs(OverrideContainersConfig+".d", configs)
+	path, err := overrideContainersConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	configs = append(configs, path)
+
+	configs, err = addConfigs(path+".d", configs)
 	if err != nil {
 		return nil, err
 	}
 
-	path, err := userConfigPath()
+	path, err = userConfigPath()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add `%PROGRAMDATA%/containers` to the list of possible config folders on Windows.

For all OSes returns the "the default config path overridden by the root user" using a function rather than a `const` to allow composing it with variable `PROGRAMDATA` on windows.

Fixes https://github.com/containers/podman/issues/22411

