### PR TITLE
Closes #22543 . Updated outdated documentation: slirp4netns vs pasta

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -442,10 +442,10 @@ default_subnet_pools = [
 ]
 ```
 
-**default_rootless_network_cmd**="pasta"
+**default_rootless_network_cmd**="slirp4netns"
 
 Configure which rootless network program to use by default. Valid options are
-`slirp4netns` and `pasta` (default).
+`slirp4netns` (default) and `pasta`.
 
 **network_config_dir**="/etc/cni/net.d/"
 


### PR DESCRIPTION
Updated outdated documentation: slirp4netns vs pasta in docs/containers.conf.5.md file.
Closes : #22543

