### PR TITLE
[skip-ci] Packit: fix copr name

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -48,10 +48,10 @@ jobs:
     trigger: commit
     notifications:
       failure_comment:
-        message: "containers-common-next COPR build failed. @containers/packit-build please check."
+        message: "podman-next COPR build failed. @containers/packit-build please check."
     branch: main
     owner: rhcontainerbot
-    project: containers-common-next
+    project: podman-next
     enable_net: true
 
   - job: propose_downstream


### PR DESCRIPTION
The copr name got mistakenly changed during a replace-all in #1960.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
