### PR TITLE
use new "lookaside" setting for RH registries

### DIFF
--- a/contrib/redhat/registry.access.redhat.com.yaml
+++ b/contrib/redhat/registry.access.redhat.com.yaml
@@ -1,3 +1,3 @@
 docker:
      registry.access.redhat.com:
-         sigstore: https://access.redhat.com/webassets/docker/content/sigstore
+         lookaside: https://access.redhat.com/webassets/docker/content/sigstore

--- a/contrib/redhat/registry.redhat.io.yaml
+++ b/contrib/redhat/registry.redhat.io.yaml
@@ -1,3 +1,3 @@
 docker:
      registry.redhat.io:
-         sigstore: https://registry.redhat.io/containers/sigstore
+         lookaside: https://registry.redhat.io/containers/sigstore


### PR DESCRIPTION
The old `sigstore` setting was confusing to users now that "Sigstore" is an independent open-source project. Use the newer `lookaside` setting as described in https://github.com/containers/image/pull/1606

(This is a resubmission of https://src.fedoraproject.org/rpms/containers-common/pull-request/6)