### PR TITLE
[skip-ci] RPM: redhat registry config files should be config(noreplace)

### DIFF
--- a/rpm/containers-common.spec
+++ b/rpm/containers-common.spec
@@ -180,8 +180,8 @@ ln -s ../../../..%{_sysconfdir}/yum.repos.d/redhat.repo %{buildroot}%{_datadir}/
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 %endif
 %config(noreplace) %{_sysconfdir}/containers/registries.d/default.yaml
-%{_sysconfdir}/containers/registries.d/registry.redhat.io.yaml
-%{_sysconfdir}/containers/registries.d/registry.access.redhat.com.yaml
+%config(noreplace) %{_sysconfdir}/containers/registries.d/registry.redhat.io.yaml
+%config(noreplace) %{_sysconfdir}/containers/registries.d/registry.access.redhat.com.yaml
 %ghost %{_sysconfdir}/containers/storage.conf
 %ghost %{_sysconfdir}/containers/containers.conf
 %dir %{_sharedstatedir}/containers/sigstore


### PR DESCRIPTION
This will allow users to edit these configs and have those changes persist.

Will be needed if users experience issues with using the `lookaside` setting instead of the current `sigstore` setting that these files ship with.
Ref: https://github.com/containers/common/pull/1983

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
