### PR TITLE
Allow configuration of podmansh

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -864,10 +864,6 @@ depend on the compression format used. For gzip, valid options are
 1-9, with a default of 5. For zstd, valid options are 1-20, with a
 default of 3.
 
-**podmansh_timeout**=30
-
-Number of seconds to wait for podmansh logins.
-
 ## SERVICE DESTINATION TABLE
 The `engine.service_destinations` table contains configuration options used to set up remote connections to the podman service for the podman API.
 
@@ -973,6 +969,25 @@ The default farm to use when farming out builds.
 **[farms.list]**
 
 Map of farms created where the key is the farm name and the value is the list of system connections.
+
+## PODMANSH TABLE
+The `podmansh` table contains configuration options used by podmansh.
+
+**shell**="/bin/sh"
+
+The shell to spawn in the container.
+The default value is `/bin/sh`.
+
+**container**="podmansh"
+
+Name of the container that podmansh joins.
+The default value is `podmansh`.
+
+**timeout**=0
+
+Number of seconds to wait for podmansh logins. This value if favoured over the deprecated field `engine.podmansh_timeout` if set.
+The default value is 30.
+
 
 # FILES
 

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -759,9 +759,6 @@ default_sysctls = [
 # A value of 0 is treated as no timeout.
 #volume_plugin_timeout = 5
 
-# Default timeout in seconds for podmansh logins.
-#podmansh_timeout = 30
-
 # Paths to look for a valid OCI runtime (crun, runc, kata, runsc, krun, etc)
 [engine.runtimes]
 #crun = [
@@ -889,3 +886,14 @@ default_sysctls = [
 #
 # map of existing farms
 #[farms.list]
+
+[podmansh]
+# Shell to spawn in container. Default: /bin/sh.
+#shell = "/bin/sh"
+# 
+# Name of the container the podmansh user should join.
+#container = "podmansh"
+# 
+# Default timeout in seconds for podmansh logins.
+# Favored over the deprecated "podmansh_timeout" field.
+#timeout = 30

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -265,10 +265,11 @@ func defaultConfig() (*Config, error) {
 			CNIPluginDirs:             attributedstring.NewSlice(DefaultCNIPluginDirs),
 			NetavarkPluginDirs:        attributedstring.NewSlice(DefaultNetavarkPluginDirs),
 		},
-		Engine:  *defaultEngineConfig,
-		Secrets: defaultSecretConfig(),
-		Machine: defaultMachineConfig(),
-		Farms:   defaultFarmConfig(),
+		Engine:   *defaultEngineConfig,
+		Secrets:  defaultSecretConfig(),
+		Machine:  defaultMachineConfig(),
+		Farms:    defaultFarmConfig(),
+		Podmansh: defaultPodmanshConfig(),
 	}, nil
 }
 
@@ -304,6 +305,18 @@ func defaultMachineConfig() MachineConfig {
 func defaultFarmConfig() FarmConfig {
 	return FarmConfig{
 		List: map[string][]string{},
+	}
+}
+
+// defaultPodmanshConfig returns the default podmansh configuration.
+func defaultPodmanshConfig() PodmanshConfig {
+	return PodmanshConfig{
+		Shell:     "/bin/sh",
+		Container: "podmansh",
+
+		// A value of 0 means "not set", needed to distinguish if engine.podmansh_timeout or podmansh.timeout should be used
+		// This is needed to keep backwards compatibility to engine.PodmanshTimeout.
+		Timeout: uint(0),
 	}
 }
 
@@ -360,7 +373,7 @@ func defaultEngineConfig() (*EngineConfig, error) {
 	c.CgroupManager = defaultCgroupManager()
 	c.ServiceTimeout = uint(5)
 	c.StopTimeout = uint(10)
-	c.PodmanshTimeout = uint(30)
+	c.PodmanshTimeout = uint(30) // deprecated: use podmansh.timeout instead, kept for backwards-compatibility
 	c.ExitCommandDelay = uint(5 * 60)
 	c.Remote = isRemote()
 	c.Retry = 3

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -287,7 +287,7 @@ runtime_supports_json = ["runc"]
 # SSH config file path
 ssh_config = "/foo/bar/.ssh/config"
 
-# Number of seconds to wait for podmansh logins.
+# Deprecated in favor of podmansh.Timeout, should not be used anymore.
 podmansh_timeout = 300
 
 # Paths to look for a valid OCI runtime (runc, runv, etc)
@@ -306,6 +306,14 @@ crun = [
 	    "/usr/bin/crun",
 	    "/usr/local/bin/crun",
 ]
+
+[podmansh]
+# Shell to start in container. Default: /bin/sh.
+shell = "/bin/zsh"
+# Name of the container the podmansh user should join.
+container = "podmansh-1"
+# Number of seconds to wait for podmansh logins.
+timeout = 42
 
 [machine]
 # Number of CPU's a machine is created with.


### PR DESCRIPTION
Adds a new configuration section `podmansh` to configure the shell,
container and the timeout for podmansh.

See https://github.com/containers/podman/pull/22683 for more context.