### PR TITLE
CI: update VM to fedora 40

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,8 +18,8 @@ env:
     ####
     #### image names to test with (double-quotes around names are critical)
     ####
-    FEDORA_NAME: "fedora-39"
-    IMAGE_SUFFIX: "c20240411t124913z-f39f38d13"
+    FEDORA_NAME: "fedora-40"
+    IMAGE_SUFFIX: "c20240513t140131z-f40f39d13"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
 
@@ -47,8 +47,6 @@ testing_task:
   env:
     NETAVARK_BINARY: "/usr/libexec/podman/netavark"
   test_script:
-    # FIXME: 2024-03-21: remove this when bumping VM to fc40
-    - dnf install -y podman-plugins
     - mkdir "$GOLANGCI_LINT_CACHE"
     - export PATH="$PATH:$GOPATH/bin"
     - gpg --batch --passphrase '' --quick-gen-key tester@localhost default default never

--- a/libnetwork/cni/config_test.go
+++ b/libnetwork/cni/config_test.go
@@ -1024,6 +1024,7 @@ var _ = Describe("Config", func() {
 		})
 
 		It("create bridge with dns", func() {
+			SkipIfNoDnsname()
 			network := types.Network{
 				Driver:     "bridge",
 				DNSEnabled: true,
@@ -1212,6 +1213,7 @@ var _ = Describe("Config", func() {
 		})
 
 		It("network create internal and dns", func() {
+			SkipIfNoDnsname()
 			network := types.Network{
 				Driver:     "bridge",
 				Internal:   true,
@@ -1737,12 +1739,12 @@ func grepNotFile(path, match string) {
 
 func grepFile(not bool, path, match string) {
 	data, err := os.ReadFile(path)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(2, err).ToNot(HaveOccurred())
 	matcher := ContainSubstring(match)
 	if not {
 		matcher = Not(matcher)
 	}
-	ExpectWithOffset(1, string(data)).To(matcher)
+	ExpectWithOffset(2, string(data)).To(matcher)
 }
 
 // HaveNetworkName is a custom GomegaMatcher to match a network name

--- a/libnetwork/cni/testfiles/invalid/invalid_gateway.conflist
+++ b/libnetwork/cni/testfiles/invalid/invalid_gateway.conflist
@@ -39,13 +39,6 @@
       },
       {
          "type": "tuning"
-      },
-      {
-         "type": "dnsname",
-         "domainName": "dns.podman",
-         "capabilities": {
-            "aliases": true
-         }
       }
    ]
 }

--- a/libnetwork/cni/testfiles/invalid/invalidname.conflist
+++ b/libnetwork/cni/testfiles/invalid/invalidname.conflist
@@ -37,13 +37,6 @@
       },
       {
          "type": "tuning"
-      },
-      {
-         "type": "dnsname",
-         "domainName": "dns.podman",
-         "capabilities": {
-            "aliases": true
-         }
       }
    ]
 }

--- a/libnetwork/cni/testfiles/invalid/noname.conflist
+++ b/libnetwork/cni/testfiles/invalid/noname.conflist
@@ -36,13 +36,6 @@
       },
       {
          "type": "tuning"
-      },
-      {
-         "type": "dnsname",
-         "domainName": "dns.podman",
-         "capabilities": {
-            "aliases": true
-         }
       }
    ]
 }

--- a/libnetwork/cni/testfiles/invalid/samename1.conflist
+++ b/libnetwork/cni/testfiles/invalid/samename1.conflist
@@ -37,13 +37,6 @@
       },
       {
          "type": "tuning"
-      },
-      {
-         "type": "dnsname",
-         "domainName": "dns.podman",
-         "capabilities": {
-            "aliases": true
-         }
       }
    ]
 }

--- a/libnetwork/cni/testfiles/invalid/samename2.conflist
+++ b/libnetwork/cni/testfiles/invalid/samename2.conflist
@@ -37,13 +37,6 @@
       },
       {
          "type": "tuning"
-      },
-      {
-         "type": "dnsname",
-         "domainName": "dns.podman",
-         "capabilities": {
-            "aliases": true
-         }
       }
    ]
 }

--- a/libnetwork/cni/testfiles/valid/bridge.conflist
+++ b/libnetwork/cni/testfiles/valid/bridge.conflist
@@ -39,13 +39,6 @@
       },
       {
          "type": "tuning"
-      },
-      {
-         "type": "dnsname",
-         "domainName": "dns.podman",
-         "capabilities": {
-            "aliases": true
-         }
       }
    ]
 }

--- a/libnetwork/cni/testfiles/valid/dualstack.conflist
+++ b/libnetwork/cni/testfiles/valid/dualstack.conflist
@@ -46,13 +46,6 @@
       },
       {
          "type": "tuning"
-      },
-      {
-         "type": "dnsname",
-         "domainName": "dns.podman",
-         "capabilities": {
-            "aliases": true
-         }
       }
    ]
 }

--- a/libnetwork/cni/testfiles/valid/ipam-empty.conflist
+++ b/libnetwork/cni/testfiles/valid/ipam-empty.conflist
@@ -22,13 +22,6 @@
       },
       {
          "type": "tuning"
-      },
-      {
-         "type": "dnsname",
-         "domainName": "dns.podman",
-         "capabilities": {
-            "aliases": true
-         }
       }
    ]
 }

--- a/libnetwork/cni/testfiles/valid/ipam-none.conflist
+++ b/libnetwork/cni/testfiles/valid/ipam-none.conflist
@@ -21,13 +21,6 @@
       },
       {
          "type": "tuning"
-      },
-      {
-         "type": "dnsname",
-         "domainName": "dns.podman",
-         "capabilities": {
-            "aliases": true
-         }
       }
    ]
 }

--- a/libnetwork/cni/testfiles/valid/ipam-static.conflist
+++ b/libnetwork/cni/testfiles/valid/ipam-static.conflist
@@ -37,13 +37,6 @@
       },
       {
          "type": "tuning"
-      },
-      {
-         "type": "dnsname",
-         "domainName": "dns.podman",
-         "capabilities": {
-            "aliases": true
-         }
       }
    ]
 }

--- a/libnetwork/cni/testfiles/valid/label.conflist
+++ b/libnetwork/cni/testfiles/valid/label.conflist
@@ -42,13 +42,6 @@
       },
       {
          "type": "tuning"
-      },
-      {
-         "type": "dnsname",
-         "domainName": "dns.podman",
-         "capabilities": {
-            "aliases": true
-         }
       }
    ]
 }

--- a/libnetwork/cni/testfiles/valid/mtu.conflist
+++ b/libnetwork/cni/testfiles/valid/mtu.conflist
@@ -37,13 +37,6 @@
       },
       {
          "type": "tuning"
-      },
-      {
-         "type": "dnsname",
-         "domainName": "dns.podman",
-         "capabilities": {
-            "aliases": true
-         }
       }
    ]
 }

--- a/libnetwork/cni/testfiles/valid/vlan.conflist
+++ b/libnetwork/cni/testfiles/valid/vlan.conflist
@@ -38,13 +38,6 @@
       },
       {
          "type": "tuning"
-      },
-      {
-         "type": "dnsname",
-         "domainName": "dns.podman",
-         "capabilities": {
-            "aliases": true
-         }
       }
    ]
 }


### PR DESCRIPTION
Also removes the podman-plugins (dnsname) package. As such I had to fix the the cni tests that use dnsname.
