### PR TITLE
libnetwork: add option to return rootless-netns ips

### DIFF
--- a/libnetwork/cni/run.go
+++ b/libnetwork/cni/run.go
@@ -295,3 +295,10 @@ func (n *cniNetwork) RunInRootlessNetns(toRun func() error) error {
 	}
 	return n.rootlessNetns.Run(n.lock, toRun)
 }
+
+func (n *cniNetwork) RootlessNetnsInfo() (*types.RootlessNetnsInfo, error) {
+	if n.rootlessNetns == nil {
+		return nil, types.ErrNotRootlessNetns
+	}
+	return n.rootlessNetns.Info(), nil
+}

--- a/libnetwork/internal/rootlessnetns/netns_freebsd.go
+++ b/libnetwork/internal/rootlessnetns/netns_freebsd.go
@@ -3,6 +3,7 @@ package rootlessnetns
 import (
 	"errors"
 
+	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/storage/pkg/lockfile"
 )
@@ -25,4 +26,8 @@ func (n *Netns) Teardown(nets int, toRun func() error) error {
 
 func (n *Netns) Run(lock *lockfile.LockFile, toRun func() error) error {
 	return ErrNotSupported
+}
+
+func (n *Netns) Info() *types.RootlessNetnsInfo {
+	return &types.RootlessNetnsInfo{}
 }

--- a/libnetwork/netavark/run.go
+++ b/libnetwork/netavark/run.go
@@ -187,3 +187,10 @@ func (n *netavarkNetwork) RunInRootlessNetns(toRun func() error) error {
 	}
 	return n.rootlessNetns.Run(n.lock, toRun)
 }
+
+func (n *netavarkNetwork) RootlessNetnsInfo() (*types.RootlessNetnsInfo, error) {
+	if n.rootlessNetns == nil {
+		return nil, types.ErrNotRootlessNetns
+	}
+	return n.rootlessNetns.Info(), nil
+}

--- a/libnetwork/types/network.go
+++ b/libnetwork/types/network.go
@@ -31,6 +31,11 @@ type ContainerNetwork interface {
 	// Only used as rootless and should return an error as root.
 	RunInRootlessNetns(toRun func() error) error
 
+	// RootlessNetnsInfo return extra information about the rootless netns.
+	// Only valid when called after Setup().
+	// Only used as rootless and should return an error as root.
+	RootlessNetnsInfo() (*RootlessNetnsInfo, error)
+
 	// Drivers will return the list of supported network drivers
 	// for this interface.
 	Drivers() []string
@@ -332,6 +337,11 @@ type SetupOptions struct {
 
 type TeardownOptions struct {
 	NetworkOptions
+}
+
+type RootlessNetnsInfo struct {
+	// IPAddresses used in the netns, must not be used for host.containers.internal
+	IPAddresses []net.IP
 }
 
 // FilterFunc can be passed to NetworkList to filter the networks.


### PR DESCRIPTION
When using the bridge network mode as rootless we use the rootless netns logic, for podman this looks like just as using bridge as root. The issue is however due the extra namespace we block certain address there. This can be seen best with pasta but actually effects other cases too. The podman logic tries to use any host ip address for host.containers.internal but we must make sure to exculde all these address in the rootless netns as they are not actually the hostns as thus cause great confusion.

For the --network pasta case I already fixed this by returning the ips on the pasta.Setup2() call in b809d7231132.
For the bridge mode this more complicated due several layers of function calls. I decided to implement this as extra function call on the interface to return the ips as this makes the usage in podman the easiest. And I also didn't want to break the API as we only have to fix this in podman not buildah.

It is needed to address #22653 but it needs podman changes as well to use this new function.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
