### PR TITLE
Update apparmor profile to support v4.0.0

### DIFF
--- a/pkg/apparmor/apparmor_linux_template.go
+++ b/pkg/apparmor/apparmor_linux_template.go
@@ -21,6 +21,10 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   # Allow signals from privileged profiles and from within the same profile
   signal (receive) peer=unconfined,
   signal (send,receive) peer={{.Name}},
+  # Allow certain signals from OCI runtimes (podman, runc and crun)
+  signal (receive) peer={/usr/bin/,/usr/sbin/,}runc,
+  signal (receive) peer={/usr/bin/,/usr/sbin/,}crun*,
+  signal (receive) set=(int, quit, kill, term) peer={/usr/bin/,/usr/sbin/,}podman,
 {{end}}
 
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)


### PR DESCRIPTION
AppArmor v4.0.0 introduced podman, runc and crun profiles for /usr/bin/podman, /usr/sbin/runc and /usr/bin/crun respectively[1]. This change breaks the stopping of containers, because the built-in profile assigned to containers doesn't accept signals from podman, runc and crun peers.

This commit extends the default profile with rules that allow receiving signals from processes that run confined with the podman, runc or crun profile. It is backward compatible because the peer value is a regular expression (AARE) so the referenced profile doesn't have to exist for this profile to successfully compile and load.

The signal set from runc or crun remains unconstrained as the user can issue any signal via the kill sub-command of podman.

Signals from podman itself are restricted to the common interrupt and termination signals.

Closes #1898

[1] https://gitlab.com/apparmor/apparmor/-/commit/2594d936

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
