### PR TITLE
[v0.59.0] Bump c/common to v0.59.1-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.59.0"
+const Version = "0.59.1-dev"


### PR DESCRIPTION
Bump the version to the initial dev for the new c/common v0.59 release branch.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
