### PR TITLE
updates pause image to 3.10

### DIFF
--- a/libimage/manifests/manifests_test.go
+++ b/libimage/manifests/manifests_test.go
@@ -51,7 +51,7 @@ type listPtr = *list
 const (
 	listImageName = "foo"
 
-	otherListImage          = "docker://k8s.gcr.io/pause:3.1"
+	otherListImage          = "docker://k8s.gcr.io/pause:3.10"
 	otherListDigest         = "sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea"
 	otherListAmd64Digest    = "sha256:59eec8837a4d942cc19a52b8c09ea75121acc38114a2c68b98983ce9356b8610"
 	otherListArm64Digest    = "sha256:f365626a556e58189fc21d099fc64603db0f440bff07f77c740989515c544a39"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -334,7 +334,7 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(defaultConfig.Engine.NetworkCmdOptions.Get()).To(gomega.BeEmpty())
 			gomega.Expect(defaultConfig.Engine.HelperBinariesDir.Get()).To(gomega.Equal(helperDirs))
 			gomega.Expect(defaultConfig.Engine.ServiceTimeout).To(gomega.BeEquivalentTo(300))
-			gomega.Expect(defaultConfig.Engine.InfraImage).To(gomega.BeEquivalentTo("k8s.gcr.io/pause:3.4.1"))
+			gomega.Expect(defaultConfig.Engine.InfraImage).To(gomega.BeEquivalentTo("k8s.gcr.io/pause:3.10"))
 			gomega.Expect(defaultConfig.Engine.PodmanshTimeout).To(gomega.BeEquivalentTo(300))
 			gomega.Expect(defaultConfig.Machine.Volumes.Get()).To(gomega.BeEquivalentTo(volumes))
 			gomega.Expect(defaultConfig.Podmansh.Timeout).To(gomega.BeEquivalentTo(42))

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -231,7 +231,7 @@ hooks_dir = [
 # cdi_spec_dirs = [ "/etc/cdi" ]
 
 # Default infra (pause) image name for pod infra containers
-infra_image = "k8s.gcr.io/pause:3.4.1"
+infra_image = "k8s.gcr.io/pause:3.10"
 
 # Default command to run the infra container
 infra_command = "/pause"


### PR DESCRIPTION
What this PR does / why we need it:
bumps pause image to 3.10
Per https://github.com/kubernetes/kubernetes/issues/125092

Which issue(s) this PR fixes:
part of https://github.com/kubernetes/kubernetes/pull/125112