### PR TITLE
[v0.59 backport] [skip-ci] Packit/RPM: more fixes

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,14 +2,15 @@
 # See the documentation for more information:
 # https://packit.dev/docs/configuration/
 
-downstream_package_name: containers-common
 upstream_tag_template: v{version}
 
 packages:
   containers-common-fedora:
+    downstream_package_name: containers-common
     pkg_tool: fedpkg
     specfile_path: rpm/containers-common.spec
   containers-common-centos:
+    downstream_package_name: containers-common
     pkg_tool: centpkg
     specfile_path: rpm/containers-common.spec
 
@@ -56,7 +57,6 @@ jobs:
 
   - job: propose_downstream
     trigger: release
-    update_release: false
     packages: [containers-common-fedora]
     dist_git_branches:
       - fedora-development
@@ -64,7 +64,6 @@ jobs:
 
   - job: propose_downstream
     trigger: release
-    update_release: false
     packages: [containers-common-centos]
     dist_git_branches:
       - c10s

--- a/rpm/containers-common.spec
+++ b/rpm/containers-common.spec
@@ -10,7 +10,10 @@
 %global storage_branch main
 %global shortnames_branch main
 
-%global github_containers https://raw.githubusercontent.com/containers
+%global project containers
+%global repo common
+
+%global raw_github_url https://raw.githubusercontent.com/%{project}
 
 %if %{defined copr_username}
 %define copr_build 1
@@ -40,21 +43,22 @@ BuildRequires: go-md2man
 Provides: skopeo-containers = %{epoch}:%{version}-%{release}
 Requires: (container-selinux >= 2:2.162.1 if selinux-policy)
 Suggests: fuse-overlayfs
-Source0: %{git0}/archive/v%{version_no_tilde}.tar.gz
-Source1: %{github_containers}/image/%{image_branch}/docs/containers-auth.json.5.md
-Source2: %{github_containers}/image/%{image_branch}/docs/containers-certs.d.5.md
-Source3: %{github_containers}/image/%{image_branch}/docs/containers-policy.json.5.md
-Source4: %{github_containers}/image/%{image_branch}/docs/containers-registries.conf.5.md
-Source5: %{github_containers}/image/%{image_branch}/docs/containers-registries.conf.d.5.md
-Source6: %{github_containers}/image/%{image_branch}/docs/containers-registries.d.5.md
-Source7: %{github_containers}/image/%{image_branch}/docs/containers-signature.5.md
-Source8: %{github_containers}/image/%{image_branch}/docs/containers-transports.5.md
-Source9: %{github_containers}/storage/%{storage_branch}/docs/containers-storage.conf.5.md
-Source10: %{github_containers}/shortnames/%{shortnames_branch}/shortnames.conf
-Source11: %{github_containers}/image/%{image_branch}/default.yaml
-Source12: %{github_containers}/image/%{image_branch}/default-policy.json
-Source13: %{github_containers}/image/%{image_branch}/registries.conf
-Source14: %{github_containers}/storage/%{storage_branch}/storage.conf
+URL: https://github.com/%{project}/%{repo}
+Source0: %{url}/archive/v%{version_no_tilde}.tar.gz
+Source1: %{raw_github_url}/image/%{image_branch}/docs/containers-auth.json.5.md
+Source2: %{raw_github_url}/image/%{image_branch}/docs/containers-certs.d.5.md
+Source3: %{raw_github_url}/image/%{image_branch}/docs/containers-policy.json.5.md
+Source4: %{raw_github_url}/image/%{image_branch}/docs/containers-registries.conf.5.md
+Source5: %{raw_github_url}/image/%{image_branch}/docs/containers-registries.conf.d.5.md
+Source6: %{raw_github_url}/image/%{image_branch}/docs/containers-registries.d.5.md
+Source7: %{raw_github_url}/image/%{image_branch}/docs/containers-signature.5.md
+Source8: %{raw_github_url}/image/%{image_branch}/docs/containers-transports.5.md
+Source9: %{raw_github_url}/storage/%{storage_branch}/docs/containers-storage.conf.5.md
+Source10: %{raw_github_url}/shortnames/%{shortnames_branch}/shortnames.conf
+Source11: %{raw_github_url}/image/%{image_branch}/default.yaml
+Source12: %{raw_github_url}/image/%{image_branch}/default-policy.json
+Source13: %{raw_github_url}/image/%{image_branch}/registries.conf
+Source14: %{raw_github_url}/storage/%{storage_branch}/storage.conf
 # Fetch RPM-GPG-KEY-redhat-release from the authoritative source instead of storing
 # a copy in repo or dist-git. Depending on distribution-gpg-keys rpm is also
 # not an option because that package doesn't exist on CentOS Stream.
@@ -92,22 +96,22 @@ This subpackage will handle dependencies common to Podman and Buildah which are
 not required by Skopeo.
 
 %prep
-%autosetup -Sgit %{name}-%{version_no_tilde}
+%autosetup -Sgit -n %{repo}-%{version_no_tilde}
 
 # Fine-grain distro- and release-specific tuning of config files,
 # e.g., seccomp, composefs, registries on different RHEL/Fedora versions
 bash rpm/update-config-files.sh
 
 %build
-mv %{SOURCE1} docs/.
-mv %{SOURCE2} docs/.
-mv %{SOURCE3} docs/.
-mv %{SOURCE4} docs/.
-mv %{SOURCE5} docs/.
-mv %{SOURCE6} docs/.
-mv %{SOURCE7} docs/.
-mv %{SOURCE8} docs/.
-mv %{SOURCE9} docs/.
+cp %{SOURCE1} docs/.
+cp %{SOURCE2} docs/.
+cp %{SOURCE3} docs/.
+cp %{SOURCE4} docs/.
+cp %{SOURCE5} docs/.
+cp %{SOURCE6} docs/.
+cp %{SOURCE7} docs/.
+cp %{SOURCE8} docs/.
+cp %{SOURCE9} docs/.
 
 mkdir -p man5
 for i in docs/*.5.md; do


### PR DESCRIPTION
Packit failed to trigger an automatic fedora package update on the upstream release v0.59.0 which brought to light further issues which this commit corrects.

Packit doesn't honor a global `downstream_package_name` key when the upstream repo and downstream package name don't match. For this very repo, upstream repo is `common`, while downstream package is `containers-common`. For such cases, `downstream_package_name` should be specified at the package level.

The `Source0` URL in rpm spec has also been corrected. This wasn't noticed in packit jobs on PRs because packit replaces Source0 with a locally created archive.

The `mv` commands in rpm spec have also been replaced by `cp` so that consecutive `rpmbuild` runs will not complain about not finding the source files.

The autosetup step in rpm spec has also been updated to the correct untarred archive name format.

Misc cleanup includes removal of `update_release: false` from downstream jobs. It's meaningless in those jobs. Even for copr jobs, we should prefer packit's default behavior of `update_release: true`.


(cherry picked from commit 3c9661748b1423a20d9e8f3e6a2fb9bb32996634)

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

doesn't look like c/common has slash-cherrypick support yet. https://github.com/containers/common/pull/2015#issuecomment-2135680743 didn't work.