### PR TITLE
[skip-ci] RPM: ensure config files are patched

### DIFF
--- a/rpm/containers-common.spec
+++ b/rpm/containers-common.spec
@@ -98,11 +98,7 @@ not required by Skopeo.
 %prep
 %autosetup -Sgit -n %{repo}-%{version_no_tilde}
 
-# Fine-grain distro- and release-specific tuning of config files,
-# e.g., seccomp, composefs, registries on different RHEL/Fedora versions
-bash rpm/update-config-files.sh
-
-%build
+# Copy manpages to docs subdir in builddir to build before installing.
 cp %{SOURCE1} docs/.
 cp %{SOURCE2} docs/.
 cp %{SOURCE3} docs/.
@@ -113,6 +109,18 @@ cp %{SOURCE7} docs/.
 cp %{SOURCE8} docs/.
 cp %{SOURCE9} docs/.
 
+# Copy config files to builddir to patch them before installing.
+# Currently, only registries.conf and storage.conf files are patched before
+# installing.
+cp %{SOURCE10} shortnames.conf
+cp %{SOURCE13} registries.conf
+cp %{SOURCE14} storage.conf
+
+# Fine-grain distro- and release-specific tuning of config files,
+# e.g., seccomp, composefs, registries on different RHEL/Fedora versions
+bash rpm/update-config-files.sh
+
+%build
 mkdir -p man5
 for i in docs/*.5.md; do
     go-md2man -in $i -out man5/$(basename $i .md)
@@ -129,11 +137,11 @@ touch %{buildroot}%{_prefix}/lib/containers/storage/overlay-images/images.lock
 install -dp -m 700 %{buildroot}%{_prefix}/lib/containers/storage/overlay-layers
 touch %{buildroot}%{_prefix}/lib/containers/storage/overlay-layers/layers.lock
 
-install -Dp -m0644 %{SOURCE10} %{buildroot}%{_sysconfdir}/containers/registries.conf.d/000-shortnames.conf
+install -Dp -m0644 shortnames.conf %{buildroot}%{_sysconfdir}/containers/registries.conf.d/000-shortnames.conf
 install -Dp -m0644 %{SOURCE11} %{buildroot}%{_sysconfdir}/containers/registries.d/default.yaml
 install -Dp -m0644 %{SOURCE12} %{buildroot}%{_sysconfdir}/containers/policy.json
-install -Dp -m0644 %{SOURCE13} %{buildroot}%{_sysconfdir}/containers/registries.conf
-install -Dp -m0644 %{SOURCE14} %{buildroot}%{_datadir}/containers/storage.conf
+install -Dp -m0644 registries.conf %{buildroot}%{_sysconfdir}/containers/registries.conf
+install -Dp -m0644 storage.conf %{buildroot}%{_datadir}/containers/storage.conf
 
 # RPM-GPG-KEY-redhat-release already exists on rhel envs, install only on
 # fedora and centos

--- a/rpm/update-config-files.sh
+++ b/rpm/update-config-files.sh
@@ -5,6 +5,10 @@
 set -exo pipefail
 
 ensure() {
+  if [[ ! -f $1 ]]; then
+      echo "File not found:" $1
+      exit 1
+  fi
   if grep ^$2[[:blank:]].*= $1 > /dev/null
   then
     sed -i "s;^$2[[:blank:]]=.*;$2 = $3;" $1

--- a/rpm/update-config-files.sh
+++ b/rpm/update-config-files.sh
@@ -32,7 +32,6 @@ ensure storage.conf                 mountopt            \"nodev,metacopy=on\"
 
 ensure pkg/config/containers.conf   runtime             \"crun\"
 ensure pkg/config/containers.conf   log_driver          \"journald\"
-ensure pkg/config/containers.conf   compression_format  \"zstd:chunked\"
 
 # Enable seccomp support keyctl and socketcall
 grep -q \"keyctl\", pkg/seccomp/seccomp.json || sed -i '/\"kill\",/i \
@@ -59,6 +58,7 @@ fi
 # Set these on Fedora Rawhide (41+), RHEL 10+, and on all COPR builds
 # regardless of distro
 if [[ -n "$COPR" ]] || [[ "$FEDORA" -gt 40 ]] || [[ "$RHEL" -ge 10 ]]; then
+    ensure pkg/config/containers.conf   compression_format  \"zstd:chunked\"
     ensure storage.conf pull_options    \{enable_partial_images\ =\ \"true\",\ use_hard_links\ =\ \"false\",\ ostree_repos=\"\",\ convert_images\ =\ \"false\"\}
     # Leave composefs disabled
     ensure storage.conf use_composefs   \"false\"


### PR DESCRIPTION
This commit copies over shortnames.conf, registries.conf and storage.conf to the rpm build dir before running the patching script.

Prior to this, the script would complain about not finding those files but the rpmbuild process itself didn't fail.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
