### PR TITLE
fix windows config path regression

### DIFF
--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -5,7 +5,7 @@ import "os"
 const (
 	// _configPath is the path to the containers/containers.conf
 	// inside a given config directory.
-	_configPath = "containers\\containers.conf"
+	_configPath = "\\containers\\containers.conf"
 
 	// DefaultContainersConfig holds the default containers config path
 	DefaultContainersConfig = ""


### PR DESCRIPTION
The path no longer included the path separator between the env and our config dir. The regression was added in commit 6c651dfac1.

Fixes #2025

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
