### PR TITLE
fix outdated firewall_driver docs

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -459,9 +459,8 @@ and "$graphroot/networks" as rootless.
 
 The firewall driver to be used by netavark.
 The default is empty which means netavark will pick one accordingly. Current supported
-drivers are "iptables", "none" (no firewall rules will be created) and "firewalld" (firewalld is
-experimental at the moment and not recommend outside of testing). In the future we are
-planning to add support for a "nftables" driver.
+drivers are "iptables", "nftables", "none" (no firewall rules will be created) and "firewalld" (firewalld is
+experimental at the moment and not recommend outside of testing).
 
 **dns_bind_port**=53
 

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -350,9 +350,9 @@ default_sysctls = [
 
 # The firewall driver to be used by netavark.
 # The default is empty which means netavark will pick one accordingly. Current supported
-# drivers are "iptables", "none" (no firewall rules will be created) and "firewalld" (firewalld is
-# experimental at the moment and not recommend outside of testing). In the future we are
-# planning to add support for a "nftables" driver.
+# drivers are "iptables", "nftables", "none" (no firewall rules will be created) and "firewalld" (firewalld is
+# experimental at the moment and not recommend outside of testing).
+#
 #firewall_driver = ""
 
 
@@ -890,10 +890,10 @@ default_sysctls = [
 [podmansh]
 # Shell to spawn in container. Default: /bin/sh.
 #shell = "/bin/sh"
-# 
+#
 # Name of the container the podmansh user should join.
 #container = "podmansh"
-# 
+#
 # Default timeout in seconds for podmansh logins.
 # Favored over the deprecated "podmansh_timeout" field.
 #timeout = 30


### PR DESCRIPTION
nftables was implemented for netavark v1.10

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
