### PR TITLE
[skip-ci] RPM: own dirs

### DIFF
--- a/rpm/containers-common.spec
+++ b/rpm/containers-common.spec
@@ -179,6 +179,7 @@ ln -s ../../../..%{_sysconfdir}/yum.repos.d/redhat.repo %{buildroot}%{_datadir}/
 %dir %{_sysconfdir}/containers/registries.conf.d
 %dir %{_sysconfdir}/containers/registries.d
 %dir %{_sysconfdir}/containers/systemd
+%dir %{_prefix}/lib/containers
 %dir %{_prefix}/lib/containers/storage
 %dir %{_prefix}/lib/containers/storage/overlay-images
 %dir %{_prefix}/lib/containers/storage/overlay-layers
@@ -207,6 +208,7 @@ ln -s ../../../..%{_sysconfdir}/yum.repos.d/redhat.repo %{buildroot}%{_datadir}/
 %{_datadir}/containers/containers.conf
 %{_datadir}/containers/mounts.conf
 %{_datadir}/containers/seccomp.json
+%dir %{_datadir}/rhel
 %dir %{_datadir}/rhel/secrets
 %{_datadir}/rhel/secrets/*
 


### PR DESCRIPTION
The rpm creates and installs to dirs /usr/share/rhel and /usr/lib/containers . So, it should own them as well.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2283290

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
