### PR TITLE
 Trivial patches to minimize patches needed by NetBSD

### DIFF
--- a/pkg/config/config_bsd.go
+++ b/pkg/config/config_bsd.go
@@ -1,3 +1,5 @@
+//go:build (freebsd || netbsd || openbsd)
+
 package config
 
 const (

--- a/pkg/config/default_bsd.go
+++ b/pkg/config/default_bsd.go
@@ -1,3 +1,5 @@
+//go:build (freebsd || netbsd || openbsd)
+
 package config
 
 // DefaultInitPath is the default path to the container-init binary.

--- a/pkg/config/default_common.go
+++ b/pkg/config/default_common.go
@@ -1,4 +1,4 @@
-//go:build !freebsd
+//go:build !freebsd && !netbsd
 
 package config
 

--- a/pkg/password/password_supported.go
+++ b/pkg/password/password_supported.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin || freebsd
+//go:build linux || darwin || freebsd || netbsd
 
 package password
 


### PR DESCRIPTION
Hi folks, I've been patching your repo to build podman on NetBSD.
The resulting podman seems to work well enough.

(Needs https://github.com/containers/storage/pull/1935 too, and a hack to overcome an issue with the unix package not having SEEK_SET defined on NetBSD)