### PR TITLE
[v0.59] Bump c/common to v0.59.1, then to v0.59.2-dev 

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.59.1-dev"
+const Version = "0.59.1"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.59.1"
+const Version = "0.59.2-dev"


### PR DESCRIPTION
Bumping to ready for the Podman v5.1.1 release.  This change will put Windows-related fixes in place.
<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
