### PR TITLE
libnetwork/rootlessnetns: create run dir explicitly

### DIFF
--- a/libnetwork/internal/rootlessnetns/netns_linux.go
+++ b/libnetwork/internal/rootlessnetns/netns_linux.go
@@ -462,6 +462,10 @@ func (n *Netns) setupMounts() error {
 
 	// 5. Mount the new prepared run dir to /run, it has to be recursive to keep the other bind mounts.
 	runDir := n.getPath("run")
+	err = os.MkdirAll(runDir, 0o700)
+	if err != nil {
+		return wrapError("create run directory", err)
+	}
 	// relabel the new run directory to the iptables /run label
 	// this is important, otherwise the iptables command will fail
 	err = label.Relabel(runDir, "system_u:object_r:iptables_var_run_t:s0", false)


### PR DESCRIPTION
Currently it does the mkdir only implicitly because the code creates run/systemd but this only happens when /run/systemd exists on the host. As such the rootless code was broken on all non systemd distros[1].

[1] https://github.com/containers/podman/discussions/22903

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
