### PR TITLE
Remove nil checks before calling slices.Clone/maps.Clone

### DIFF
--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"time"
 
@@ -20,7 +21,6 @@ import (
 	structcopier "github.com/jinzhu/copier"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"golang.org/x/exp/maps"
 )
 
 // NOTE: the abstractions and APIs here are a first step to further merge
@@ -238,9 +238,7 @@ func (m *ManifestList) Inspect() (*define.ManifestListData, error) {
 	for i, manifest := range ociFormat.Manifests {
 		inspectList.Manifests[i].Annotations = manifest.Annotations
 		inspectList.Manifests[i].ArtifactType = manifest.ArtifactType
-		if manifest.URLs != nil {
-			inspectList.Manifests[i].URLs = slices.Clone(manifest.URLs)
-		}
+		inspectList.Manifests[i].URLs = slices.Clone(manifest.URLs)
 		inspectList.Manifests[i].Data = manifest.Data
 		inspectList.Manifests[i].Files, err = m.list.Files(manifest.Digest)
 		if err != nil {
@@ -252,10 +250,7 @@ func (m *ManifestList) Inspect() (*define.ManifestListData, error) {
 		if platform == nil {
 			platform = &imgspecv1.Platform{}
 		}
-		var osFeatures []string
-		if platform.OSFeatures != nil {
-			osFeatures = slices.Clone(platform.OSFeatures)
-		}
+		osFeatures := slices.Clone(platform.OSFeatures)
 		inspectList.Subject = &define.ManifestListDescriptor{
 			Platform: manifest.Schema2PlatformSpec{
 				OS:           platform.OS,

--- a/libimage/manifests/manifests.go
+++ b/libimage/manifests/manifests.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime"
 	"net/http"
 	"os"
@@ -40,7 +41,6 @@ import (
 	imgspec "github.com/opencontainers/image-spec/specs-go"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/maps"
 )
 
 const (
@@ -236,11 +236,7 @@ func (l *list) SaveToImage(store storage.Store, imageID string, names []string, 
 // Files returns the list of files associated with a particular artifact
 // instance in the image index, primarily for display purposes.
 func (l *list) Files(instanceDigest digest.Digest) ([]string, error) {
-	filesList, ok := l.artifacts.Files[instanceDigest]
-	if ok {
-		return slices.Clone(filesList), nil
-	}
-	return nil, nil
+	return slices.Clone(l.artifacts.Files[instanceDigest]), nil
 }
 
 // instanceByFile returns the instanceDigest of the first manifest in the index
@@ -640,9 +636,7 @@ func (l *list) Add(ctx context.Context, sys *types.SystemContext, ref types.Imag
 			if instanceInfo.OS == "" {
 				instanceInfo.OS = config.OS
 				instanceInfo.OSVersion = config.OSVersion
-				if config.OSFeatures != nil {
-					instanceInfo.OSFeatures = slices.Clone(config.OSFeatures)
-				}
+				instanceInfo.OSFeatures = slices.Clone(config.OSFeatures)
 			}
 			if instanceInfo.Architecture == "" {
 				instanceInfo.Architecture = config.Architecture
@@ -906,9 +900,7 @@ func (l *list) AddArtifact(ctx context.Context, sys *types.SystemContext, option
 		Subject:      subject,
 	}
 	// Add in annotations, more or less exactly as specified.
-	if options.Annotations != nil {
-		artifactManifest.Annotations = maps.Clone(options.Annotations)
-	}
+	artifactManifest.Annotations = maps.Clone(options.Annotations)
 
 	// Encode and save the data we care about.
 	artifactManifestBytes, err := json.Marshal(artifactManifest)


### PR DESCRIPTION
Both slices.Clone() and maps.Clone() return `nil` when passed `nil`, so we don't need to check for a `nil` pointer before calling them.

Imports that used the golang.org/x/exp versions of the maps and slices packages can now use the versions in the standard library, since we require Go 1.21.