### PR TITLE
Allow --debug/--trace options for pasta

### DIFF
--- a/libnetwork/pasta/pasta_linux.go
+++ b/libnetwork/pasta/pasta_linux.go
@@ -130,6 +130,7 @@ func createPastaArgs(opts *SetupOptions) ([]string, []string, error) {
 	noTCPNamespacePorts := true
 	noUDPNamespacePorts := true
 	noMapGW := true
+	quiet := true
 
 	cmdArgs := []string{"--config-net"}
 	// first append options set in the config
@@ -158,6 +159,8 @@ func createPastaArgs(opts *SetupOptions) ([]string, []string, error) {
 			noTCPNamespacePorts = false
 		case "-U", "--udp-ns":
 			noUDPNamespacePorts = false
+		case "-d", "--debug", "--trace":
+			quiet = false
 		case dnsForwardOpt:
 			// if there is no arg after it pasta will likely error out anyway due invalid cli args
 			if len(cmdArgs) > i+1 {
@@ -216,9 +219,12 @@ func createPastaArgs(opts *SetupOptions) ([]string, []string, error) {
 	if noMapGW {
 		cmdArgs = append(cmdArgs, "--no-map-gw")
 	}
+	if quiet {
+		// pass --quiet to silence the info output from pasta if verbose/trace pasta is not required
+		cmdArgs = append(cmdArgs, "--quiet")
+	}
 
-	// always pass --quiet to silence the info output from pasta
-	cmdArgs = append(cmdArgs, "--quiet", "--netns", opts.Netns)
+	cmdArgs = append(cmdArgs, "--netns", opts.Netns)
 
 	return cmdArgs, dnsForwardIPs, nil
 }

--- a/libnetwork/pasta/pasta_linux_test.go
+++ b/libnetwork/pasta/pasta_linux_test.go
@@ -251,6 +251,20 @@ func Test_createPastaArgs(t *testing.T) {
 			},
 			wantDnsForward: []string{dnsForwardIpv4},
 		},
+		{
+			name: "Add verbose logging",
+			input: makeSetupOptions(
+				nil,
+				[]string{"--log-file=/tmp/log", "--trace", "--debug"},
+				nil,
+			),
+			wantArgs: []string{
+				"--config-net", "--log-file=/tmp/log", "--trace", "--debug",
+				"--dns-forward", dnsForwardIpv4, "-t", "none", "-u", "none", "-T", "none", "-U", "none",
+				"--no-map-gw", "--netns", "netns123",
+			},
+			wantDnsForward: []string{dnsForwardIpv4},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Now the user can't pass --debug/--trace option to pasta in order to get more logs when pasta fails. Indeed, the option --quiet is added by default and it is exclusive with  --debug/--trace option.

The PR remove the --quiet option when  --debug/--trace option are set by the user.

Example :
--network=pasta:--map-gw,--debug,--log-file=/tmp/log,--trace
