### PR TITLE
libnetwork/netavark: accept metric option for mac/ipvlan

### DIFF
--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -326,6 +326,11 @@ func createIpvlanOrMacvlan(network *types.Network) error {
 					return fmt.Errorf("unknown ipvlan mode %q", value)
 				}
 			}
+		case types.MetricOption:
+			_, err := strconv.ParseUint(value, 10, 32)
+			if err != nil {
+				return err
+			}
 		case types.MTUOption:
 			_, err := internalutil.ParseMTU(value)
 			if err != nil {

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -1750,6 +1750,19 @@ var _ = Describe("Config", func() {
 		Expect(err.Error()).To(Equal("route gateway nil"))
 	})
 
+	It("create macvlan config with metric option", func() {
+		network := types.Network{
+			Driver: "macvlan",
+			Options: map[string]string{
+				"metric": "99",
+			},
+		}
+		network1, err := libpodNet.NetworkCreate(network, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(network1.Options).To(HaveLen(1))
+		Expect(network1.Options["metric"]).To(Equal("99"))
+	})
+
 	It("create bridge config with no_default_route", func() {
 		network := types.Network{
 			Driver: "bridge",

--- a/libnetwork/netavark/netavark_suite_test.go
+++ b/libnetwork/netavark/netavark_suite_test.go
@@ -14,12 +14,18 @@ import (
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/libnetwork/util"
 	"github.com/containers/common/pkg/config"
+	"github.com/containers/storage/pkg/unshare"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegaTypes "github.com/onsi/gomega/types"
 )
 
 func TestNetavark(t *testing.T) {
+	// commit 26fc823c27 added a check for the userns env var in the network interface code,
+	// it does not actually check the uid
+	if unshare.IsRootless() {
+		t.Setenv(unshare.UsernsEnvName, "done")
+	}
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Netavark Suite")
 }


### PR DESCRIPTION
This option is also supported by netavark for macvlan and ipvlan
networks.

Fixes #2051