### PR TITLE
[skip-ci] Packit: isolate rhel jobs from centos

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -29,8 +29,7 @@ jobs:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
     enable_net: true
     targets:
-      fedora-development: {}
-      fedora-latest: {}
+      fedora-all: {}
       fedora-eln:
         # Need this to fetch go-md2man which is present in koji envs but not by
         # default on copr envs. Also helps to avoid bundling go-md2man in

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -57,6 +57,7 @@ jobs:
   # Run on commit to main branch
   - job: copr_build
     trigger: commit
+    packages: [containers-common-fedora]
     notifications:
       failure_comment:
         message: "podman-next COPR build failed. @containers/packit-build please check."

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,6 +13,9 @@ packages:
     downstream_package_name: containers-common
     pkg_tool: centpkg
     specfile_path: rpm/containers-common.spec
+  containers-common-rhel:
+    downstream_package_name: containers-common
+    specfile_path: rpm/containers-common.spec
 
 actions:
   pre-sync: "bash rpm/update-lib-versions.sh"
@@ -41,8 +44,16 @@ jobs:
     notifications: *ephemeral_build_failure_notification
     enable_net: true
     targets:
-      - epel-9
+      - centos-stream-9
       - centos-stream-10
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [containers-common-rhel]
+    notifications: *ephemeral_build_failure_notification
+    enable_net: true
+    targets:
+      - epel-9
 
   # Run on commit to main branch
   - job: copr_build


### PR DESCRIPTION
This allows centos stream jobs to be triggered for PRs by authors who don't have commit access to the repo.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
