### PR TITLE
[skip-ci] RPM: ghost `/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release`

### DIFF
--- a/rpm/containers-common.spec
+++ b/rpm/containers-common.spec
@@ -27,6 +27,10 @@
 %define netavark_epoch 2
 %endif
 
+%if %{defined fedora} || %{defined centos}
+%define install_gpg_key 1
+%endif
+
 Name: containers-common
 %if %{defined copr_build}
 Epoch: 102
@@ -195,13 +199,12 @@ ln -s ../../../..%{_sysconfdir}/yum.repos.d/redhat.repo %{buildroot}%{_datadir}/
 %dir %{_prefix}/lib/containers/storage/overlay-layers
 %{_prefix}/lib/containers/storage/overlay-images/images.lock
 %{_prefix}/lib/containers/storage/overlay-layers/layers.lock
-
 %config(noreplace) %{_sysconfdir}/containers/policy.json
 %config(noreplace) %{_sysconfdir}/containers/registries.conf
 %config(noreplace) %{_sysconfdir}/containers/registries.conf.d/000-shortnames.conf
-%if 0%{?fedora} || 0%{?centos}
-%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-%endif
+# This file is owned by redhat-release on RHEL and early testing on RHEL will
+# need packages built on CentOS Stream so it's best ghosted
+%ghost %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 %config(noreplace) %{_sysconfdir}/containers/registries.d/default.yaml
 %config(noreplace) %{_sysconfdir}/containers/registries.d/registry.redhat.io.yaml
 %config(noreplace) %{_sysconfdir}/containers/registries.d/registry.access.redhat.com.yaml


### PR DESCRIPTION
Packages built on CentOS Stream 10 aren't installable on RHEL 10 because
of installation conflict on /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release.
So far, that has prevented us from early testing of packages on proper
RHEL 10 environments.
    
This will continue to be an issue when an upcoming RHEL is available for
testing but doesn't have copr build targets enabled and you need to
depend on the equivalent CentOS Stream targets.