### PR TITLE
Make the definition of LookupReferenceFunc unconditional

### DIFF
--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containers/common/libimage/manifests"
 	"github.com/containers/common/libimage/platform"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/retry"
@@ -31,12 +30,6 @@ const (
 	defaultMaxRetries = 3
 	defaultRetryDelay = time.Second
 )
-
-// LookupReferenceFunc return an image reference based on the specified one.
-// The returned reference can return custom ImageSource or ImageDestination
-// objects which intercept or filter blobs, manifests, and signatures as
-// they are read and written.
-type LookupReferenceFunc = manifests.LookupReferenceFunc
 
 // CopyOptions allow for customizing image-copy operations.
 type CopyOptions struct {

--- a/libimage/types.go
+++ b/libimage/types.go
@@ -1,0 +1,9 @@
+package libimage
+
+import "github.com/containers/common/libimage/manifests"
+
+// LookupReferenceFunc return an image reference based on the specified one.
+// The returned reference can return custom ImageSource or ImageDestination
+// objects which intercept or filter blobs, manifests, and signatures as
+// they are read and written.
+type LookupReferenceFunc = manifests.LookupReferenceFunc


### PR DESCRIPTION
Move the definition of our LookupReferenceFunc type alias to a file that isn't conditionally compiled, as an alternative to https://github.com/containers/buildah/pull/5628.