### PR TITLE
[skip-ci] RPM: move netavark deps to netavark package

### DIFF
--- a/rpm/containers-common.spec
+++ b/rpm/containers-common.spec
@@ -85,10 +85,8 @@ Summary: Extra dependencies for Podman and Buildah
 Requires: %{name} = %{epoch}:%{version}-%{release}
 Requires: container-network-stack
 Requires: oci-runtime
-Requires: nftables
 Requires: passt
 %if %{defined fedora}
-Requires: iptables
 Conflicts: podman < 5:5.0.0~rc4-1
 Recommends: composefs
 Recommends: crun


### PR DESCRIPTION
iptables and nftables are best handled in netavark package.
Ref: https://github.com/containers/netavark/pull/1033

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
