### PR TITLE
Use the WSL convention for the windows machines default volumes

### DIFF
--- a/pkg/config/default_windows.go
+++ b/pkg/config/default_windows.go
@@ -42,11 +42,17 @@ func getLibpodTmpDir() string {
 }
 
 // getDefaultMachineVolumes returns default mounted volumes (possibly with env vars, which will be expanded)
+// It is executed only if the machine provider is Hyper-V and it mimics WSL
+// behavior where the host %USERPROFILE% drive (e.g. C:\) is automatically
+// mounted in the guest under /mnt/ (e.g. /mnt/c/)
 func getDefaultMachineVolumes() []string {
 	hd := homedir.Get()
 	vol := filepath.VolumeName(hd)
 	hostMnt := filepath.ToSlash(strings.TrimPrefix(hd, vol))
-	return []string{fmt.Sprintf("%s:%s", hd, hostMnt)}
+	return []string{
+		fmt.Sprintf("%s:%s", hd, hostMnt),
+		fmt.Sprintf("%s:%s", vol+"\\", "/mnt/"+strings.ToLower(vol[0:1])),
+	}
 }
 
 func getDefaultComposeProviders() []string {

--- a/pkg/config/default_windows_test.go
+++ b/pkg/config/default_windows_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDefaultMachineVolumes(t *testing.T) {
+	for _, tc := range []struct {
+		envs   [][]string
+		output []string
+	}{
+		{
+			envs: [][]string{
+				{"USERPROFILE", "C:\\Users\\test"},
+			},
+			output: []string{
+				"C:\\Users\\test:/Users/test",
+				"C:\\:/mnt/c",
+			},
+		},
+		{
+			envs: [][]string{
+				{"USERPROFILE", "C:\\Users\\test\\AppData\\Local\\Temp\\podman_test123456789"},
+			},
+			output: []string{
+				"C:\\Users\\test\\AppData\\Local\\Temp\\podman_test123456789:/Users/test/AppData/Local/Temp/podman_test123456789",
+				"C:\\:/mnt/c",
+			},
+		},
+		{
+			envs: [][]string{
+				{"USERPROFILE", "D:\\Users\\test"},
+			},
+			output: []string{
+				"D:\\Users\\test:/Users/test",
+				"D:\\:/mnt/d",
+			},
+		},
+		{
+			envs: [][]string{
+				{"USERPROFILE", "c:\\users\\test"},
+			},
+			output: []string{
+				"c:\\users\\test:/users/test",
+				"c:\\:/mnt/c",
+			},
+		},
+		{
+			envs: [][]string{
+				{"USERPROFILE", "C:/Users/test"},
+			},
+			output: []string{
+				"C:/Users/test:/Users/test",
+				"C:\\:/mnt/c",
+			},
+		},
+		{
+			envs: [][]string{
+				{"USERPROFILE", "C:\\Users\\test\\"},
+			},
+			output: []string{
+				"C:\\Users\\test\\:/Users/test/",
+				"C:\\:/mnt/c",
+			},
+		},
+	} {
+		for _, env := range tc.envs {
+			t.Setenv(env[0], env[1])
+		}
+		output := getDefaultMachineVolumes()
+		assert.Equal(t, tc.output, output)
+	}
+}


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

Currently on Windows, volumes are mounted differently based on the provider:
- WSL automatically mounts the main drive `C:/` under `/mnt/c` on every Linux VM
- For HyperV instead, `podman` mounts `C:\Users\name` under `/Users/name`

Issues like [this one](https://github.com/containers/podman/issues/21036) are the consequence of such behavior.

With this PR `getDefaultMachineVolumes()` is updated to be consistent with WSL default behavior. That means that on both WSL and HyperV machines, the default volumes will be the `%userprofile%` drive (e.g. `C:/`) mounted under `/mnt/` (e.g. `/mnt/c`).

The old Hyper-V mount is still supported. Users can still use the notation `podman run -v /Users` when the provider is Hyper-V although the notation `podman run -v C:\Users` should be preferred.
