### PR TITLE
cgroups: systemdDestroyConn ignores stopped units

### DIFF
--- a/pkg/cgroups/systemd_linux.go
+++ b/pkg/cgroups/systemd_linux.go
@@ -130,6 +130,12 @@ func systemdDestroyConn(path string, c *systemdDbus.Conn) error {
 	ch := make(chan string)
 	_, err := c.StopUnitContext(context.TODO(), name, "replace", ch)
 	if err != nil {
+		if dbe, ok := err.(dbus.Error); ok {
+			if dbe.Name == "org.freedesktop.systemd1.NoSuchUnit" {
+				// the unit was already removed
+				return nil
+			}
+		}
 		return err
 	}
 	<-ch


### PR DESCRIPTION
Podman can request the pod cgroup cleanup from different processes.

Do not report an error if the cgroup is already stopped.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
