### PR TITLE
gofmt/go fix

### DIFF
--- a/libnetwork/network/interface_cni.go
+++ b/libnetwork/network/interface_cni.go
@@ -1,6 +1,4 @@
 //go:build (linux || freebsd) && cni
-// +build linux freebsd
-// +build cni
 
 package network
 

--- a/libnetwork/network/interface_cni_unsupported.go
+++ b/libnetwork/network/interface_cni_unsupported.go
@@ -1,6 +1,4 @@
 //go:build (linux || freebsd) && !cni
-// +build linux freebsd
-// +build !cni
 
 package network
 

--- a/pkg/config/config_bsd.go
+++ b/pkg/config/config_bsd.go
@@ -1,4 +1,4 @@
-//go:build (freebsd || netbsd || openbsd)
+//go:build freebsd || netbsd || openbsd
 
 package config
 

--- a/pkg/config/default_bsd.go
+++ b/pkg/config/default_bsd.go
@@ -1,4 +1,4 @@
-//go:build (freebsd || netbsd || openbsd)
+//go:build freebsd || netbsd || openbsd
 
 package config
 


### PR DESCRIPTION
1. Remove old-style build tags
    
Brought to you by
    
            go1.23rc2 fix ./...

2. Use gofmt -s on sources
    
Brought to you by
    
            git ls-files \*.go | grep -Ev '/?vendor/' | xargs gofmt -w -s
    
I thought this should be caught by gofmt/gofumpt linters (that are part
of golangci-lint army) but I guess this did not happen because the
version of golangci-lint is a tad old.
