### PR TITLE
libimage.runtime.layerTree: Use consistent layers and images

### DIFF
--- a/libimage/disk_usage.go
+++ b/libimage/disk_usage.go
@@ -31,12 +31,12 @@ type ImageDiskUsage struct {
 // storage.  Note that a single image may yield multiple usage reports, one for
 // each repository tag.
 func (r *Runtime) DiskUsage(ctx context.Context) ([]ImageDiskUsage, int64, error) {
-	images, err := r.ListImages(ctx, nil)
+	images, layers, err := r.getImagesAndLayers()
 	if err != nil {
 		return nil, -1, err
 	}
 
-	layerTree, err := r.layerTree(ctx, images)
+	layerTree, err := r.newLayerTreeFromData(images, layers)
 	if err != nil {
 		return nil, -1, err
 	}

--- a/libimage/disk_usage.go
+++ b/libimage/disk_usage.go
@@ -31,7 +31,7 @@ type ImageDiskUsage struct {
 // storage.  Note that a single image may yield multiple usage reports, one for
 // each repository tag.
 func (r *Runtime) DiskUsage(ctx context.Context) ([]ImageDiskUsage, int64, error) {
-	images, err := r.ListImages(ctx, nil, nil)
+	images, err := r.ListImages(ctx, nil)
 	if err != nil {
 		return nil, -1, err
 	}

--- a/libimage/filters.go
+++ b/libimage/filters.go
@@ -19,13 +19,16 @@ import (
 
 // filterFunc is a prototype for a positive image filter.  Returning `true`
 // indicates that the image matches the criteria.
-type filterFunc func(*Image) (bool, error)
+type filterFunc func(*Image, *layerTree) (bool, error)
+
+type compiledFilters map[string][]filterFunc
 
 // Apply the specified filters.  All filters of each key must apply.
-func (i *Image) applyFilters(ctx context.Context, filters map[string][]filterFunc) (bool, error) {
+// tree must be provided if compileImageFilters indicated it is necessary.
+func (i *Image) applyFilters(ctx context.Context, filters compiledFilters, tree *layerTree) (bool, error) {
 	for key := range filters {
 		for _, filter := range filters[key] {
-			matches, err := filter(i)
+			matches, err := filter(i, tree)
 			if err != nil {
 				// Some images may have been corrupted in the
 				// meantime, so do an extra check and make the
@@ -47,18 +50,11 @@ func (i *Image) applyFilters(ctx context.Context, filters map[string][]filterFun
 
 // filterImages returns a slice of images which are passing all specified
 // filters.
-func (r *Runtime) filterImages(ctx context.Context, images []*Image, options *ListImagesOptions) ([]*Image, error) {
-	if len(options.Filters) == 0 || len(images) == 0 {
-		return images, nil
-	}
-
-	filters, err := r.compileImageFilters(ctx, options)
-	if err != nil {
-		return nil, err
-	}
+// tree must be provided if compileImageFilters indicated it is necessary.
+func (r *Runtime) filterImages(ctx context.Context, images []*Image, filters compiledFilters, tree *layerTree) ([]*Image, error) {
 	result := []*Image{}
 	for i := range images {
-		match, err := images[i].applyFilters(ctx, filters)
+		match, err := images[i].applyFilters(ctx, filters, tree)
 		if err != nil {
 			return nil, err
 		}
@@ -73,25 +69,19 @@ func (r *Runtime) filterImages(ctx context.Context, images []*Image, options *Li
 // required format is `key=value` with the following supported keys:
 //
 //	after, since, before, containers, dangling, id, label, readonly, reference, intermediate
-func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOptions) (map[string][]filterFunc, error) {
+//
+// compileImageFilters returns: compiled filters, if LayerTree is needed, error
+func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOptions) (compiledFilters, bool, error) {
 	logrus.Tracef("Parsing image filters %s", options.Filters)
-
-	var tree *layerTree
-	getTree := func() (*layerTree, error) {
-		if tree == nil {
-			t, err := r.layerTree(ctx, nil)
-			if err != nil {
-				return nil, err
-			}
-			tree = t
-		}
-		return tree, nil
+	if len(options.Filters) == 0 {
+		return nil, false, nil
 	}
 
 	filterInvalidValue := `invalid image filter %q: must be in the format "filter=value or filter!=value"`
 
 	var wantedReferenceMatches, unwantedReferenceMatches []string
-	filters := map[string][]filterFunc{}
+	filters := compiledFilters{}
+	needsLayerTree := false
 	duplicate := map[string]string{}
 	for _, f := range options.Filters {
 		var key, value string
@@ -103,7 +93,7 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 		} else {
 			split = strings.SplitN(f, "=", 2)
 			if len(split) != 2 {
-				return nil, fmt.Errorf(filterInvalidValue, f)
+				return nil, false, fmt.Errorf(filterInvalidValue, f)
 			}
 		}
 
@@ -113,7 +103,7 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 		case "after", "since":
 			img, err := r.time(key, value)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			key = "since"
 			filter = filterAfter(img.Created())
@@ -121,27 +111,23 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 		case "before":
 			img, err := r.time(key, value)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			filter = filterBefore(img.Created())
 
 		case "containers":
 			if err := r.containers(duplicate, key, value, options.IsExternalContainerFunc); err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			filter = filterContainers(value, options.IsExternalContainerFunc)
 
 		case "dangling":
 			dangling, err := r.bool(duplicate, key, value)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
-			t, err := getTree()
-			if err != nil {
-				return nil, err
-			}
-
-			filter = filterDangling(ctx, dangling, t)
+			needsLayerTree = true
+			filter = filterDangling(ctx, dangling)
 
 		case "id":
 			filter = filterID(value)
@@ -149,35 +135,31 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 		case "digest":
 			f, err := filterDigest(value)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			filter = f
 
 		case "intermediate":
 			intermediate, err := r.bool(duplicate, key, value)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
-			t, err := getTree()
-			if err != nil {
-				return nil, err
-			}
-
-			filter = filterIntermediate(ctx, intermediate, t)
+			needsLayerTree = true
+			filter = filterIntermediate(ctx, intermediate)
 
 		case "label":
 			filter = filterLabel(ctx, value)
 		case "readonly":
 			readOnly, err := r.bool(duplicate, key, value)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			filter = filterReadOnly(readOnly)
 
 		case "manifest":
 			manifest, err := r.bool(duplicate, key, value)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			filter = filterManifest(ctx, manifest)
 
@@ -192,12 +174,12 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 		case "until":
 			until, err := r.until(value)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			filter = filterBefore(until)
 
 		default:
-			return nil, fmt.Errorf(filterInvalidValue, key)
+			return nil, false, fmt.Errorf(filterInvalidValue, key)
 		}
 		if negate {
 			filter = negateFilter(filter)
@@ -210,12 +192,12 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 	filter := filterReferences(r, wantedReferenceMatches, unwantedReferenceMatches)
 	filters["reference"] = append(filters["reference"], filter)
 
-	return filters, nil
+	return filters, needsLayerTree, nil
 }
 
 func negateFilter(f filterFunc) filterFunc {
-	return func(img *Image) (bool, error) {
-		b, err := f(img)
+	return func(img *Image, tree *layerTree) (bool, error) {
+		b, err := f(img, tree)
 		return !b, err
 	}
 }
@@ -272,7 +254,7 @@ func (r *Runtime) bool(duplicate map[string]string, key, value string) (bool, er
 
 // filterManifest filters whether or not the image is a manifest list
 func filterManifest(ctx context.Context, value bool) filterFunc {
-	return func(img *Image) (bool, error) {
+	return func(img *Image, _ *layerTree) (bool, error) {
 		isManifestList, err := img.IsManifestList(ctx)
 		if err != nil {
 			return false, err
@@ -284,7 +266,7 @@ func filterManifest(ctx context.Context, value bool) filterFunc {
 // filterReferences creates a reference filter for matching the specified wantedReferenceMatches value (OR logic)
 // and for matching the unwantedReferenceMatches values (AND logic)
 func filterReferences(r *Runtime, wantedReferenceMatches, unwantedReferenceMatches []string) filterFunc {
-	return func(img *Image) (bool, error) {
+	return func(img *Image, _ *layerTree) (bool, error) {
 		// Empty reference filters, return true
 		if len(wantedReferenceMatches) == 0 && len(unwantedReferenceMatches) == 0 {
 			return true, nil
@@ -376,7 +358,7 @@ func imageMatchesReferenceFilter(r *Runtime, img *Image, value string) (bool, er
 
 // filterLabel creates a label for matching the specified value.
 func filterLabel(ctx context.Context, value string) filterFunc {
-	return func(img *Image) (bool, error) {
+	return func(img *Image, _ *layerTree) (bool, error) {
 		labels, err := img.Labels(ctx)
 		if err != nil {
 			return false, err
@@ -387,28 +369,28 @@ func filterLabel(ctx context.Context, value string) filterFunc {
 
 // filterAfter creates an after filter for matching the specified value.
 func filterAfter(value time.Time) filterFunc {
-	return func(img *Image) (bool, error) {
+	return func(img *Image, _ *layerTree) (bool, error) {
 		return img.Created().After(value), nil
 	}
 }
 
 // filterBefore creates a before filter for matching the specified value.
 func filterBefore(value time.Time) filterFunc {
-	return func(img *Image) (bool, error) {
+	return func(img *Image, _ *layerTree) (bool, error) {
 		return img.Created().Before(value), nil
 	}
 }
 
 // filterReadOnly creates a readonly filter for matching the specified value.
 func filterReadOnly(value bool) filterFunc {
-	return func(img *Image) (bool, error) {
+	return func(img *Image, _ *layerTree) (bool, error) {
 		return img.IsReadOnly() == value, nil
 	}
 }
 
 // filterContainers creates a container filter for matching the specified value.
 func filterContainers(value string, fn IsExternalContainerFunc) filterFunc {
-	return func(img *Image) (bool, error) {
+	return func(img *Image, _ *layerTree) (bool, error) {
 		ctrs, err := img.Containers()
 		if err != nil {
 			return false, err
@@ -433,8 +415,8 @@ func filterContainers(value string, fn IsExternalContainerFunc) filterFunc {
 }
 
 // filterDangling creates a dangling filter for matching the specified value.
-func filterDangling(ctx context.Context, value bool, tree *layerTree) filterFunc {
-	return func(img *Image) (bool, error) {
+func filterDangling(ctx context.Context, value bool) filterFunc {
+	return func(img *Image, tree *layerTree) (bool, error) {
 		isDangling, err := img.isDangling(ctx, tree)
 		if err != nil {
 			return false, err
@@ -445,7 +427,7 @@ func filterDangling(ctx context.Context, value bool, tree *layerTree) filterFunc
 
 // filterID creates an image-ID filter for matching the specified value.
 func filterID(value string) filterFunc {
-	return func(img *Image) (bool, error) {
+	return func(img *Image, _ *layerTree) (bool, error) {
 		return strings.HasPrefix(img.ID(), value), nil
 	}
 }
@@ -455,7 +437,7 @@ func filterDigest(value string) (filterFunc, error) {
 	if !strings.HasPrefix(value, "sha256:") {
 		return nil, fmt.Errorf("invalid value %q for digest filter", value)
 	}
-	return func(img *Image) (bool, error) {
+	return func(img *Image, _ *layerTree) (bool, error) {
 		return img.containsDigestPrefix(value), nil
 	}, nil
 }
@@ -463,8 +445,8 @@ func filterDigest(value string) (filterFunc, error) {
 // filterIntermediate creates an intermediate filter for images.  An image is
 // considered to be an intermediate image if it is dangling (i.e., no tags) and
 // has no children (i.e., no other image depends on it).
-func filterIntermediate(ctx context.Context, value bool, tree *layerTree) filterFunc {
-	return func(img *Image) (bool, error) {
+func filterIntermediate(ctx context.Context, value bool) filterFunc {
+	return func(img *Image, tree *layerTree) (bool, error) {
 		isIntermediate, err := img.isIntermediate(ctx, tree)
 		if err != nil {
 			return false, err

--- a/libimage/filters_test.go
+++ b/libimage/filters_test.go
@@ -97,7 +97,7 @@ func TestFilterReference(t *testing.T) {
 		listOptions := &ListImagesOptions{
 			Filters: filters,
 		}
-		listedImages, err := runtime.ListImages(ctx, nil, listOptions)
+		listedImages, err := runtime.ListImages(ctx, listOptions)
 		require.NoError(t, err, "%v", test)
 		require.Len(t, listedImages, test.matches, "%s -> %v", test.filters, listedImages)
 	}
@@ -134,12 +134,12 @@ func TestFilterDigest(t *testing.T) {
 		listOptions := &ListImagesOptions{
 			Filters: []string{"digest=" + test.filter},
 		}
-		listedImages, err := runtime.ListImages(ctx, nil, listOptions)
+		listedImages, err := runtime.ListImages(ctx, listOptions)
 		require.NoError(t, err, "%v", test)
 		require.Len(t, listedImages, test.matches, "%s -> %v", test.filter, listedImages)
 		require.Equal(t, listedImages[0].ID(), test.id)
 	}
-	_, err = runtime.ListImages(ctx, nil, &ListImagesOptions{
+	_, err = runtime.ListImages(ctx, &ListImagesOptions{
 		Filters: []string{"digest=this-is-not-a-digest"},
 	})
 	assert.Error(t, err)
@@ -176,7 +176,7 @@ func TestFilterID(t *testing.T) {
 		listOptions := &ListImagesOptions{
 			Filters: []string{"id=" + test.filter},
 		}
-		listedImages, err := runtime.ListImages(ctx, nil, listOptions)
+		listedImages, err := runtime.ListImages(ctx, listOptions)
 		require.NoError(t, err, "%v", test)
 		require.Len(t, listedImages, test.matches, "%s -> %v", test.filter, listedImages)
 		require.Equal(t, listedImages[0].ID(), test.id)
@@ -229,7 +229,7 @@ func TestFilterManifest(t *testing.T) {
 		listOptions := &ListImagesOptions{
 			Filters: test.filters,
 		}
-		listedImages, err := runtime.ListImages(ctx, nil, listOptions)
+		listedImages, err := runtime.ListImages(ctx, listOptions)
 		require.NoError(t, err, "%v", test)
 		require.Len(t, listedImages, test.matches, "%s -> %v", test.filters, listedImages)
 	}
@@ -281,7 +281,7 @@ func TestFilterAfterSinceBeforeUntil(t *testing.T) {
 		listOptions := &ListImagesOptions{
 			Filters: test.filters,
 		}
-		listedImages, err := runtime.ListImages(ctx, nil, listOptions)
+		listedImages, err := runtime.ListImages(ctx, listOptions)
 		require.NoError(t, err, "%v", test)
 		require.Len(t, listedImages, test.matches, "%s -> %v", test.filters, listedImages)
 	}
@@ -326,7 +326,7 @@ func TestFilterIdLabel(t *testing.T) {
 		listOptions := &ListImagesOptions{
 			Filters: test.filters,
 		}
-		listedImages, err := runtime.ListImages(ctx, nil, listOptions)
+		listedImages, err := runtime.ListImages(ctx, listOptions)
 		require.NoError(t, err, "%v", test)
 		require.Len(t, listedImages, test.matches, "%s -> %v", test.filters, listedImages)
 	}

--- a/libimage/history.go
+++ b/libimage/history.go
@@ -25,7 +25,7 @@ func (i *Image) History(ctx context.Context) ([]ImageHistory, error) {
 		return nil, err
 	}
 
-	layerTree, err := i.runtime.layerTree(ctx, nil)
+	layerTree, err := i.runtime.newFreshLayerTree()
 	if err != nil {
 		return nil, err
 	}

--- a/libimage/image.go
+++ b/libimage/image.go
@@ -257,7 +257,7 @@ func (i *Image) TopLayer() string {
 
 // Parent returns the parent image or nil if there is none
 func (i *Image) Parent(ctx context.Context) (*Image, error) {
-	tree, err := i.runtime.layerTree(ctx, nil)
+	tree, err := i.runtime.newFreshLayerTree()
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +291,7 @@ func (i *Image) Children(ctx context.Context) ([]*Image, error) {
 // created for this invocation only.
 func (i *Image) getChildren(ctx context.Context, all bool, tree *layerTree) ([]*Image, error) {
 	if tree == nil {
-		t, err := i.runtime.layerTree(ctx, nil)
+		t, err := i.runtime.newFreshLayerTree()
 		if err != nil {
 			return nil, err
 		}

--- a/libimage/image_tree.go
+++ b/libimage/image_tree.go
@@ -3,7 +3,6 @@
 package libimage
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -38,7 +37,7 @@ func (i *Image) Tree(traverseChildren bool) (string, error) {
 		fmt.Fprintf(sb, "No Image Layers")
 	}
 
-	layerTree, err := i.runtime.layerTree(context.Background(), nil)
+	layerTree, err := i.runtime.newFreshLayerTree()
 	if err != nil {
 		return "", err
 	}

--- a/libimage/layer_tree.go
+++ b/libimage/layer_tree.go
@@ -89,21 +89,18 @@ func (l *layerNode) repoTags() ([]string, error) {
 	return orderedTags, nil
 }
 
-// layerTree extracts a layerTree from the layers in the local storage and
-// relates them to the specified images.
-func (r *Runtime) layerTree(ctx context.Context, images []*Image) (*layerTree, error) {
-	layers, err := r.store.Layers()
+// newFreshLayerTree extracts a layerTree from consistent layers and images in the local storage.
+func (r *Runtime) newFreshLayerTree() (*layerTree, error) {
+	images, layers, err := r.getImagesAndLayers()
 	if err != nil {
 		return nil, err
 	}
+	return r.newLayerTreeFromData(images, layers)
+}
 
-	if images == nil {
-		images, err = r.ListImages(ctx, nil)
-		if err != nil {
-			return nil, err
-		}
-	}
-
+// newLayerTreeFromData extracts a layerTree from the given the layers and images.
+// The caller is responsible for (layers, images) being consistent.
+func (r *Runtime) newLayerTreeFromData(images []*Image, layers []storage.Layer) (*layerTree, error) {
 	tree := layerTree{
 		nodes:    make(map[string]*layerNode),
 		ociCache: make(map[string]*ociv1.Image),

--- a/libimage/layer_tree.go
+++ b/libimage/layer_tree.go
@@ -98,7 +98,7 @@ func (r *Runtime) layerTree(ctx context.Context, images []*Image) (*layerTree, e
 	}
 
 	if images == nil {
-		images, err = r.ListImages(ctx, nil, nil)
+		images, err = r.ListImages(ctx, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -139,7 +139,7 @@ func (m *ManifestList) LookupInstance(ctx context.Context, architecture, os, var
 		return nil, err
 	}
 
-	allImages, err := m.image.runtime.ListImages(ctx, nil, nil)
+	allImages, err := m.image.runtime.ListImages(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/libimage/push_test.go
+++ b/libimage/push_test.go
@@ -55,7 +55,7 @@ func TestPush(t *testing.T) {
 	// Now there should only be two images: alpine in Docker format and
 	// alpine in OCI format.
 	listOptions := ListImagesOptions{SetListData: true}
-	listedImages, err := runtime.ListImages(ctx, nil, &listOptions)
+	listedImages, err := runtime.ListImages(ctx, &listOptions)
 	require.NoError(t, err, "error listing images")
 	require.Len(t, listedImages, 2, "there should only be two images (alpine in Docke/OCI)")
 	for _, image := range listedImages {

--- a/libimage/runtime_test.go
+++ b/libimage/runtime_test.go
@@ -112,7 +112,7 @@ func TestRuntimeListImagesAllImages(t *testing.T) {
 	testRuntimePullImage(t, runtime, ctx, "docker.io/library/alpine:latest")
 	testRuntimePullImage(t, runtime, ctx, "docker.io/library/busybox:latest")
 
-	images, err := runtime.ListImages(ctx, nil, nil)
+	images, err := runtime.ListImages(ctx, nil)
 	require.NoError(t, err)
 
 	require.Len(t, images, 2)
@@ -126,7 +126,7 @@ func TestRuntimeListImagesAllImages(t *testing.T) {
 	)
 }
 
-func TestRuntimeListImagesOneImage(t *testing.T) {
+func TestRuntimeListImagesByNames(t *testing.T) {
 	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
@@ -134,12 +134,18 @@ func TestRuntimeListImagesOneImage(t *testing.T) {
 	testRuntimePullImage(t, runtime, ctx, "docker.io/library/alpine:latest")
 	testRuntimePullImage(t, runtime, ctx, "docker.io/library/busybox:latest")
 
-	images, err := runtime.ListImages(ctx, []string{"alpine"}, nil)
-	require.NoError(t, err)
-
-	require.Len(t, images, 1)
-	for _, i := range images {
-		image_names := i.Names()
-		require.Contains(t, image_names, "docker.io/library/alpine:latest")
+	for _, test := range []struct {
+		name     string
+		fullName string
+	}{
+		{"alpine", "docker.io/library/alpine:latest"},
+		{"busybox", "docker.io/library/busybox:latest"},
+	} {
+		images, err := runtime.ListImagesByNames([]string{test.name})
+		require.NoError(t, err)
+		require.Len(t, images, 1)
+		require.Contains(t, images[0].Names(), test.fullName)
 	}
+	_, err := runtime.ListImagesByNames([]string{""})
+	require.Error(t, err)
 }

--- a/libimage/save_test.go
+++ b/libimage/save_test.go
@@ -101,7 +101,7 @@ func TestSave(t *testing.T) {
 		if strings.HasSuffix(test.format, "-dir") {
 			continue
 		}
-		_, err = runtime.ListImages(ctx, namesAndTags, nil)
+		_, err = runtime.ListImagesByNames(namesAndTags)
 		require.NoError(t, err, "%v", test)
 	}
 }


### PR DESCRIPTION
This PR changes `runtime.layerTree` method to use consistent values for the creation of layerTree. Before images and layers could vary between calls that obtain images and layers now using `storage.MultiList` to obtain consistent images and layers. Also, this PR adapts callers of `runtime.layerTree` to use consistent images and layers and vendor pre-release of `c/storage` with  `storage.MultiList` method. 

Fixes: https://github.com/containers/podman/issues/23331

Depends on: #2131