### PR TITLE
[skip-ci] Packit: update targets for propose-downstream

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -70,8 +70,7 @@ jobs:
     trigger: release
     packages: [containers-common-fedora]
     dist_git_branches:
-      - fedora-development
-      - fedora-latest
+      - fedora-all
 
   - job: propose_downstream
     trigger: release


### PR DESCRIPTION
When a new Fedora target (41 currently), is branched from rawhide, `fedora-latest` packit target will point to fedora-41, while `fedora-latest-stable` will point to `fedora-40`. Once fedora-41 has released, `fedora-latest` and `fedora-latest-stable` will both point to fedora-41.

So, to have Packit continue to create PRs for Fedora 40 once Fedora 41 has released, it's best to set the target back to `fedora-all`.

Similar patch for Podman: https://github.com/containers/podman/pull/23669

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
