### PR TITLE
[v0.51] cgroups: fix memory usage on cgroup v1

### DIFF
--- a/pkg/cgroups/memory_linux.go
+++ b/pkg/cgroups/memory_linux.go
@@ -4,7 +4,9 @@
 package cgroups
 
 import (
+	"fmt"
 	"path/filepath"
+	"strconv"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
@@ -63,8 +65,25 @@ func (c *linuxMemHandler) Stat(ctr *CgroupControl, m *cgroups.Stats) error {
 	} else {
 		memoryRoot = ctr.getCgroupv1Path(Memory)
 		limitFilename = "memory.limit_in_bytes"
-		if memUsage.Usage.Usage, err = readFileAsUint64(filepath.Join(memoryRoot, "memory.usage_in_bytes")); err != nil {
+
+		path := filepath.Join(memoryRoot, "memory.stat")
+		values, err := readCgroup2MapPath(path)
+		if err != nil {
 			return err
+		}
+
+		// cgroup v1 does not have a single "anon" field, but we can calculate it
+		// from total_active_anon and total_inactive_anon
+		memUsage.Usage.Usage = 0
+		for _, key := range []string{"total_active_anon", "total_inactive_anon"} {
+			if _, found := values[key]; !found {
+				continue
+			}
+			res, err := strconv.ParseUint(values[key][0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("parse %s from %s: %w", key, path, err)
+			}
+			memUsage.Usage.Usage += res
 		}
 	}
 


### PR DESCRIPTION
calculate the memory usage on cgroup v1 using the same logic as cgroup v2.

Since there is no single "anon" field, calculate the memory usage by summing the two fields "total_active_anon" and "total_inactive_anon".

Closes: https://github.com/containers/common/issues/1642

Closes: https://issues.redhat.com/browse/RHEL-16376

[NO NEW TESTS NEEDED]

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit 1a9d45ced26ca62aacc8d6ba4fa7e870acbf9eac)

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
