### PR TITLE
[skip-ci] Packit: Enable sidetags for bodhi updates

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,6 +16,9 @@ packages:
   containers-common-rhel:
     downstream_package_name: containers-common
     specfile_path: rpm/containers-common.spec
+  containers-common-eln:
+    downstream_package_name: containers-common
+    specfile_path: rpm/containers-common.spec
 
 actions:
   pre-sync: "bash rpm/update-lib-versions.sh"
@@ -29,7 +32,14 @@ jobs:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
     enable_net: true
     targets:
-      fedora-all: {}
+      - fedora-all
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [containers-common-eln]
+    notifications: *ephemeral_build_failure_notification
+    enable_net: true
+    targets:
       fedora-eln:
         # Need this to fetch go-md2man which is present in koji envs but not by
         # default on copr envs. Also helps to avoid bundling go-md2man in
@@ -69,7 +79,7 @@ jobs:
   - job: propose_downstream
     trigger: release
     packages: [containers-common-fedora]
-    dist_git_branches:
+    dist_git_branches: &fedora_targets
       - fedora-all
 
   - job: propose_downstream
@@ -87,5 +97,4 @@ jobs:
     # Ref: https://packit.dev/docs/fedora-releases-guide/releasing-multiple-packages
     dependents:
       - podman
-    dist_git_branches:
-      - fedora-all
+    dist_git_branches: *fedora_targets

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -78,14 +78,14 @@ jobs:
     dist_git_branches:
       - c10s
 
+  # Fedora Koji build
   - job: koji_build
     trigger: commit
-    packages: [containers-common-fedora]
+    sidetag_group: podman-releases
+    # Dependencies are not rpm dependencies, but packages that should go in the
+    # same bodhi update
+    # Ref: https://packit.dev/docs/fedora-releases-guide/releasing-multiple-packages
+    dependents:
+      - podman
     dist_git_branches:
       - fedora-all
-
-  - job: bodhi_update
-    trigger: commit
-    packages: [containers-common-fedora]
-    dist_git_branches:
-      - fedora-branched # rawhide updates are created automatically


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

Packit now has sidetag support for adding multiple builds into a single bodhi update.
    
Since we release c/ccommon, skopeo, buildah and podman often almoost simultaneously, we should release them to Fedora in a single bodhi update using sidetags so all builds can be tested together.
