### PR TITLE
Export copier and create interface

### DIFF
--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -206,10 +206,10 @@ func getDockerAuthConfig(name, passwd, creds, idToken string) (*types.DockerAuth
 	}
 }
 
-// newCopier creates a copier.  Note that fields in options *may* overwrite the
+// NewCopier creates a copier.  Note that fields in options *may* overwrite the
 // counterparts of the specified system context.  Please make sure to call
 // `(*copier).close()`.
-func (r *Runtime) newCopier(options *CopyOptions) (*copier, error) {
+func (r *Runtime) NewCopier(options *CopyOptions) (*copier, error) {
 	c := copier{extendTimeoutSocket: options.extendTimeoutSocket}
 	c.systemContext = r.systemContextCopy()
 
@@ -325,14 +325,14 @@ func (r *Runtime) newCopier(options *CopyOptions) (*copier, error) {
 	return &c, nil
 }
 
-// close open resources.
-func (c *copier) close() error {
+// Close open resources.
+func (c *copier) Close() error {
 	return c.policyContext.Destroy()
 }
 
-// copy the source to the destination.  Returns the bytes of the copied
+// Copy the source to the destination.  Returns the bytes of the copied
 // manifest which may be used for digest computation.
-func (c *copier) copy(ctx context.Context, source, destination types.ImageReference) ([]byte, error) {
+func (c *copier) Copy(ctx context.Context, source, destination types.ImageReference) ([]byte, error) {
 	logrus.Debugf("Copying source image %s to destination image %s", source.StringWithinTransport(), destination.StringWithinTransport())
 
 	// Avoid running out of time when running inside a systemd unit by

--- a/libimage/import.go
+++ b/libimage/import.go
@@ -104,13 +104,13 @@ func (r *Runtime) Import(ctx context.Context, path string, options *ImportOption
 		return "", err
 	}
 
-	c, err := r.newCopier(&options.CopyOptions)
+	c, err := r.NewCopier(&options.CopyOptions)
 	if err != nil {
 		return "", err
 	}
-	defer c.close()
+	defer c.Close()
 
-	if _, err := c.copy(ctx, srcRef, destRef); err != nil {
+	if _, err := c.Copy(ctx, srcRef, destRef); err != nil {
 		return "", err
 	}
 

--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -26,6 +26,12 @@ import (
 // NOTE: the abstractions and APIs here are a first step to further merge
 // `libimage/manifests` into `libimage`.
 
+// Copier is a simple interface declaration for the existing copier
+type Copier interface {
+	Copy(ctx context.Context, source, destination types.ImageReference) ([]byte, error)
+	Close() error
+}
+
 // ErrNotAManifestList indicates that an image was found in the local
 // containers storage but it is not a manifest list as requested.
 var ErrNotAManifestList = errors.New("image is not a manifest list")
@@ -632,11 +638,11 @@ func (m *ManifestList) Push(ctx context.Context, destination string, options *Ma
 	// NOTE: we're using the logic in copier to create a proper
 	// types.SystemContext. This prevents us from having an error prone
 	// code duplicate here.
-	copier, err := m.image.runtime.newCopier(&options.CopyOptions)
+	copier, err := m.image.runtime.NewCopier(&options.CopyOptions)
 	if err != nil {
 		return "", err
 	}
-	defer copier.close()
+	defer copier.Close()
 
 	pushOptions := manifests.PushOptions{
 		AddCompression:                   options.AddCompression,

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -231,11 +231,11 @@ func nameFromAnnotations(annotations map[string]string) string {
 // copyFromDefault is the default copier for a number of transports.  Other
 // transports require some specific dancing, sometimes Yoga.
 func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference, options *CopyOptions) ([]string, error) {
-	c, err := r.newCopier(options)
+	c, err := r.NewCopier(options)
 	if err != nil {
 		return nil, err
 	}
-	defer c.close()
+	defer c.Close()
 
 	// Figure out a name for the storage destination.
 	var storageName, imageName string
@@ -321,7 +321,7 @@ func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference,
 		return nil, fmt.Errorf("parsing %q: %w", storageName, err)
 	}
 
-	_, err = c.copy(ctx, ref, destRef)
+	_, err = c.Copy(ctx, ref, destRef)
 	return []string{imageName}, err
 }
 
@@ -387,11 +387,11 @@ func (r *Runtime) copyFromDockerArchive(ctx context.Context, ref types.ImageRefe
 
 // copyFromDockerArchiveReaderReference copies the specified readerRef from reader.
 func (r *Runtime) copyFromDockerArchiveReaderReference(ctx context.Context, reader *dockerArchiveTransport.Reader, readerRef types.ImageReference, options *CopyOptions) ([]string, error) {
-	c, err := r.newCopier(options)
+	c, err := r.NewCopier(options)
 	if err != nil {
 		return nil, err
 	}
-	defer c.close()
+	defer c.Close()
 
 	// Get a slice of storage references we can copy.
 	references, destNames, err := r.storageReferencesReferencesFromArchiveReader(ctx, readerRef, reader)
@@ -401,7 +401,7 @@ func (r *Runtime) copyFromDockerArchiveReaderReference(ctx context.Context, read
 
 	// Now copy all of the images.  Use readerRef for performance.
 	for _, destRef := range references {
-		if _, err := c.copy(ctx, readerRef, destRef); err != nil {
+		if _, err := c.Copy(ctx, readerRef, destRef); err != nil {
 			return nil, err
 		}
 	}
@@ -636,11 +636,11 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 	if socketPath, ok := os.LookupEnv("NOTIFY_SOCKET"); ok {
 		options.extendTimeoutSocket = socketPath
 	}
-	c, err := r.newCopier(&options.CopyOptions)
+	c, err := r.NewCopier(&options.CopyOptions)
 	if err != nil {
 		return nil, err
 	}
-	defer c.close()
+	defer c.Close()
 
 	var pullErrors []error
 	for _, candidate := range resolved.PullCandidates {
@@ -678,7 +678,7 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 			}
 		}
 		var manifestBytes []byte
-		if manifestBytes, err = c.copy(ctx, srcRef, destRef); err != nil {
+		if manifestBytes, err = c.Copy(ctx, srcRef, destRef); err != nil {
 			logrus.Debugf("Error pulling candidate %s: %v", candidateString, err)
 			pullErrors = append(pullErrors, err)
 			continue

--- a/libimage/push.go
+++ b/libimage/push.go
@@ -109,12 +109,12 @@ func (r *Runtime) Push(ctx context.Context, source, destination string, options 
 		}
 	}
 
-	c, err := r.newCopier(&options.CopyOptions)
+	c, err := r.NewCopier(&options.CopyOptions)
 	if err != nil {
 		return nil, err
 	}
 
-	defer c.close()
+	defer c.Close()
 
-	return c.copy(ctx, srcRef, destRef)
+	return c.Copy(ctx, srcRef, destRef)
 }

--- a/libimage/save.go
+++ b/libimage/save.go
@@ -119,13 +119,13 @@ func (r *Runtime) saveSingleImage(ctx context.Context, name, format, path string
 		return err
 	}
 
-	c, err := r.newCopier(&options.CopyOptions)
+	c, err := r.NewCopier(&options.CopyOptions)
 	if err != nil {
 		return err
 	}
-	defer c.close()
+	defer c.Close()
 
-	_, err = c.copy(ctx, srcRef, destRef)
+	_, err = c.Copy(ctx, srcRef, destRef)
 	return err
 }
 
@@ -204,11 +204,11 @@ func (r *Runtime) saveDockerArchive(ctx context.Context, names []string, path st
 		copyOpts := options.CopyOptions
 		copyOpts.dockerArchiveAdditionalTags = local.tags
 
-		c, err := r.newCopier(&copyOpts)
+		c, err := r.NewCopier(&copyOpts)
 		if err != nil {
 			return err
 		}
-		defer c.close()
+		defer c.Close()
 
 		destRef, err := writer.NewReference(nil)
 		if err != nil {
@@ -220,7 +220,7 @@ func (r *Runtime) saveDockerArchive(ctx context.Context, names []string, path st
 			return err
 		}
 
-		if _, err := c.copy(ctx, srcRef, destRef); err != nil {
+		if _, err := c.Copy(ctx, srcRef, destRef); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR exports NewCopier and the Copy() and Close() methods for the copier.  We prefer to use this for artifact support.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
