### PR TITLE
cgroups: ignore ownership for cgroup v1 controllers

### DIFF
--- a/pkg/cgroups/cgroups_linux.go
+++ b/pkg/cgroups/cgroups_linux.go
@@ -822,6 +822,12 @@ func UserOwnsCurrentSystemdCgroup() (bool, error) {
 			continue
 		}
 
+		// If we are on a cgroup v2 system and there are cgroup v1 controllers
+		// mounted, ignore them when the current process is at the root cgroup.
+		if cgroup2 && parts[1] != "" && parts[2] == "/" {
+			continue
+		}
+
 		var cgroupPath string
 
 		if cgroup2 {


### PR DESCRIPTION
if the system is running on cgroup v2, ignore the ownership of cgroup v1 controllers when the current process is at the root cgroup.

Closes: https://github.com/containers/podman/issues/23990

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
