### PR TITLE
RPM: use default seccomp.json profiles

### DIFF
--- a/rpm/update-config-files.sh
+++ b/rpm/update-config-files.sh
@@ -33,12 +33,6 @@ ensure storage.conf                 mountopt            \"nodev,metacopy=on\"
 ensure pkg/config/containers.conf   runtime             \"crun\"
 ensure pkg/config/containers.conf   log_driver          \"journald\"
 
-# Enable seccomp support keyctl and socketcall
-grep -q \"keyctl\", pkg/seccomp/seccomp.json || sed -i '/\"kill\",/i \
-    "keyctl",' pkg/seccomp/seccomp.json
-grep -q \"socket\", pkg/seccomp/seccomp.json || sed -i '/\"socketcall\",/i \
-    "socket",' pkg/seccomp/seccomp.json
-
 FEDORA=$(rpm --eval '%{?fedora}')
 RHEL=$(rpm --eval '%{?rhel}')
 


### PR DESCRIPTION
keyctl is in ALLOW by default and `socket` should not always be ALLOW, per @giuseppe.

This change removes seccomp.json customizations and we'll use the distro's default seccomp profile.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
