### PR TITLE
[v0.60] Backport + version 0.60.3

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.60.2"
+const Version = "0.60.3"


### PR DESCRIPTION
Back port of https://github.com/containers/common/pull/2168, I had to fix some merge conflicts as main uses the new go 1.22 loop while here we still support go 1.21 so I had to change them back.

Needed for https://issues.redhat.com/browse/RHEL-59703