### PR TITLE
Export Copier to support OCI artifacts

### DIFF
--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -160,8 +160,8 @@ type CopyOptions struct {
 	extendTimeoutSocket string
 }
 
-// copier is an internal helper to conveniently copy images.
-type copier struct {
+// Copier is a helper to conveniently copy images.
+type Copier struct {
 	extendTimeoutSocket string
 	imageCopyOptions    copy.Options
 	retryOptions        retry.Options
@@ -170,6 +170,13 @@ type copier struct {
 
 	sourceLookup      LookupReferenceFunc
 	destinationLookup LookupReferenceFunc
+}
+
+// newCopier creates a Copier based on a runtime's system context.
+// Note that fields in options *may* overwrite the counterparts of
+// the specified system context.  Please make sure to call `(*Copier).Close()`.
+func (r *Runtime) newCopier(options *CopyOptions) (*Copier, error) {
+	return NewCopier(options, r.SystemContext())
 }
 
 // storageAllowedPolicyScopes overrides the policy for local storage
@@ -213,12 +220,13 @@ func getDockerAuthConfig(name, passwd, creds, idToken string) (*types.DockerAuth
 	}
 }
 
-// newCopier creates a copier.  Note that fields in options *may* overwrite the
-// counterparts of the specified system context.  Please make sure to call
-// `(*copier).close()`.
-func (r *Runtime) newCopier(options *CopyOptions) (*copier, error) {
-	c := copier{extendTimeoutSocket: options.extendTimeoutSocket}
-	c.systemContext = r.systemContextCopy()
+// NewCopier creates a Copier based on a provided system context.
+// Note that fields in options *may* overwrite the counterparts of
+// the specified system context.  Please make sure to call `(*Copier).Close()`.
+func NewCopier(options *CopyOptions, sc *types.SystemContext) (*Copier, error) {
+	c := Copier{extendTimeoutSocket: options.extendTimeoutSocket}
+	sysContextCopy := *sc
+	c.systemContext = &sysContextCopy
 
 	if options.SourceLookupReferenceFunc != nil {
 		c.sourceLookup = options.SourceLookupReferenceFunc
@@ -333,14 +341,14 @@ func (r *Runtime) newCopier(options *CopyOptions) (*copier, error) {
 	return &c, nil
 }
 
-// close open resources.
-func (c *copier) close() error {
+// Close open resources.
+func (c *Copier) Close() error {
 	return c.policyContext.Destroy()
 }
 
-// copy the source to the destination.  Returns the bytes of the copied
+// Copy the source to the destination.  Returns the bytes of the copied
 // manifest which may be used for digest computation.
-func (c *copier) copy(ctx context.Context, source, destination types.ImageReference) ([]byte, error) {
+func (c *Copier) Copy(ctx context.Context, source, destination types.ImageReference) ([]byte, error) {
 	logrus.Debugf("Copying source image %s to destination image %s", source.StringWithinTransport(), destination.StringWithinTransport())
 
 	// Avoid running out of time when running inside a systemd unit by

--- a/libimage/import.go
+++ b/libimage/import.go
@@ -108,9 +108,9 @@ func (r *Runtime) Import(ctx context.Context, path string, options *ImportOption
 	if err != nil {
 		return "", err
 	}
-	defer c.close()
+	defer c.Close()
 
-	if _, err := c.copy(ctx, srcRef, destRef); err != nil {
+	if _, err := c.Copy(ctx, srcRef, destRef); err != nil {
 		return "", err
 	}
 

--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -796,7 +796,7 @@ func (m *ManifestList) Push(ctx context.Context, destination string, options *Ma
 	if err != nil {
 		return "", err
 	}
-	defer copier.close()
+	defer copier.Close()
 
 	pushOptions := manifests.PushOptions{
 		AddCompression:                   options.AddCompression,

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -235,7 +235,7 @@ func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference,
 	if err != nil {
 		return nil, err
 	}
-	defer c.close()
+	defer c.Close()
 
 	// Figure out a name for the storage destination.
 	var storageName, imageName string
@@ -321,7 +321,7 @@ func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference,
 		return nil, fmt.Errorf("parsing %q: %w", storageName, err)
 	}
 
-	_, err = c.copy(ctx, ref, destRef)
+	_, err = c.Copy(ctx, ref, destRef)
 	return []string{imageName}, err
 }
 
@@ -391,7 +391,7 @@ func (r *Runtime) copyFromDockerArchiveReaderReference(ctx context.Context, read
 	if err != nil {
 		return nil, err
 	}
-	defer c.close()
+	defer c.Close()
 
 	// Get a slice of storage references we can copy.
 	references, destNames, err := r.storageReferencesReferencesFromArchiveReader(ctx, readerRef, reader)
@@ -401,7 +401,7 @@ func (r *Runtime) copyFromDockerArchiveReaderReference(ctx context.Context, read
 
 	// Now copy all of the images.  Use readerRef for performance.
 	for _, destRef := range references {
-		if _, err := c.copy(ctx, readerRef, destRef); err != nil {
+		if _, err := c.Copy(ctx, readerRef, destRef); err != nil {
 			return nil, err
 		}
 	}
@@ -640,7 +640,7 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 	if err != nil {
 		return nil, err
 	}
-	defer c.close()
+	defer c.Close()
 
 	var pullErrors []error
 	for _, candidate := range resolved.PullCandidates {
@@ -678,7 +678,7 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 			}
 		}
 		var manifestBytes []byte
-		if manifestBytes, err = c.copy(ctx, srcRef, destRef); err != nil {
+		if manifestBytes, err = c.Copy(ctx, srcRef, destRef); err != nil {
 			logrus.Debugf("Error pulling candidate %s: %v", candidateString, err)
 			pullErrors = append(pullErrors, err)
 			continue

--- a/libimage/push.go
+++ b/libimage/push.go
@@ -114,7 +114,7 @@ func (r *Runtime) Push(ctx context.Context, source, destination string, options 
 		return nil, err
 	}
 
-	defer c.close()
+	defer c.Close()
 
-	return c.copy(ctx, srcRef, destRef)
+	return c.Copy(ctx, srcRef, destRef)
 }

--- a/libimage/save.go
+++ b/libimage/save.go
@@ -123,9 +123,9 @@ func (r *Runtime) saveSingleImage(ctx context.Context, name, format, path string
 	if err != nil {
 		return err
 	}
-	defer c.close()
+	defer c.Close()
 
-	_, err = c.copy(ctx, srcRef, destRef)
+	_, err = c.Copy(ctx, srcRef, destRef)
 	return err
 }
 
@@ -208,7 +208,7 @@ func (r *Runtime) saveDockerArchive(ctx context.Context, names []string, path st
 		if err != nil {
 			return err
 		}
-		defer c.close()
+		defer c.Close()
 
 		destRef, err := writer.NewReference(nil)
 		if err != nil {
@@ -220,7 +220,7 @@ func (r *Runtime) saveDockerArchive(ctx context.Context, names []string, path st
 			return err
 		}
 
-		if _, err := c.copy(ctx, srcRef, destRef); err != nil {
+		if _, err := c.Copy(ctx, srcRef, destRef); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
To support OCI artifacts in Podman, we need to export the Copier type and create an exported constructor (NewCopier).  Additionally, the actual copy and close methods are now exported.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
