### PR TITLE
removing network-cmd-path from podman configuration

### DIFF
--- a/libnetwork/slirp4netns/slirp4netns.go
+++ b/libnetwork/slirp4netns/slirp4netns.go
@@ -246,13 +246,10 @@ func createBasicSlirpCmdArgs(options *networkOptions, features *slirpFeatures) (
 // Setup can be called in rootful as well as in rootless.
 // Spawns the slirp4netns process and setup port forwarding if ports are given.
 func Setup(opts *SetupOptions) (*SetupResult, error) {
-	path := opts.Config.Engine.NetworkCmdPath
-	if path == "" {
-		var err error
-		path, err = opts.Config.FindHelperBinary(BinaryName, true)
-		if err != nil {
-			return nil, fmt.Errorf("could not find slirp4netns, the network namespace can't be configured: %w", err)
-		}
+	var err error
+	path, err := opts.Config.FindHelperBinary(BinaryName, true)
+	if err != nil {
+		return nil, fmt.Errorf("could not find slirp4netns, the network namespace can't be configured: %w", err)
 	}
 
 	syncR, syncW, err := os.Pipe()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -393,9 +393,6 @@ type EngineConfig struct {
 	// containers and pods will be visible. The default namespace is "".
 	Namespace string `toml:"namespace,omitempty"`
 
-	// NetworkCmdPath is the path to the slirp4netns binary.
-	NetworkCmdPath string `toml:"network_cmd_path,omitempty"`
-
 	// NetworkCmdOptions is the default options to pass to the slirp4netns binary.
 	// For example "allow_host_loopback=true"
 	NetworkCmdOptions attributedstring.Slice `toml:"network_cmd_options,omitempty"`

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -628,10 +628,6 @@ default_sysctls = [
 #
 #namespace = ""
 
-# Path to the slirp4netns binary
-#
-#network_cmd_path = ""
-
 # Default options to pass to the slirp4netns binary.
 # Valid options values are:
 #


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

resolves: https://github.com/containers/podman/issues/23711 