### PR TITLE
config: prefer compose CLI plugin over docker-compose binary

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -120,12 +120,12 @@ var (
 	additionalHelperBinariesDir string
 
 	defaultUnixComposeProviders = []string{
-		"docker-compose",
 		"$HOME/.docker/cli-plugins/docker-compose",
 		"/usr/local/lib/docker/cli-plugins/docker-compose",
 		"/usr/local/libexec/docker/cli-plugins/docker-compose",
 		"/usr/lib/docker/cli-plugins/docker-compose",
 		"/usr/libexec/docker/cli-plugins/docker-compose",
+		"docker-compose",
 		"podman-compose",
 	}
 


### PR DESCRIPTION
Now that Fedora has packaged docker-compose v2, /usr/bin/docker-compose is provided by the docker-compose-switch project which is a shim that translates `docker-compose ...` into `docker compose ...` while translating any deprecated CLI arguments into the new compose v2 counterparts.

This has been a problem for podman users that have podman-docker installed, because `podman compose` tries to call the docker-compose-switch shim and the shim assumes that `docker compose` will be provided by the actual docker command that calls the appropriate CLI plugin, not a podman wrapper that tries to call the docker-compose shim again, resulting in an endless loop.

Changing `podman compose` to prefer calling the docker-compose CLI plugin directly should fix this issue.

Ref: https://discussion.fedoraproject.org/t/conflicts-when-trying-to-install-docker-compose-having-podman-and-podman-docker-already-installed/132760/
Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2316333

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
