### PR TITLE
config: do not set the default nproc to the max available

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -231,7 +231,6 @@ func defaultConfig() (*Config, error) {
 			DNSServers:          attributedstring.Slice{},
 			DefaultCapabilities: attributedstring.NewSlice(DefaultCapabilities),
 			DefaultSysctls:      attributedstring.Slice{},
-			DefaultUlimits:      attributedstring.NewSlice(getDefaultProcessLimits()),
 			Devices:             attributedstring.Slice{},
 			EnableKeyring:       true,
 			EnableLabeling:      selinuxEnabled(),

--- a/pkg/config/default_linux.go
+++ b/pkg/config/default_linux.go
@@ -1,45 +1,11 @@
 package config
 
 import (
-	"fmt"
 	"os"
-	"strconv"
-	"strings"
-
-	"golang.org/x/sys/unix"
-)
-
-const (
-	oldMaxSize = uint64(1048576)
 )
 
 func getDefaultCgroupsMode() string {
 	return "enabled"
-}
-
-// getDefaultProcessLimits returns the nproc for the current process in ulimits format
-// Note that nfile sometimes cannot be set to unlimited, and the limit is hardcoded
-// to (oldMaxSize) 1048576 (2^20), see: http://stackoverflow.com/a/1213069/1811501
-// In rootless containers this will fail, and the process will just use its current limits
-func getDefaultProcessLimits() []string {
-	rlim := unix.Rlimit{Cur: oldMaxSize, Max: oldMaxSize}
-	oldrlim := rlim
-	// Attempt to set file limit and process limit to pid_max in OS
-	dat, err := os.ReadFile("/proc/sys/kernel/pid_max")
-	if err == nil {
-		val := strings.TrimSuffix(string(dat), "\n")
-		maxLimit, err := strconv.ParseUint(val, 10, 64)
-		if err == nil {
-			rlim = unix.Rlimit{Cur: maxLimit, Max: maxLimit}
-		}
-	}
-	defaultLimits := []string{}
-	if err := unix.Setrlimit(unix.RLIMIT_NPROC, &rlim); err == nil {
-		defaultLimits = append(defaultLimits, fmt.Sprintf("nproc=%d:%d", rlim.Cur, rlim.Max))
-	} else if err := unix.Setrlimit(unix.RLIMIT_NPROC, &oldrlim); err == nil {
-		defaultLimits = append(defaultLimits, fmt.Sprintf("nproc=%d:%d", oldrlim.Cur, oldrlim.Max))
-	}
-	return defaultLimits
 }
 
 // getDefaultTmpDir for linux


### PR DESCRIPTION
it is wrong for two reasons: 1) we set the current process limits from a library, and 2) it sets a too high value for root, since it is the maximum allowed value on the system.
    
