### PR TITLE
Revert "Move fuse-overlayfs to suggests" for Fedora 40 and older

### DIFF
--- a/rpm/containers-common.spec
+++ b/rpm/containers-common.spec
@@ -50,7 +50,12 @@ BuildRequires: git-core
 BuildRequires: go-md2man
 Provides: skopeo-containers = %{epoch}:%{version}-%{release}
 Requires: (container-selinux >= 2:2.162.1 if selinux-policy)
+%if 0%{?fedora} && 0%{?fedora} <= 40
+Recommends: fuse-overlayfs
+Requires: (fuse-overlayfs if fedora-release-identity-server)
+%else
 Suggests: fuse-overlayfs
+%endif
 URL: https://github.com/%{project}/%{repo}
 Source0: %{url}/archive/v%{version_no_tilde}.tar.gz
 Source1: %{raw_github_url}/image/%{image_branch}/docs/containers-auth.json.5.md


### PR DESCRIPTION
Fedora completely ignores `Suggests` by default [1].  So, listing anything as `Suggests` is as good as not mentioning it at all, unless it's intended for tools and users who specifically respect it.

Downgrading the dependency on `fuse-overlayfs` to `Suggests` can make it go missing from the user's system, and break old Toolbx containers [2].

This is a problem because when Fedora 40 was released, it included `containers-common-0.58.0-2.fc40` [3,4], which still had:
```
  Recommends: fuse-overlayfs
  Requires: (fuse-overlayfs if fedora-release-identity-server)
```

The change to `Suggests` in Fedora commit [447945e59a01cb67](https://src.fedoraproject.org/rpms/containers-common/c/447945e59a01cb67) ("Move fuse-overlayfs to suggests") was made after that.

Such breaking changes are not meant for stable Fedora releases to avoid surprising users, and are best done in the next upcoming version [5]. This is particularly true for atomic Fedora variants like Silverblue, where the `fuse-overlayfs` RPM fell off the operating system image and had to be reinstated [6].  It could also happen to those using other Fedora variants, if, for example, they were trying to use a Kickstart for installation.

This reverts Fedora commit [447945e59a01cb6715ed2a21877d45bf0b91ef67](https://src.fedoraproject.org/rpms/containers-common/c/447945e59a01cb6715ed2a21877d45bf0b91ef67) for Fedora 40 and older releases.

[1] https://docs.fedoraproject.org/en-US/packaging-guidelines/WeakDependencies/

[2] https://discussion.fedoraproject.org/t/rpm-ostree-update-breaks-toolbox-fedora-40

[3] See the `f40` tag against `containers-common-0.58.0-2.fc40`:
    https://koji.fedoraproject.org/koji/buildinfo?buildID=2423622

[4] The update with `containers-common-0.58.0-2.fc40` was marked as stable
    before Final Freeze started:
    https://bodhi.fedoraproject.org/updates/FEDORA-2024-a267e93f8c
    https://fedorapeople.org/groups/schedule/f-40/f-40-key-tasks.html

[5] https://docs.fedoraproject.org/en-US/fesco/Updates_Policy/

[6] workstation-ostree-config commit c7f72d2cd5eea6b1
    https://pagure.io/workstation-ostree-config/c/c7f72d2cd5eea6b1
    https://pagure.io/workstation-ostree-config/pull-request/526

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
