### PR TITLE
Revert "Move fuse-overlayfs to suggests" for all Fedoras

### DIFF
--- a/rpm/containers-common.spec
+++ b/rpm/containers-common.spec
@@ -50,7 +50,7 @@ BuildRequires: git-core
 BuildRequires: go-md2man
 Provides: skopeo-containers = %{epoch}:%{version}-%{release}
 Requires: (container-selinux >= 2:2.162.1 if selinux-policy)
-%if 0%{?fedora} && 0%{?fedora} <= 40
+%if 0%{?fedora}
 Recommends: fuse-overlayfs
 Requires: (fuse-overlayfs if fedora-release-identity-server)
 %else


### PR DESCRIPTION
Commit 5ad221daa4d8d182 ("Revert \"Move fuse-overlayfs to suggests\" for Fedora 40 and older") restored the dependency on fuse-overlayfs for Fedora 40 and older to not disrupt stable Fedora releases by breaking backwards compatibility with existing containers.

Fedora completely ignores Suggests by default [1].  So, listing anything as Suggests is as good as not mentioning it at all, unless it's intended for tools and users who specifically respect it.

It turns out that there are important use-cases where the Linux kernel's overlay file system doesn't work, and one could really benefit from having fuse-overlayfs(1).  A container cannot use an overlayfs when the underlying file system is also an overlayfs, such as on the Fedora Workstation live media, or a network file system.

Therefore, it's worth restoring the dependency on all Fedora releases to cover these use-cases.

As suggested by Giuseppe Scrivano.

This reverts Fedora commit 447945e59a01cb6715ed2a21877d45bf0b91ef67 for all Fedora releases.

[1] https://docs.fedoraproject.org/en-US/packaging-guidelines/WeakDependencies/

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1749
Fixes: https://github.com/containers/toolbox/issues/1512
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2299284

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
