### PR TITLE
rpm/update-config-files: zstd:chunked not enabled in Fedora yet

### DIFF
--- a/rpm/update-config-files.sh
+++ b/rpm/update-config-files.sh
@@ -48,9 +48,8 @@ if [[ -n "$FEDORA" ]] || [[ "$RHEL" -ge 10 ]]; then
     sed -i -e '/^additionalimagestores\ =\ \[/a "\/usr\/lib\/containers\/storage",' storage.conf
 fi
 
-# Set these on Fedora 41+ and RHEL 10+
-# regardless of distro
-if [[ "$FEDORA" -gt 40 ]] || [[ "$RHEL" -ge 10 ]]; then
+# Set these on RHEL 10+
+if [[ "$RHEL" -ge 10 ]]; then
     ensure pkg/config/containers.conf   compression_format  \"zstd:chunked\"
     # Leave composefs disabled
     ensure storage.conf use_composefs   \"false\"


### PR DESCRIPTION
See: https://fedoraproject.org/wiki/Changes/zstd:chunked
See: https://pagure.io/fesco/issue/3252
See: https://github.com/containers/common/pull/2048
See: https://src.fedoraproject.org/rpms/containers-common/c/9f4dd38589309fbc189eac94367f520c105c3c1c?branch=f41
