### PR TITLE
[skip-ci][v0.60] RPM: do not set zstd:chunked default anywhere

### DIFF
--- a/rpm/update-config-files.sh
+++ b/rpm/update-config-files.sh
@@ -54,12 +54,3 @@ fi
 if [[ -n "$FEDORA" ]] || [[ "$RHEL" -ge 10 ]]; then
     sed -i -e '/^additionalimagestores\ =\ \[/a "\/usr\/lib\/containers\/storage",' storage.conf
 fi
-
-# Set these on Fedora Rawhide (41+), RHEL 10+, and on all COPR builds
-# regardless of distro
-if [[ -n "$COPR" ]] || [[ "$FEDORA" -gt 40 ]] || [[ "$RHEL" -ge 10 ]]; then
-    ensure pkg/config/containers.conf   compression_format  \"zstd:chunked\"
-    ensure storage.conf pull_options    \{enable_partial_images\ =\ \"true\",\ use_hard_links\ =\ \"false\",\ ostree_repos=\"\",\ convert_images\ =\ \"false\"\}
-    # Leave composefs disabled
-    ensure storage.conf use_composefs   \"false\"
-fi


### PR DESCRIPTION
Fixed in main with #2208 and #2213.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
