### PR TITLE
rpm/update-config-files: Don't set zstd:chunked default anywhere

### DIFF
--- a/rpm/update-config-files.sh
+++ b/rpm/update-config-files.sh
@@ -47,10 +47,3 @@ fi
 if [[ -n "$FEDORA" ]] || [[ "$RHEL" -ge 10 ]]; then
     sed -i -e '/^additionalimagestores\ =\ \[/a "\/usr\/lib\/containers\/storage",' storage.conf
 fi
-
-# Set these on RHEL 10+
-if [[ "$RHEL" -ge 10 ]]; then
-    ensure pkg/config/containers.conf   compression_format  \"zstd:chunked\"
-    # Leave composefs disabled
-    ensure storage.conf use_composefs   \"false\"
-fi


### PR DESCRIPTION
xref commit 1ad44cb67c70370f15d1981621824d1256a10041 "rpm/update-config-files: zstd:chunked not enabled in Fedora yet"

Basically it doesn't make sense to keep this enabled in RHEL10 but not in Fedora, that *seriously* undermines the testing story.

My immediate practical issue is that zstd:chunked in RHEL10 as of right now still breaks the bootc path, xref: https://github.com/containers/bootc/issues/509#issuecomment-2419695362
