### PR TITLE
libnetwork/pasta: remove Setup2()

### DIFF
--- a/libnetwork/internal/rootlessnetns/netns_linux.go
+++ b/libnetwork/internal/rootlessnetns/netns_linux.go
@@ -201,7 +201,7 @@ func (n *Netns) setupPasta(nsPath string) error {
 		Netns:        nsPath,
 		ExtraOptions: []string{"--pid", pidPath},
 	}
-	res, err := pasta.Setup2(&pastaOpts)
+	res, err := pasta.Setup(&pastaOpts)
 	if err != nil {
 		return fmt.Errorf("setting up Pasta: %w", err)
 	}

--- a/libnetwork/pasta/pasta_linux.go
+++ b/libnetwork/pasta/pasta_linux.go
@@ -50,11 +50,6 @@ type SetupOptions struct {
 	ExtraOptions []string
 }
 
-// Setup2 alias for Setup()
-func Setup2(opts *SetupOptions) (*SetupResult, error) {
-	return Setup(opts)
-}
-
 // Setup start the pasta process for the given netns.
 // The pasta binary is looked up in the HelperBinariesDir and $PATH.
 // Note that there is no need for any special cleanup logic, the pasta


### PR DESCRIPTION
This was just added as alias to allow vendoring without having to fix all callers at the same time.

These are the PRs that updat the callers:
https://github.com/containers/podman/pull/24417
https://github.com/containers/buildah/pull/5724

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
