### PR TITLE
pkg/timezone: handle TZDIR and local correctly

### DIFF
--- a/pkg/timezone/timezone.go
+++ b/pkg/timezone/timezone.go
@@ -23,18 +23,20 @@ func ConfigureContainerTimeZone(timezone, containerRunDir, mountPoint, etcPath, 
 	switch {
 	case timezone == "":
 		return "", nil
-	case os.Getenv("TZDIR") != "":
-		// Allow using TZDIR per:
-		// https://sourceware.org/git/?p=glibc.git;a=blob;f=time/tzfile.c;h=8a923d0cccc927a106dc3e3c641be310893bab4e;hb=HEAD#l149
-
-		timezonePath = filepath.Join(os.Getenv("TZDIR"), timezone)
 	case timezone == "local":
 		timezonePath, err = filepath.EvalSymlinks("/etc/localtime")
 		if err != nil {
 			return "", fmt.Errorf("finding local timezone for container %s: %w", containerID, err)
 		}
 	default:
-		timezonePath = filepath.Join("/usr/share/zoneinfo", timezone)
+		// Allow using TZDIR per:
+		// https://sourceware.org/git/?p=glibc.git;a=blob;f=time/tzfile.c;h=8a923d0cccc927a106dc3e3c641be310893bab4e;hb=HEAD#l149
+		zoneinfo := os.Getenv("TZDIR")
+		if zoneinfo == "" {
+			// default zoneinfo location
+			zoneinfo = "/usr/share/zoneinfo"
+		}
+		timezonePath = filepath.Join(zoneinfo, timezone)
 	}
 
 	etcFd, err := openDirectory(etcPath)


### PR DESCRIPTION
The special value local must always be higher priority then the TZDIR env so make sure local is matched before. Without this we joined local on the TZDIR path which of course does not result in a valid timezone path.

I will add a regression test in podman.

Fixes: containers/podman#23550

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
