### PR TITLE
Revert PR 2202

### DIFF
--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -533,14 +533,6 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 	if options.OS != runtime.GOOS {
 		lookupImageOptions.OS = options.OS
 	}
-	// FIXME: We sometimes return resolvedImageName from this function.
-	// The function documentation says this returns an image ID, resolvedImageName is frequently not an image ID.
-	//
-	// Ultimately Runtime.Pull looks up the returned name... again, possibly finding some other match
-	// than we did.
-	//
-	// This should be restructured so that the image we found here is returned to the caller of Pull
-	// directly, without another image -> name -> image round-trip and possible inconsistency.
 	localImage, resolvedImageName, err = r.LookupImage(imageName, lookupImageOptions)
 	if err != nil && !errors.Is(err, storage.ErrImageUnknown) {
 		logrus.Errorf("Looking up %s in local storage: %v", imageName, err)


### PR DESCRIPTION
We suspect this is causing issue sin podman as multi arch builds are no longer working as the pulling in parallel seems to break

```
# Error: [linux/s390x]: creating build container: looking up a just-pulled image: reference "[vfs@/var/tmp/buildah_tests.6dq4pu/root+/var/tmp/buildah_tests.6dq4pu/runroot]docker.io/library/alpine@sha256:43955d6857268cc948ae9b370b221091057de83c4962da0826f9a2bdc9bd6b44" does not resolve to an image ID: identifier is not an image
```

https://github.com/containers/podman/pull/24447

Draft until we now we will not fix it in time for the 5.3 release and I confirmed this fixes the podman regression