### PR TITLE
update apparmor profile to allow podman to send any signal

### DIFF
--- a/pkg/apparmor/apparmor_linux_template.go
+++ b/pkg/apparmor/apparmor_linux_template.go
@@ -24,7 +24,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   # Allow certain signals from OCI runtimes (podman, runc and crun)
   signal (receive) peer={/usr/bin/,/usr/sbin/,}runc,
   signal (receive) peer={/usr/bin/,/usr/sbin/,}crun*,
-  signal (receive) set=(int, quit, kill, term) peer={/usr/bin/,/usr/sbin/,}podman,
+  signal (receive) peer={/usr/bin/,/usr/sbin/,}podman,
 {{end}}
 
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)


### PR DESCRIPTION
This change updates the default apparmor profile to allow podman to send any signal rather than the allow listed "SIGINT", "SIGQUIT", "SIGKILL", and "SIGTERM". This fixes podman with signal proxying turned on (``--sig-proxy``) not being able to forward signals from the terminal such as "SIGWINCH" when attached to a TTY.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
