### PR TITLE
docs(container.conf): command typo

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -612,7 +612,7 @@ The default method is different based on the platform that
 Podman is being run upon.  To determine the current value,
 use this command:
 
-`podman info --format {{.Host.EventLogger}`
+`podman info --format {{.Host.EventLogger}}`
 
 Valid values are: `file`, `journald`, and `none`.
 


### PR DESCRIPTION
I read the contributing guidelines and I think I am up to speed.

PR was done when scrolling about `containers.conf` and saw this might affect users who copy-paste and don't look.

very low priority but keeping here.

if any changes are required let me know
