### PR TITLE
libnetwork/resolvconf: filter out ipv6 link local

### DIFF
--- a/libnetwork/resolvconf/resolv_test.go
+++ b/libnetwork/resolvconf/resolv_test.go
@@ -122,6 +122,18 @@ func TestNew(t *testing.T) {
 			ipv6:        true,
 			want:        "nameserver 1.1.1.1\nnameserver fd::1\n",
 		},
+		{
+			name:        "ipv6 link local must always be filtered when netns is private",
+			baseContent: "nameserver 1.1.1.1\nnameserver fe80::1%eth1\nnameserver fd::1\n",
+			ipv6:        true,
+			want:        "nameserver 1.1.1.1\nnameserver fd::1\n",
+		},
+		{
+			name:        "ipv6 link local must not be filtered when netns is host",
+			baseContent: "nameserver 1.1.1.1\nnameserver fe80::1%eth1\nnameserver fd::1\n",
+			hostns:      true,
+			want:        "nameserver 1.1.1.1\nnameserver fe80::1%eth1\nnameserver fd::1\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
One thing I noticed in the recent aardvark-dns bug[1] that we copy link local nameservers into the container. This makes no sense as the link local address contains a zone (interface name/index) and cannot work without it. However a container by design will have a different interface name/index so the address can never work in the normal case.

Only when we do share the host netns then we should keep it.

[1] https://github.com/containers/aardvark-dns/pull/537

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
