### PR TITLE
pkg/netns: add 60s timeout

### DIFF
--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -260,33 +260,34 @@ func newNSPath(nsPath string) (ns.NetNS, error) {
 // UnmountNS unmounts the given netns path
 func UnmountNS(nsPath string) error {
 	// Only unmount if it's been bind-mounted (don't touch namespaces in /proc...)
-	if !strings.HasPrefix(nsPath, "/proc/") {
-		// EINVAL means the path exists but is not mounted, just try to remove the path below
-		if err := unix.Unmount(nsPath, unix.MNT_DETACH); err != nil && !errors.Is(err, unix.EINVAL) {
-			// If path does not exists we can return without error as we have nothing to do.
+	if strings.HasPrefix(nsPath, "/proc/") {
+		return nil
+	}
+	// EINVAL means the path exists but is not mounted, just try to remove the path below
+	if err := unix.Unmount(nsPath, unix.MNT_DETACH); err != nil && !errors.Is(err, unix.EINVAL) {
+		// If path does not exists we can return without error as we have nothing to do.
+		if errors.Is(err, unix.ENOENT) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to unmount NS: at %s: %w", nsPath, err)
+	}
+
+	for {
+		if err := os.Remove(nsPath); err != nil {
+			if errors.Is(err, unix.EBUSY) {
+				// mount is still busy, sleep a moment and try again to remove
+				logrus.Debugf("Netns %s still busy, try removing it again in 10ms", nsPath)
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+			// If path does not exists we can return without error.
 			if errors.Is(err, unix.ENOENT) {
-				return nil
+				break
 			}
-
-			return fmt.Errorf("failed to unmount NS: at %s: %w", nsPath, err)
+			return fmt.Errorf("failed to remove ns path: %w", err)
 		}
-
-		for {
-			if err := os.Remove(nsPath); err != nil {
-				if errors.Is(err, unix.EBUSY) {
-					// mount is still busy, sleep a moment and try again to remove
-					logrus.Debugf("Netns %s still busy, try removing it again in 10ms", nsPath)
-					time.Sleep(10 * time.Millisecond)
-					continue
-				}
-				// If path does not exists we can return without error.
-				if errors.Is(err, unix.ENOENT) {
-					break
-				}
-				return fmt.Errorf("failed to remove ns path: %w", err)
-			}
-			break
-		}
+		break
 	}
 
 	return nil


### PR DESCRIPTION
pkg/netns: do not loop forever

So this is not so simple as one thinks, apparently there are cases where
it is impossible to remove the file but umount() worked fine...
We fixed one issue that ran into this[1] but there seems to be
another[2] problem, unknown cause yet.

Regardless of the real fix for issue[2] add a timeout to not hang/loop
forever. If we were not able to remove the file after 60s give up and
print an error. Leaking these files is not great as the netns references
stay around but it will not prevent containers from running. It will
only start leaking resources.

[1] https://issues.redhat.com/browse/RHEL-59620
[2] https://github.com/containers/podman/issues/24487