### PR TITLE
PerNetworkOptions: add driver specific options

### DIFF
--- a/libnetwork/types/network.go
+++ b/libnetwork/types/network.go
@@ -269,6 +269,8 @@ type PerNetworkOptions struct {
 	// InterfaceName for this container. Required in the backend.
 	// Optional in the frontend. Will be filled with ethX (where X is a integer) when empty.
 	InterfaceName string `json:"interface_name"`
+	// Driver-specific options for this container.
+	Options map[string]string `json:"options,omitempty"`
 }
 
 // NetworkOptions for a given container.


### PR DESCRIPTION
This allows us to pass through data to netavaark without bloating this struct. See #24523.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

Required by:
https://github.com/containers/podman/pull/24535
https://github.com/containers/netavark/pull/1125
