### PR TITLE
Add fields for TLS material to destination config

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -933,15 +933,15 @@ URI to access the Podman service
 
 Path to file containing ssh identity key
 
-**tls_cert_file="~/certs/podman/tls.crt"**
+**tls_cert_file="/path/to/certs/podman/tls.crt"**
 
 Path to PEM file containing TLS client certificate
 
-**tls_key_file="~/certs/podman/tls.key"**
+**tls_key_file="/path/to/certs/podman/tls.key"**
 
 Path to PEM file containing TLS client certificate private key
 
-**tls_ca_file="~/certs/podman/ca.crt"**
+**tls_ca_file="/path/to/certs/podman/ca.crt"**
 
 Path to PEM file containing TLS certificate authority (CA) bundle
 

--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -927,10 +927,23 @@ URI to access the Podman service
 - **rootless remote** - ssh://user@engineering.lab.company.com/run/user/1000/podman/podman.sock
 - **rootful local**  - unix:///run/podman/podman.sock
 - **rootful remote** - ssh://root@10.10.1.136:22/run/podman/podman.sock
+- **tcp/tls remote** - tcp://10.10.1.136:9443
 
 **identity="~/.ssh/id_rsa**
 
 Path to file containing ssh identity key
+
+**tls_cert_file="~/certs/podman/tls.crt"**
+
+Path to PEM file containing TLS client certificate
+
+**tls_key_file="~/certs/podman/tls.key"**
+
+Path to PEM file containing TLS client certificate private key
+
+**tls_ca_file="~/certs/podman/ca.crt"**
+
+Path to PEM file containing TLS certificate authority (CA) bundle
 
 **[engine.volume_plugins]**
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -704,6 +704,13 @@ type Destination struct {
 	// Identity file with ssh key, optional
 	Identity string `json:",omitempty" toml:"identity,omitempty"`
 
+	// Path to TLS client certificate PEM file, optional
+	TLSCertFile string `json:",omitempty" toml:"tls_cert_file,omitempty"`
+	// Path to TLS client certificate private key PEM file, optional
+	TLSKeyFile string `json:",omitempty" toml:"tls_key_file,omitempty"`
+	// Path to TLS certificate authority PEM file, optional
+	TLSCAFile string `json:",omitempty" toml:"tls_ca_file,omitempty"`
+
 	// isMachine describes if the remote destination is a machine.
 	IsMachine bool `json:",omitempty" toml:"is_machine,omitempty"`
 }

--- a/pkg/config/connections_test.go
+++ b/pkg/config/connections_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Connections conf", func() {
 	})
 
 	Context("GetConnection/Farm", func() {
-		const defConnectionsConf = `{"Connection":{"Default":"test","Connections":{"test":{"URI":"ssh://podman.io"},"QA":{"URI":"ssh://test","Identity":".ssh/id","IsMachine":true}}},"farm":{"Default":"farm1","List":{"farm1":["test"]}}}`
+		const defConnectionsConf = `{"Connection":{"Default":"test","Connections":{"test":{"URI":"ssh://podman.io"},"QA":{"URI":"ssh://test","Identity":".ssh/id","IsMachine":true},"TLS": {"URI": "tcp://podman.io:443", "TLSCAFile":"/path/to/ca.pem"},"mTLS":{"URI": "tcp://podman.io:443/subpath", "TLSCAFile": "/path/to/ca.pem", "TLSCertFile": "/path/to/tls.crt", "TLSKeyFile": "/path/to/tls.key"}}},"farm":{"Default":"farm1","List":{"farm1":["test"]}}}`
 		const defContainersConf = `
 [engine]
   active_service = "containers"
@@ -156,6 +156,24 @@ var _ = Describe("Connections conf", func() {
 				Default:     false,
 				ReadWrite:   true,
 				Destination: Destination{URI: "ssh://test", Identity: ".ssh/id", IsMachine: true},
+			}))
+
+			con, err = conf.GetConnection("TLS", false)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(con).To(gomega.Equal(&Connection{
+				Name:        "TLS",
+				Default:     false,
+				ReadWrite:   true,
+				Destination: Destination{URI: "tcp://podman.io:443", TLSCAFile: "/path/to/ca.pem"},
+			}))
+
+			con, err = conf.GetConnection("mTLS", false)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(con).To(gomega.Equal(&Connection{
+				Name:        "mTLS",
+				Default:     false,
+				ReadWrite:   true,
+				Destination: Destination{URI: "tcp://podman.io:443/subpath", TLSCAFile: "/path/to/ca.pem", TLSCertFile: "/path/to/tls.crt", TLSKeyFile: "/path/to/tls.key"},
 			}))
 
 			con, err = conf.GetConnection("containers", false)

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -783,11 +783,11 @@ default_sysctls = [
 #    Path to file containing ssh identity key
 #    identity = "~/.ssh/id_rsa"
 #    Path to PEM file containing TLS client certificate
-#    tls_cert_file = "~/certs/podman/tls.crt"
+#    tls_cert_file = "/path/to/certs/podman/tls.crt"
 #    Path to PEM file containing TLS client certificate private key
-#    tls_key_file = "~/certs/podman/tls.key"
+#    tls_key_file = "/path/to/certs/podman/tls.key"
 #    Path to PEM file containing TLS certificate authority (CA) bundle
-#    tls_ca_file = "~/certs/podman/ca.crt"
+#    tls_ca_file = "/path/to/certs/podman/ca.crt"
 
 
 # Directory for temporary files. Must be tmpfs (wiped after reboot)

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -777,10 +777,18 @@ default_sysctls = [
 #       rootful "unix:///run/podman/podman.sock (Default)
 #       remote rootless ssh://engineering.lab.company.com/run/user/1000/podman/podman.sock
 #       remote rootful ssh://root@10.10.1.136:22/run/podman/podman.sock
+#       tcp/tls remote tcp://10.10.1.136:9443
 #
 #    uri = "ssh://user@production.example.com/run/user/1001/podman/podman.sock"
 #    Path to file containing ssh identity key
 #    identity = "~/.ssh/id_rsa"
+#    Path to PEM file containing TLS client certificate
+#    tls_cert_file = "~/certs/podman/tls.crt"
+#    Path to PEM file containing TLS client certificate private key
+#    tls_key_file = "~/certs/podman/tls.key"
+#    Path to PEM file containing TLS certificate authority (CA) bundle
+#    tls_ca_file = "~/certs/podman/ca.crt"
+
 
 # Directory for temporary files. Must be tmpfs (wiped after reboot)
 #

--- a/pkg/config/containers.conf-freebsd
+++ b/pkg/config/containers.conf-freebsd
@@ -598,10 +598,17 @@ default_sysctls = [
 #       rootful "unix:///run/podman/podman.sock (Default)
 #       remote rootless ssh://engineering.lab.company.com/run/user/1000/podman/podman.sock
 #       remote rootful ssh://root@10.10.1.136:22/run/podman/podman.sock
+#       tcp/tls remote tcp://10.10.1.136:9443
 #
 #    uri = "ssh://user@production.example.com/run/user/1001/podman/podman.sock"
 #    Path to file containing ssh identity key
 #    identity = "~/.ssh/id_rsa"
+#    Path to PEM file containing TLS client certificate
+#    tls_cert_file = "~/certs/podman/tls.crt"
+#    Path to PEM file containing TLS client certificate private key
+#    tls_key_file = "~/certs/podman/tls.key"
+#    Path to PEM file containing TLS certificate authority (CA) bundle
+#    tls_ca_file = "~/certs/podman/ca.crt"
 
 # Directory for temporary files. Must be tmpfs (wiped after reboot)
 #

--- a/pkg/config/containers.conf-freebsd
+++ b/pkg/config/containers.conf-freebsd
@@ -604,11 +604,11 @@ default_sysctls = [
 #    Path to file containing ssh identity key
 #    identity = "~/.ssh/id_rsa"
 #    Path to PEM file containing TLS client certificate
-#    tls_cert_file = "~/certs/podman/tls.crt"
+#    tls_cert_file = "/path/to/certs/podman/tls.crt"
 #    Path to PEM file containing TLS client certificate private key
-#    tls_key_file = "~/certs/podman/tls.key"
+#    tls_key_file = "/path/to/certs/podman/tls.key"
 #    Path to PEM file containing TLS certificate authority (CA) bundle
-#    tls_ca_file = "~/certs/podman/ca.crt"
+#    tls_ca_file = "/path/to/certs/podman/ca.crt"
 
 # Directory for temporary files. Must be tmpfs (wiped after reboot)
 #


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

Adds optional fields `tls_cert_file`, `tls_key_file`, and `tls_cafile` to the configuration TOML to support connecting to TLS and mTLS podman API sockets.

This is in support of https://github.com/containers/podman/pull/24601 to fix https://github.com/containers/podman/issues/24583 .


