### PR TITLE
libimage tests: try to avoid docker.io images

### DIFF
--- a/libimage/image_test.go
+++ b/libimage/image_test.go
@@ -391,7 +391,7 @@ func TestUntag(t *testing.T) {
 func getImageAndRuntime(t *testing.T) (*Runtime, *Image) {
 	// Note: this will resolve pull from the GCR registry (see
 	// testdata/registries.conf).
-	busyboxLatest := "docker.io/library/busybox:latest"
+	busyboxLatest := "quay.io/libpod/busybox:latest"
 
 	runtime := testNewRuntime(t)
 	ctx := context.Background()

--- a/libimage/pull_test.go
+++ b/libimage/pull_test.go
@@ -223,7 +223,7 @@ func TestPullOCINoReference(t *testing.T) {
 	// Exercise pulling from the OCI transport and make sure that a
 	// specified reference is preserved in the image name.
 
-	busybox := "docker.io/library/busybox:latest"
+	busybox := "quay.io/libpod/busybox:latest"
 	runtime := testNewRuntime(t)
 	ctx := context.Background()
 	pullOptions := &PullOptions{}

--- a/libimage/push_test.go
+++ b/libimage/push_test.go
@@ -22,7 +22,7 @@ func TestPush(t *testing.T) {
 	// Prefetch alpine.
 	pullOptions := &PullOptions{}
 	pullOptions.Writer = os.Stdout
-	_, err := runtime.Pull(ctx, "docker.io/library/alpine:latest", config.PullPolicyAlways, pullOptions)
+	_, err := runtime.Pull(ctx, "quay.io/libpod/alpine:latest", config.PullPolicyAlways, pullOptions)
 	require.NoError(t, err)
 
 	pushOptions := &PushOptions{}
@@ -81,7 +81,7 @@ func TestPushOtherPlatform(t *testing.T) {
 	pullOptions := &PullOptions{}
 	pullOptions.Writer = os.Stdout
 	pullOptions.Architecture = "arm64"
-	pulledImages, err := runtime.Pull(ctx, "docker.io/library/alpine:latest", config.PullPolicyAlways, pullOptions)
+	pulledImages, err := runtime.Pull(ctx, "quay.io/libpod/alpine:latest", config.PullPolicyAlways, pullOptions)
 	require.NoError(t, err)
 	require.Len(t, pulledImages, 1)
 
@@ -95,7 +95,7 @@ func TestPushOtherPlatform(t *testing.T) {
 	require.NoError(t, err)
 	tmp.Close()
 	defer os.Remove(tmp.Name())
-	_, err = runtime.Push(ctx, "docker.io/library/alpine:latest", "docker-archive:"+tmp.Name(), pushOptions)
+	_, err = runtime.Push(ctx, "quay.io/libpod/alpine:latest", "docker-archive:"+tmp.Name(), pushOptions)
 	require.NoError(t, err)
 }
 
@@ -107,7 +107,7 @@ func TestPushWithForceCompression(t *testing.T) {
 	pullOptions := &PullOptions{}
 	pullOptions.Writer = os.Stdout
 	pullOptions.Architecture = "arm64"
-	pulledImages, err := runtime.Pull(ctx, "docker.io/library/alpine:latest", config.PullPolicyAlways, pullOptions)
+	pulledImages, err := runtime.Pull(ctx, "quay.io/libpod/alpine:latest", config.PullPolicyAlways, pullOptions)
 	require.NoError(t, err)
 	require.Len(t, pulledImages, 1)
 
@@ -121,7 +121,7 @@ func TestPushWithForceCompression(t *testing.T) {
 	pushOptions.SystemContext.DirForceDecompress = true
 	pushOptions.Writer = os.Stdout
 	dirDest := t.TempDir()
-	_, err = runtime.Push(ctx, "docker.io/library/alpine:latest", "dir:"+dirDest, pushOptions)
+	_, err = runtime.Push(ctx, "quay.io/libpod/alpine:latest", "dir:"+dirDest, pushOptions)
 	require.NoError(t, err)
 
 	// Pull uncompressed alpine from `dir:dirDest` as source.
@@ -137,7 +137,7 @@ func TestPushWithForceCompression(t *testing.T) {
 	pushOptions.OciAcceptUncompressedLayers = true
 	pushOptions.Writer = os.Stdout
 	ociDest := t.TempDir()
-	_, err = runtime.Push(ctx, "docker.io/library/alpine:latest", "oci:"+ociDest, pushOptions)
+	_, err = runtime.Push(ctx, "quay.io/libpod/alpine:latest", "oci:"+ociDest, pushOptions)
 	require.NoError(t, err)
 
 	// blobs from first push
@@ -154,7 +154,7 @@ func TestPushWithForceCompression(t *testing.T) {
 	pushOptions.Writer = os.Stdout
 	pushOptions.CompressionFormat = &compression.Gzip
 	pushOptions.ForceCompressionFormat = false
-	_, err = runtime.Push(ctx, "docker.io/library/alpine:latest", "oci:"+ociDest, pushOptions)
+	_, err = runtime.Push(ctx, "quay.io/libpod/alpine:latest", "oci:"+ociDest, pushOptions)
 	require.NoError(t, err)
 
 	// blobs from second push
@@ -175,7 +175,7 @@ func TestPushWithForceCompression(t *testing.T) {
 	pushOptions.Writer = os.Stdout
 	pushOptions.CompressionFormat = &compression.Gzip
 	pushOptions.ForceCompressionFormat = true
-	_, err = runtime.Push(ctx, "docker.io/library/alpine:latest", "oci:"+ociDest, pushOptions)
+	_, err = runtime.Push(ctx, "quay.io/libpod/alpine:latest", "oci:"+ociDest, pushOptions)
 	require.NoError(t, err)
 
 	// collect blobs from third push

--- a/libimage/remove_test.go
+++ b/libimage/remove_test.go
@@ -14,7 +14,7 @@ import (
 func TestRemoveImages(t *testing.T) {
 	// Note: this will resolve pull from the GCR registry (see
 	// testdata/registries.conf).
-	busyboxLatest := "docker.io/library/busybox:latest"
+	busyboxLatest := "quay.io/libpod/busybox:latest"
 
 	runtime := testNewRuntime(t)
 	ctx := context.Background()

--- a/libimage/runtime_test.go
+++ b/libimage/runtime_test.go
@@ -109,8 +109,8 @@ func TestRuntimeListImagesAllImages(t *testing.T) {
 	ctx := context.Background()
 
 	// Prefetch alpine, busybox.
-	testRuntimePullImage(t, runtime, ctx, "docker.io/library/alpine:latest")
-	testRuntimePullImage(t, runtime, ctx, "docker.io/library/busybox:latest")
+	testRuntimePullImage(t, runtime, ctx, "quay.io/libpod/alpine:latest")
+	testRuntimePullImage(t, runtime, ctx, "quay.io/libpod/busybox:latest")
 
 	images, err := runtime.ListImages(ctx, nil)
 	require.NoError(t, err)
@@ -122,7 +122,7 @@ func TestRuntimeListImagesAllImages(t *testing.T) {
 	}
 	assert.ElementsMatch(t,
 		image_names,
-		[]string{"docker.io/library/alpine:latest", "docker.io/library/busybox:latest"},
+		[]string{"quay.io/libpod/alpine:latest", "quay.io/libpod/busybox:latest"},
 	)
 }
 
@@ -131,15 +131,15 @@ func TestRuntimeListImagesByNames(t *testing.T) {
 	ctx := context.Background()
 
 	// Prefetch alpine, busybox.
-	testRuntimePullImage(t, runtime, ctx, "docker.io/library/alpine:latest")
-	testRuntimePullImage(t, runtime, ctx, "docker.io/library/busybox:latest")
+	testRuntimePullImage(t, runtime, ctx, "quay.io/libpod/alpine:latest")
+	testRuntimePullImage(t, runtime, ctx, "quay.io/libpod/busybox:latest")
 
 	for _, test := range []struct {
 		name     string
 		fullName string
 	}{
-		{"alpine", "docker.io/library/alpine:latest"},
-		{"busybox", "docker.io/library/busybox:latest"},
+		{"alpine", "quay.io/libpod/alpine:latest"},
+		{"busybox", "quay.io/libpod/busybox:latest"},
 	} {
 		images, err := runtime.ListImagesByNames([]string{test.name})
 		require.NoError(t, err)

--- a/libimage/save_test.go
+++ b/libimage/save_test.go
@@ -19,9 +19,9 @@ func TestSave(t *testing.T) {
 	// Prefetch alpine, busybox.
 	pullOptions := &PullOptions{}
 	pullOptions.Writer = os.Stdout
-	_, err := runtime.Pull(ctx, "docker.io/library/alpine:latest", config.PullPolicyAlways, pullOptions)
+	_, err := runtime.Pull(ctx, "quay.io/libpod/alpine:latest", config.PullPolicyAlways, pullOptions)
 	require.NoError(t, err)
-	_, err = runtime.Pull(ctx, "docker.io/library/busybox:latest", config.PullPolicyAlways, pullOptions)
+	_, err = runtime.Pull(ctx, "quay.io/libpod/busybox:latest", config.PullPolicyAlways, pullOptions)
 	require.NoError(t, err)
 
 	// Save the two images into a multi-image archive.  This way, we can


### PR DESCRIPTION
These images can and will change at any time and thus can break our CI without any external changes which is very bad. The TestPush test is failing because it expects two not one image as it converts from docker to oci on push. However the upstream docker.io/library/alpine was switched to an oci image thus the test started failing as the local storage now has the same id and just stores two different tags for the same image.

Switch to our own controlled quay.io images where possible. This is neither complete nor do I fully understand the tests here. I did a quick search and replace and will see what works or not.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
