### PR TITLE
Allow Podman to send the container's hostname to Netavark

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -124,6 +124,16 @@ Options are:
 `private` Create private Cgroup Namespace for the container.
 `host`    Share host Cgroup Namespace with the container.
 
+**container_name_as_hostname**=true|false
+
+When no hostname is set for a container, use the container's name, with
+characters not valid for a hostname removed, as the hostname instead of
+the first 12 characters of the container's ID. Containers not running
+in a private UTS namespace will have their hostname set to the host's
+hostname regardless of this setting.
+
+Default is false.
+
 **default_capabilities**=[]
 
 List of default capabilities for containers.

--- a/libnetwork/types/network.go
+++ b/libnetwork/types/network.go
@@ -277,7 +277,7 @@ type PerNetworkOptions struct {
 type NetworkOptions struct {
 	// ContainerID is the container id, used for iptables comments and ipam allocation.
 	ContainerID string `json:"container_id"`
-	// ContainerName is the container name, used as dns name.
+	// ContainerName is the container name.
 	ContainerName string `json:"container_name"`
 	// PortMappings contains the port mappings for this container
 	PortMappings []PortMapping `json:"port_mappings,omitempty"`
@@ -287,6 +287,8 @@ type NetworkOptions struct {
 	// List of custom DNS server for podman's DNS resolver.
 	// Priority order will be kept as defined by user in the configuration.
 	DNSServers []string `json:"dns_servers,omitempty"`
+	// ContainerHostname is the configured DNS hostname of the container.
+	ContainerHostname string `json:"container_hostname"`
 }
 
 // PortMapping is one or more ports that will be mapped into the container.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -96,6 +96,13 @@ type ContainersConfig struct {
 	// "memory.high=1073741824" sets the memory.high limit to 1GB.
 	CgroupConf attributedstring.Slice `toml:"cgroup_conf,omitempty"`
 
+	// When no hostname is set for a container, use the container's name, with
+	// characters not valid for a hostname removed, as the hostname instead of
+	// the first 12 characters of the container's ID. Containers not running
+	// in a private UTS namespace will have their hostname set to the host's
+	// hostname regardless of this setting.
+	ContainerNameAsHostName bool `toml:"container_name_as_hostname,omitempty"`
+
 	// Capabilities to add to all containers.
 	DefaultCapabilities attributedstring.Slice `toml:"default_capabilities,omitempty"`
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -215,6 +215,7 @@ image_copy_tmp_dir="storage"`
 			// prior to reading local config, shows hard coded defaults
 			gomega.Expect(defaultConfig.Containers.HTTPProxy).To(gomega.BeTrue())
 			gomega.Expect(defaultConfig.Engine.HealthcheckEvents).To(gomega.BeTrue())
+			gomega.Expect(defaultConfig.Containers.ContainerNameAsHostName).To(gomega.BeFalse())
 
 			err := readConfigFromFile("testdata/containers_default.conf", defaultConfig, false)
 
@@ -322,6 +323,7 @@ image_copy_tmp_dir="storage"`
 			// Then
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(defaultConfig.Engine.CgroupManager).To(gomega.Equal("systemd"))
+			gomega.Expect(defaultConfig.Containers.ContainerNameAsHostName).To(gomega.BeTrue())
 			gomega.Expect(defaultConfig.Containers.Env.Get()).To(gomega.BeEquivalentTo(envs))
 			gomega.Expect(defaultConfig.Containers.Mounts.Get()).To(gomega.BeEquivalentTo(mounts))
 			gomega.Expect(defaultConfig.Containers.PidsLimit).To(gomega.BeEquivalentTo(2048))

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -58,6 +58,14 @@
 #
 #cgroups = "enabled"
 
+# When no hostname is set for a container, use the container's name, with
+# characters not valid for a hostname removed, as the hostname instead of
+# the first 12 characters of the container's ID. Containers not running
+# in a private UTS namespace will have their hostname set to the host's
+# hostname regardless of this setting.
+#
+#container_name_as_hostname = false
+
 # List of default capabilities for containers. If it is empty or commented out,
 # the default capabilities defined in the container engine will be added.
 #

--- a/pkg/config/containers.conf-freebsd
+++ b/pkg/config/containers.conf-freebsd
@@ -29,6 +29,12 @@
 #
 #base_hosts_file = ""
 
+# When no hostname is set for a container, use the container's name, with
+# characters not valid for a hostname removed, as the hostname instead of
+# the first 12 characters of the container's ID.
+#
+#container_name_as_hostname = false
+
 # The database backend of Podman.  Supported values are "" (default), "boltdb"
 # and "sqlite". An empty value means it will check whenever a boltdb already
 # exists and use it when it does, otherwise it will use sqlite as default

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -23,6 +23,8 @@ apparmor_profile = "container-default"
 
 base_hosts_file = "/etc/hosts2"
 
+container_name_as_hostname = true
+
 # List of default capabilities for containers. If it is empty or commented out,
 # only the capabilities defined in the containers json file by the user/kube
 # will be added.


### PR DESCRIPTION
* Added ContainerHostname to NetworkOptions. Podman will set this
  and Netavark will read it.

* Added the `container_name_as_hostname` option to the
  CONTAINERS table in containers.conf.  Currently, if you don't
  explicitly set a hostname when creating a container, podman will
  set it to the short ID. If this option set to `true` and a
  hostname isn't explicitly set, podman will use the container's
  name, with characters not in the set `[0-9a-zA-Z.-]` removed,
  as the hostname instead of the short ID. Set to false by default
  to preserve existing behavior.

Signed-off-by: George Joseph <g.devel@wxy78.net>

Required by containers/podman#24675
Required by containers/netavark#1130
