### PR TITLE
pkg/ssh: fix windows path logic

### DIFF
--- a/pkg/ssh/connection_golang.go
+++ b/pkg/ssh/connection_golang.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -313,7 +312,7 @@ func ValidateAndConfigure(uri *url.URL, iden string, insecureIsMachineConnection
 		if !errors.Is(err, os.ErrNotExist) {
 			return nil, err
 		}
-		keyDir := path.Dir(keyFilePath)
+		keyDir := filepath.Dir(keyFilePath)
 		if err := fileutils.Exists(keyDir); errors.Is(err, os.ErrNotExist) {
 			if err := os.Mkdir(keyDir, 0o700); err != nil {
 				return nil, err


### PR DESCRIPTION
Using the path package is not correct on windows as it always defaults to the "/" as path separator. Instead one must use the filepath package.

Fixes containers/podman#24616

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
