### PR TITLE
spec: create/own /etc/containers/networks

### DIFF
--- a/rpm/containers-common.spec
+++ b/rpm/containers-common.spec
@@ -141,7 +141,7 @@ done
 
 %install
 # install config and policy files for registries
-install -dp %{buildroot}%{_sysconfdir}/containers/{certs.d,oci/hooks.d,systemd}
+install -dp %{buildroot}%{_sysconfdir}/containers/{certs.d,oci/hooks.d,networks,systemd}
 install -dp %{buildroot}%{_sharedstatedir}/containers/sigstore
 install -dp %{buildroot}%{_datadir}/containers/systemd
 install -dp %{buildroot}%{_prefix}/lib/containers/storage
@@ -187,6 +187,7 @@ ln -s ../../../..%{_sysconfdir}/yum.repos.d/redhat.repo %{buildroot}%{_datadir}/
 %files
 %dir %{_sysconfdir}/containers
 %dir %{_sysconfdir}/containers/certs.d
+%dir %{_sysconfdir}/containers/networks
 %dir %{_sysconfdir}/containers/oci
 %dir %{_sysconfdir}/containers/oci/hooks.d
 %dir %{_sysconfdir}/containers/registries.conf.d


### PR DESCRIPTION
In some cases if /etc/ is mounted read-only the non-existence of the `/etc/containers/networks` directory will cause basic functionality to fail.

```
bash-5.2# mount --bind -o ro /etc/containers/ /etc/containers/
bash-5.2# podman info
Error: mkdir /etc/containers/networks: read-only file system
```

Since it's going to get created anyway let's just have the directory exist from the beginning.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
