### PR TITLE
libnetwork/netavark: do not create config dir in init

### DIFF
--- a/libnetwork/netavark/config.go
+++ b/libnetwork/netavark/config.go
@@ -30,6 +30,9 @@ func sliceRemoveDuplicates(strList []string) []string {
 }
 
 func (n *netavarkNetwork) commitNetwork(network *types.Network) error {
+	if err := os.MkdirAll(n.networkConfigDir, 0o755); err != nil {
+		return nil
+	}
 	confPath := filepath.Join(n.networkConfigDir, network.Name+".json")
 	f, err := os.Create(confPath)
 	if err != nil {


### PR DESCRIPTION
Podman creates/initializes the network backend for every command. However most commands will not need it so we should keep the required actions we do to a minimum.

In this case the config directory /etc/containers/networks by default as root may not exists and then we try to create it which can fail, i.e. when /etc is read only[1].

The code here are a bit more changes then I would have liked but we must make sure the default in memory network always exists and do not create the directory there.

[1] https://github.com/containers/common/pull/2265

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
