### PR TITLE
[skip-ci] Packit: remove epel/rhel copr targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,9 +13,6 @@ packages:
     downstream_package_name: containers-common
     pkg_tool: centpkg
     specfile_path: rpm/containers-common.spec
-  containers-common-rhel:
-    downstream_package_name: containers-common
-    specfile_path: rpm/containers-common.spec
   containers-common-eln:
     downstream_package_name: containers-common
     specfile_path: rpm/containers-common.spec
@@ -55,14 +52,6 @@ jobs:
     targets:
       - centos-stream-9
       - centos-stream-10
-
-  - job: copr_build
-    trigger: pull_request
-    packages: [containers-common-rhel]
-    notifications: *ephemeral_build_failure_notification
-    enable_net: true
-    targets:
-      - epel-9
 
   # Run on commit to main branch
   - job: copr_build


### PR DESCRIPTION
rhel copr targets are often outdated causing failed builds and tests. Best to only have CentOS Stream targets upstream, so we ensure everything that enters RHEL at some point has been tested upstream.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
