### PR TITLE
config: drop /sys/dev/block from masked paths

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -46,7 +46,6 @@ var (
 		"/proc/scsi",
 		"/proc/timer_list",
 		"/proc/timer_stats",
-		"/sys/dev/block",
 		"/sys/devices/virtual/powercap",
 		"/sys/firmware",
 		"/sys/fs/selinux",


### PR DESCRIPTION
there is no real advantage in masking this path, since this information is already available under /sys/devices.  In fact, the files under /sys/dev/block are just symlinks.

[root@953139a2851f /]# ls -l /sys/dev/block/252\:0 lrwxrwxrwx. 1 root root 0 Dec 17 12:47 /sys/dev/block/252:0 -> ../../devices/virtual/block/zram0

Fixes: https://github.com/containers/common/issues/2277
Fixes: https://issues.redhat.com/browse/RHEL-3115
 