### PR TITLE
pkg/config: make Capabilities() a no-op stub on non-linux platforms

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/containers/common/internal/attributedstring"
 	"github.com/containers/common/libnetwork/types"
-	"github.com/containers/common/pkg/capabilities"
 	"github.com/containers/storage/pkg/fileutils"
 	"github.com/containers/storage/pkg/homedir"
 	"github.com/containers/storage/pkg/unshare"
@@ -977,24 +976,6 @@ func (c *Config) GetDefaultEnvEx(envHost, httpProxy bool) []string {
 		}
 	}
 	return append(env, c.Containers.Env.Get()...)
-}
-
-// Capabilities returns the capabilities parses the Add and Drop capability
-// list from the default capabilities for the container
-func (c *Config) Capabilities(user string, addCapabilities, dropCapabilities []string) ([]string, error) {
-	userNotRoot := func(user string) bool {
-		if user == "" || user == "root" || user == "0" {
-			return false
-		}
-		return true
-	}
-
-	defaultCapabilities := c.Containers.DefaultCapabilities.Get()
-	if userNotRoot(user) {
-		defaultCapabilities = []string{}
-	}
-
-	return capabilities.MergeCapabilities(defaultCapabilities, addCapabilities, dropCapabilities)
 }
 
 // Device parses device mapping string to a src, dest & permissions string

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/containers/common/pkg/capabilities"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 )
 
@@ -25,4 +26,22 @@ var defaultHelperBinariesDir = []string{
 	"/usr/local/lib/podman",
 	"/usr/libexec/podman",
 	"/usr/lib/podman",
+}
+
+// Capabilities returns the capabilities parses the Add and Drop capability
+// list from the default capabilities for the container
+func (c *Config) Capabilities(user string, addCapabilities, dropCapabilities []string) ([]string, error) {
+	userNotRoot := func(user string) bool {
+		if user == "" || user == "root" || user == "0" {
+			return false
+		}
+		return true
+	}
+
+	defaultCapabilities := c.Containers.DefaultCapabilities.Get()
+	if userNotRoot(user) {
+		defaultCapabilities = []string{}
+	}
+
+	return capabilities.MergeCapabilities(defaultCapabilities, addCapabilities, dropCapabilities)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -439,18 +439,21 @@ image_copy_tmp_dir="storage"`
 				},
 			}
 
-			defCaps := []string{
-				"CAP_CHOWN",
-				"CAP_DAC_OVERRIDE",
-				"CAP_FOWNER",
-				"CAP_FSETID",
-				"CAP_KILL",
-				"CAP_NET_BIND_SERVICE",
-				"CAP_SETFCAP",
-				"CAP_SETGID",
-				"CAP_SETPCAP",
-				"CAP_SETUID",
-				"CAP_SYS_CHROOT",
+			var defCaps []string
+			if runtime.GOOS == "linux" {
+				defCaps = []string{
+					"CAP_CHOWN",
+					"CAP_DAC_OVERRIDE",
+					"CAP_FOWNER",
+					"CAP_FSETID",
+					"CAP_KILL",
+					"CAP_NET_BIND_SERVICE",
+					"CAP_SETFCAP",
+					"CAP_SETGID",
+					"CAP_SETPCAP",
+					"CAP_SETUID",
+					"CAP_SYS_CHROOT",
+				}
 			}
 
 			envs := []string{
@@ -480,7 +483,8 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(config.Engine.OCIRuntimes["runc"]).To(gomega.Equal(OCIRuntimeMap["runc"]))
 			gomega.Expect(config.Containers.CgroupConf.Get()).To(gomega.BeEmpty())
 
-			caps, _ := config.Capabilities("", nil, nil)
+			caps, err := config.Capabilities("", nil, nil)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(caps).Should(gomega.Equal(defCaps))
 
 			if useSystemd() {

--- a/pkg/config/config_unsupported.go
+++ b/pkg/config/config_unsupported.go
@@ -5,3 +5,9 @@ package config
 func selinuxEnabled() bool {
 	return false
 }
+
+// Capabilities returns the capabilities parses the Add and Drop capability
+// list from the default capabilities for the container
+func (c *Config) Capabilities(user string, addCapabilities, dropCapabilities []string) ([]string, error) {
+	return nil, nil
+}


### PR DESCRIPTION
This fixes 'podman build' and 'buildah build' on non-linux platforms where (*Config).Capabilities started throwing errors after the pkg/capabilities package started using github.com/moby/sys/capability to validate the capability lists.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
