### PR TITLE
Use UnparsedInstance.Manifest instead of ImageSource.GetManifest

### DIFF
--- a/libimage/image.go
+++ b/libimage/image.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/containers/common/libimage/platform"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
 	storageTransport "github.com/containers/image/v5/storage"
 	"github.com/containers/image/v5/types"
@@ -1002,7 +1003,7 @@ func (i *Image) Manifest(ctx context.Context) (rawManifest []byte, mimeType stri
 	if err != nil {
 		return nil, "", err
 	}
-	return src.GetManifest(ctx, nil)
+	return image.UnparsedInstance(src, nil).Manifest(ctx)
 }
 
 // getImageID creates an image object and uses the hex value of the config

--- a/libimage/inspect.go
+++ b/libimage/inspect.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
@@ -159,7 +160,7 @@ func (i *Image) Inspect(ctx context.Context, options *InspectOptions) (*ImageDat
 	if err != nil {
 		return nil, err
 	}
-	manifestRaw, manifestType, err := src.GetManifest(ctx, nil)
+	manifestRaw, manifestType, err := image.UnparsedInstance(src, nil).Manifest(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containers/common/pkg/supplemented"
 	imageCopy "github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/docker"
+	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/signature"
@@ -370,11 +371,11 @@ func (i *Image) IsManifestList(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	imgRef, err := ref.NewImageSource(ctx, i.runtime.systemContextCopy())
+	imgSrc, err := ref.NewImageSource(ctx, i.runtime.systemContextCopy())
 	if err != nil {
 		return false, err
 	}
-	_, manifestType, err := imgRef.GetManifest(ctx, nil)
+	_, manifestType, err := image.UnparsedInstance(imgSrc, nil).Manifest(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -717,7 +718,7 @@ func (m *ManifestList) AnnotateInstance(d digest.Digest, options *ManifestListAn
 			return err
 		}
 		defer src.Close()
-		subjectManifestBytes, subjectManifestType, err := src.GetManifest(ctx, nil)
+		subjectManifestBytes, subjectManifestType, err := image.UnparsedInstance(src, nil).Manifest(ctx)
 		if err != nil {
 			return err
 		}

--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -375,6 +375,7 @@ func (i *Image) IsManifestList(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	defer imgSrc.Close()
 	_, manifestType, err := image.UnparsedInstance(imgSrc, nil).Manifest(ctx)
 	if err != nil {
 		return false, err

--- a/libimage/manifest_list_test.go
+++ b/libimage/manifest_list_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/containers/common/pkg/config"
 	cp "github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/transports/alltransports"
@@ -329,7 +330,7 @@ func TestAddArtifacts(t *testing.T) {
 		src, err := ref.NewImageSource(ctx, nil)
 		require.NoError(t, err)
 		defer src.Close()
-		manifestBytes, manifestType, err := src.GetManifest(ctx, nil)
+		manifestBytes, manifestType, err := image.UnparsedInstance(src, nil).Manifest(ctx)
 		require.NoError(t, err)
 		manifestDigest, err := manifest.Digest(manifestBytes)
 		require.NoError(t, err)
@@ -390,7 +391,7 @@ func TestAddArtifacts(t *testing.T) {
 
 			src, err := ref.NewImageSource(ctx, list.image.runtime.systemContextCopy())
 			require.NoError(t, err)
-			indexManifest, indexType, err := src.GetManifest(ctx, nil)
+			indexManifest, indexType, err := image.UnparsedInstance(src, nil).Manifest(ctx)
 			require.NoError(t, err)
 			require.True(t, manifest.MIMETypeIsMultiImage(indexType))
 			var index imgspecv1.Index
@@ -401,7 +402,7 @@ func TestAddArtifacts(t *testing.T) {
 				assert.Equal(t, indexSubjectDescriptor, *index.Subject, "subject in index was not preserved")
 			}
 			for _, descriptor := range index.Manifests {
-				artifactManifest, artifactManifestType, err := src.GetManifest(ctx, &descriptor.Digest)
+				artifactManifest, artifactManifestType, err := image.UnparsedInstance(src, &descriptor.Digest).Manifest(ctx)
 				require.NoError(t, err)
 				require.False(t, manifest.MIMETypeIsMultiImage(artifactManifestType))
 				var artifact imgspecv1.Manifest

--- a/libimage/manifests/manifests_test.go
+++ b/libimage/manifests/manifests_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containers/common/pkg/manifests"
 	cp "github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/directory"
+	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/signature"
@@ -120,8 +121,8 @@ func TestAddRemove(t *testing.T) {
 	src, err := ref.NewImageSource(ctx, sys)
 	assert.NoError(t, err, "NewImageSource(%q)", otherListImage)
 	defer assert.NoError(t, src.Close(), "ImageSource.Close()")
-	m, _, err := src.GetManifest(ctx, nil)
-	assert.NoError(t, err, "ImageSource.GetManifest()")
+	m, _, err := image.UnparsedInstance(src, nil).Manifest(ctx)
+	require.NoError(t, err, "UnparsedInstance.Manifest()")
 	assert.NoError(t, src.Close(), "ImageSource.GetManifest()")
 	listDigest, err := manifest.Digest(m)
 	assert.NoError(t, err, "manifest.Digest()")
@@ -271,7 +272,7 @@ func TestAddArtifact(t *testing.T) {
 			src, err := ref.NewImageSource(ctx, &types.SystemContext{})
 			require.NoError(t, err)
 			defer src.Close()
-			manifestBytes, manifestType, err := src.GetManifest(ctx, &instanceDigest)
+			manifestBytes, manifestType, err := image.UnparsedInstance(src, &instanceDigest).Manifest(ctx)
 			require.NoError(t, err)
 			// decode the artifact manifest
 			var m v1.Manifest
@@ -361,7 +362,7 @@ func TestAddArtifact(t *testing.T) {
 				subject, err := subjectReference.NewImageSource(ctx, &types.SystemContext{})
 				require.NoError(t, err)
 				defer subject.Close()
-				subjectManifestBytes, subjectManifestType, err := subject.GetManifest(ctx, nil)
+				subjectManifestBytes, subjectManifestType, err := image.UnparsedInstance(subject, nil).Manifest(ctx)
 				require.NoError(t, err)
 				subjectManifestDigest, err := manifest.Digest(subjectManifestBytes)
 				require.NoError(t, err)

--- a/pkg/supplemented/supplemented.go
+++ b/pkg/supplemented/supplemented.go
@@ -205,7 +205,7 @@ func (s *supplementedImageReference) NewImageSource(ctx context.Context, sys *ty
 		}
 
 		// Read the default manifest for the image.
-		manifestBytes, manifestType, err := src.GetManifest(ctx, nil)
+		manifestBytes, manifestType, err := image.UnparsedInstance(src, nil).Manifest(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("reading default manifest from image %q: %w", transports.ImageName(ref), err)
 		}
@@ -261,7 +261,7 @@ func (s *supplementedImageReference) NewImageSource(ctx context.Context, sys *ty
 		}
 
 		// Read the instance's manifest.
-		manifestBytes, manifestType, err := manifestToRead.src.GetManifest(ctx, manifestToRead.instance)
+		manifestBytes, manifestType, err := image.UnparsedInstance(manifestToRead.src, manifestToRead.instance).Manifest(ctx)
 		if err != nil {
 			// if errors.Is(err, storage.ErrImageUnknown) || errors.Is(err, os.ErrNotExist) {
 			// Trust that we either don't need it, or that it's in another reference.


### PR DESCRIPTION
... to validate that the manifests match expected digests, if any.

Do this everywhere, even where we read local storage which is mostly trusted, because it is cheap enough and being consistent makes it less likely for the code to be copied into other contexts shere the sources are not trusted.