### PR TITLE
[v0.62] Bump c/image to v5.34.1, c/common to v0.62.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/platforms v0.2.1
 	github.com/containernetworking/cni v1.2.3
 	github.com/containernetworking/plugins v1.5.1
-	github.com/containers/image/v5 v5.34.0
+	github.com/containers/image/v5 v5.34.1
 	github.com/containers/ocicrypt v1.2.1
 	github.com/containers/storage v1.57.1
 	github.com/coreos/go-systemd/v22 v22.5.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/containernetworking/cni v1.2.3 h1:hhOcjNVUQTnzdRJ6alC5XF+wd9mfGIUaj8F
 github.com/containernetworking/cni v1.2.3/go.mod h1:DuLgF+aPd3DzcTQTtp/Nvl1Kim23oFKdm2okJzBQA5M=
 github.com/containernetworking/plugins v1.5.1 h1:T5ji+LPYjjgW0QM+KyrigZbLsZ8jaX+E5J/EcKOE4gQ=
 github.com/containernetworking/plugins v1.5.1/go.mod h1:MIQfgMayGuHYs0XdNudf31cLLAC+i242hNm6KuDGqCM=
-github.com/containers/image/v5 v5.34.0 h1:HPqQaDUsox/3mC1pbOyLAIQEp0JhQqiUZ+6JiFIZLDI=
-github.com/containers/image/v5 v5.34.0/go.mod h1:/WnvUSEfdqC/ahMRd4YJDBLrpYWkGl018rB77iB3FDo=
+github.com/containers/image/v5 v5.34.1 h1:/m2bkFnuedTyNkzma8s7cFLjeefPIb4trjyafWhIlwM=
+github.com/containers/image/v5 v5.34.1/go.mod h1:/WnvUSEfdqC/ahMRd4YJDBLrpYWkGl018rB77iB3FDo=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.2.1 h1:0qIOTT9DoYwcKmxSt8QJt+VzMY18onl9jUXsxpVhSmM=

--- a/vendor/github.com/containers/image/v5/signature/pki_cert.go
+++ b/vendor/github.com/containers/image/v5/signature/pki_cert.go
@@ -1,0 +1,74 @@
+package signature
+
+import (
+	"crypto"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/containers/image/v5/signature/internal"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+)
+
+type pkiTrustRoot struct {
+	caRootsCertificates        *x509.CertPool
+	caIntermediateCertificates *x509.CertPool
+	subjectEmail               string
+	subjectHostname            string
+}
+
+func (p *pkiTrustRoot) validate() error {
+	if p.subjectEmail == "" && p.subjectHostname == "" {
+		return errors.New("Internal inconsistency: PKI use set up without subject email or subject hostname")
+	}
+	return nil
+}
+
+func verifyPKI(pkiTrustRoot *pkiTrustRoot, untrustedCertificateBytes []byte, untrustedIntermediateChainBytes []byte) (crypto.PublicKey, error) {
+	var untrustedIntermediatePool *x509.CertPool
+	if pkiTrustRoot.caIntermediateCertificates != nil {
+		untrustedIntermediatePool = pkiTrustRoot.caIntermediateCertificates.Clone()
+	} else {
+		untrustedIntermediatePool = x509.NewCertPool()
+	}
+	if len(untrustedIntermediateChainBytes) > 0 {
+		untrustedIntermediateChain, err := cryptoutils.UnmarshalCertificatesFromPEM(untrustedIntermediateChainBytes)
+		if err != nil {
+			return nil, internal.NewInvalidSignatureError(fmt.Sprintf("loading certificate chain: %v", err))
+		}
+		if len(untrustedIntermediateChain) > 1 {
+			for _, untrustedIntermediateCert := range untrustedIntermediateChain[:len(untrustedIntermediateChain)-1] {
+				untrustedIntermediatePool.AddCert(untrustedIntermediateCert)
+			}
+		}
+	}
+
+	untrustedCertificate, err := parseLeafCertFromPEM(untrustedCertificateBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := untrustedCertificate.Verify(x509.VerifyOptions{
+		Intermediates: untrustedIntermediatePool,
+		Roots:         pkiTrustRoot.caRootsCertificates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+	}); err != nil {
+		return nil, internal.NewInvalidSignatureError(fmt.Sprintf("veryfing leaf certificate failed: %v", err))
+	}
+
+	if pkiTrustRoot.subjectEmail != "" {
+		if !slices.Contains(untrustedCertificate.EmailAddresses, pkiTrustRoot.subjectEmail) {
+			return nil, internal.NewInvalidSignatureError(fmt.Sprintf("Required email %q not found (got %q)",
+				pkiTrustRoot.subjectEmail,
+				untrustedCertificate.EmailAddresses))
+		}
+	}
+	if pkiTrustRoot.subjectHostname != "" {
+		if err = untrustedCertificate.VerifyHostname(pkiTrustRoot.subjectHostname); err != nil {
+			return nil, internal.NewInvalidSignatureError(fmt.Sprintf("Unexpected subject hostname: %v", err))
+		}
+	}
+
+	return untrustedCertificate.PublicKey, nil
+}

--- a/vendor/github.com/containers/image/v5/signature/policy_types.go
+++ b/vendor/github.com/containers/image/v5/signature/policy_types.go
@@ -111,16 +111,16 @@ type prSignedBaseLayer struct {
 type prSigstoreSigned struct {
 	prCommon
 
-	// KeyPath is a pathname to a local file containing the trusted key. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas and Fulcio must be specified.
+	// KeyPath is a pathname to a local file containing the trusted key. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas, Fulcio, and PKI must be specified.
 	KeyPath string `json:"keyPath,omitempty"`
-	// KeyPaths is a set of pathnames to local files containing the trusted key(s). Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas and Fulcio must be specified.
+	// KeyPaths is a set of pathnames to local files containing the trusted key(s). Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas, Fulcio, and PKI must be specified.
 	KeyPaths []string `json:"keyPaths,omitempty"`
-	// KeyData contains the trusted key, base64-encoded. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas and Fulcio must be specified.
+	// KeyData contains the trusted key, base64-encoded. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas, Fulcio, and PKI must be specified.
 	KeyData []byte `json:"keyData,omitempty"`
-	// KeyDatas is a set of trusted keys, base64-encoded. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas and Fulcio must be specified.
+	// KeyDatas is a set of trusted keys, base64-encoded. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas, Fulcio, and PKI must be specified.
 	KeyDatas [][]byte `json:"keyDatas,omitempty"`
 
-	// Fulcio specifies which Fulcio-generated certificates are accepted. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas and Fulcio must be specified.
+	// Fulcio specifies which Fulcio-generated certificates are accepted. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas, Fulcio, and PKI must be specified.
 	// If Fulcio is specified, one of RekorPublicKeyPath or RekorPublicKeyData must be specified as well.
 	Fulcio PRSigstoreSignedFulcio `json:"fulcio,omitempty"`
 
@@ -140,6 +140,9 @@ type prSigstoreSigned struct {
 	// If Fulcio is used, one of RekorPublicKeyPath, RekorPublicKeyPaths, RekorPublicKeyData and RekorPublicKeyDatas must be specified as well;
 	// otherwise it is optional (and Rekor inclusion is not required if a Rekor public key is not specified).
 	RekorPublicKeyDatas [][]byte `json:"rekorPublicKeyDatas,omitempty"`
+
+	// PKI specifies which PKI-generated certificates are accepted. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas, Fulcio, and PKI must be specified.
+	PKI PRSigstoreSignedPKI `json:"pki,omitempty"`
 
 	// SignedIdentity specifies what image identity the signature must be claiming about the image.
 	// Defaults to "matchRepoDigestOrExact" if not specified.
@@ -165,6 +168,30 @@ type prSigstoreSignedFulcio struct {
 	OIDCIssuer string `json:"oidcIssuer,omitempty"`
 	// SubjectEmail specifies the expected email address of the authenticated OIDC identity, recorded by Fulcio into the generated certificates.
 	SubjectEmail string `json:"subjectEmail,omitempty"`
+}
+
+// PRSigstoreSignedPKI contains PKI configuration options for a "sigstoreSigned" PolicyRequirement.
+type PRSigstoreSignedPKI interface {
+	// prepareTrustRoot creates a pkiTrustRoot from the input data.
+	// (This also prevents external implementations of this interface, ensuring that prSigstoreSignedPKI is the only one.)
+	prepareTrustRoot() (*pkiTrustRoot, error)
+}
+
+// prSigstoreSignedPKI contains non-fulcio certificate PKI configuration options for prSigstoreSigned
+type prSigstoreSignedPKI struct {
+	// CARootsPath a path to a file containing accepted CA root certificates, in PEM format. Exactly one of CARootsPath and CARootsData must be specified.
+	CARootsPath string `json:"caRootsPath"`
+	// CARootsData contains accepted CA root certificates in PEM format, all of that base64-encoded. Exactly one of CARootsPath and CARootsData must be specified.
+	CARootsData []byte `json:"caRootsData"`
+	// CAIntermediatesPath a path to a file containing accepted CA intermediate certificates, in PEM format. Only one of CAIntermediatesPath or CAIntermediatesData can be specified, not both.
+	CAIntermediatesPath string `json:"caIntermediatesPath"`
+	// CAIntermediatesData contains accepted CA intermediate certificates in PEM format, all of that base64-encoded. Only one of CAIntermediatesPath or CAIntermediatesData can be specified, not both.
+	CAIntermediatesData []byte `json:"caIntermediatesData"`
+
+	// SubjectEmail specifies the expected email address imposed on the subject to which the certificate was issued. At least one of SubjectEmail and SubjectHostname must be specified.
+	SubjectEmail string `json:"subjectEmail"`
+	// SubjectHostname specifies the expected hostname imposed on the subject to which the certificate was issued. At least one of SubjectEmail and SubjectHostname must be specified.
+	SubjectHostname string `json:"subjectHostname"`
 }
 
 // PolicyReferenceMatch specifies a set of image identities accepted in PolicyRequirement.

--- a/vendor/github.com/containers/image/v5/version/version.go
+++ b/vendor/github.com/containers/image/v5/version/version.go
@@ -8,7 +8,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 34
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = ""

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -98,7 +98,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.5.1
 ## explicit; go 1.20
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/image/v5 v5.34.0
+# github.com/containers/image/v5 v5.34.1
 ## explicit; go 1.22.8
 github.com/containers/image/v5/copy
 github.com/containers/image/v5/directory

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.62.0"
+const Version = "0.62.1"


### PR DESCRIPTION
Bumping c/image to v5.34.1 and c/common to v0.62.1.  This will allow us to deliver BYOPKI signature verification
for RHEL 9.6/10.0 ZeroDay.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
