### PR TITLE
pull,load: use `*Image` instead of re-resolving via `name`

### DIFF
--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -177,8 +177,8 @@ type Copier struct {
 // newCopier creates a Copier based on a runtime's system context.
 // Note that fields in options *may* overwrite the counterparts of
 // the specified system context.  Please make sure to call `(*Copier).Close()`.
-func (r *Runtime) newCopier(options *CopyOptions, reportResolvedReference *types.ImageReference) (*Copier, error) {
-	return NewCopier(options, r.SystemContext(), reportResolvedReference)
+func (r *Runtime) newCopier(options *CopyOptions) (*Copier, error) {
+	return NewCopier(options, r.SystemContext(), nil)
 }
 
 // storageAllowedPolicyScopes overrides the policy for local storage

--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -21,8 +21,10 @@ import (
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/signature/signer"
 	storageTransport "github.com/containers/image/v5/storage"
+	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	encconfig "github.com/containers/ocicrypt/config"
+	"github.com/containers/storage"
 	"github.com/sirupsen/logrus"
 )
 
@@ -350,6 +352,12 @@ func (c *Copier) Close() error {
 // Copy the source to the destination.  Returns the bytes of the copied
 // manifest which may be used for digest computation.
 func (c *Copier) Copy(ctx context.Context, source, destination types.ImageReference) ([]byte, error) {
+	return c.copyInternal(ctx, source, destination, nil)
+}
+
+// Copy the source to the destination.  Returns the bytes of the copied
+// manifest which may be used for digest computation.
+func (c *Copier) copyInternal(ctx context.Context, source, destination types.ImageReference, reportResolvedReference *types.ImageReference) ([]byte, error) {
 	logrus.Debugf("Copying source image %s to destination image %s", source.StringWithinTransport(), destination.StringWithinTransport())
 
 	// Avoid running out of time when running inside a systemd unit by
@@ -454,6 +462,11 @@ func (c *Copier) Copy(ctx context.Context, source, destination types.ImageRefere
 	var returnManifest []byte
 	f := func() error {
 		opts := c.imageCopyOptions
+		// This is already set when `newCopier` was called but there is an option
+		// to override it by callers if needed.
+		if reportResolvedReference != nil {
+			opts.ReportResolvedReference = reportResolvedReference
+		}
 		if sourceInsecure != nil {
 			value := types.NewOptionalBool(*sourceInsecure)
 			opts.SourceCtx.DockerInsecureSkipTLSVerify = value
@@ -470,6 +483,22 @@ func (c *Copier) Copy(ctx context.Context, source, destination types.ImageRefere
 		return err
 	}
 	return returnManifest, retry.IfNecessary(ctx, f, &c.retryOptions)
+}
+
+func (c *Copier) copyToStorage(ctx context.Context, source, destination types.ImageReference) (*storage.Image, error) {
+	var resolvedReference types.ImageReference
+	_, err := c.copyInternal(ctx, source, destination, &resolvedReference)
+	if err != nil {
+		return nil, fmt.Errorf("internal error: unable to copy from source %s: %w", source, err)
+	}
+	if resolvedReference == nil {
+		return nil, fmt.Errorf("internal error: After attempting to copy %s, resolvedReference is nil", source)
+	}
+	_, image, err := storageTransport.ResolveReference(resolvedReference)
+	if err != nil {
+		return nil, fmt.Errorf("resolving an already-resolved reference %q to the pulled image: %w", transports.ImageName(resolvedReference), err)
+	}
+	return image, nil
 }
 
 // checkRegistrySourcesAllows checks the $BUILD_REGISTRY_SOURCES environment

--- a/libimage/image_test.go
+++ b/libimage/image_test.go
@@ -61,15 +61,11 @@ func TestImageFunctions(t *testing.T) {
 	// Just make sure that the ID has 64 characters.
 	require.True(t, len(image.ID()) == 64, "ID should be 64 characters long")
 
-	// Make sure that the image we pulled by digest is the same one we
-	// pulled by tag.
-	require.Equal(t, origDigest.String(), image.Digest().String(), "digests of pulled images should match")
-
 	// NOTE: we're recording two digests. One for the image and one for the
 	// manifest list we chose it from.
 	digests := image.Digests()
 	require.Len(t, digests, 2)
-	require.Equal(t, origDigest.String(), digests[0].String(), "first recorded digest should be the one of the image")
+	require.Contains(t, digests, origDigest, "original digest string should be present in the digests array of new pulled image")
 
 	// containers/podman/issues/12729: make sure manifest lookup returns
 	// the correct error for both digests.

--- a/libimage/import.go
+++ b/libimage/import.go
@@ -104,7 +104,7 @@ func (r *Runtime) Import(ctx context.Context, path string, options *ImportOption
 		return "", err
 	}
 
-	c, err := r.newCopier(&options.CopyOptions, nil)
+	c, err := r.newCopier(&options.CopyOptions)
 	if err != nil {
 		return "", err
 	}

--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -794,7 +794,7 @@ func (m *ManifestList) Push(ctx context.Context, destination string, options *Ma
 	// NOTE: we're using the logic in copier to create a proper
 	// types.SystemContext. This prevents us from having an error prone
 	// code duplicate here.
-	copier, err := m.image.runtime.newCopier(&options.CopyOptions, nil)
+	copier, err := m.image.runtime.newCopier(&options.CopyOptions)
 	if err != nil {
 		return "", err
 	}

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -225,7 +225,7 @@ func nameFromAnnotations(annotations map[string]string) string {
 // copyFromDefault is the default copier for a number of transports.  Other
 // transports require some specific dancing, sometimes Yoga.
 func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference, options *CopyOptions) ([]*Image, []string, error) {
-	c, err := r.newCopier(options, nil)
+	c, err := r.newCopier(options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -384,7 +384,7 @@ func (r *Runtime) copyFromDockerArchive(ctx context.Context, ref types.ImageRefe
 
 // copyFromDockerArchiveReaderReference copies the specified readerRef from reader.
 func (r *Runtime) copyFromDockerArchiveReaderReference(ctx context.Context, reader *dockerArchiveTransport.Reader, readerRef types.ImageReference, options *CopyOptions) ([]*Image, []string, error) {
-	c, err := r.newCopier(options, nil)
+	c, err := r.newCopier(options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -591,7 +591,7 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 	if socketPath, ok := os.LookupEnv("NOTIFY_SOCKET"); ok {
 		options.extendTimeoutSocket = socketPath
 	}
-	c, err := r.newCopier(&options.CopyOptions, nil)
+	c, err := r.newCopier(&options.CopyOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -21,7 +21,6 @@ import (
 	ociTransport "github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/pkg/shortnames"
 	storageTransport "github.com/containers/image/v5/storage"
-	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
@@ -52,6 +51,10 @@ type PullOptions struct {
 // The error is storage.ErrImageUnknown iff the pull policy is set to "never"
 // and no local image has been found.  This allows for an easier integration
 // into some users of this package (e.g., Buildah).
+//
+// Pull returns a slice of the pulled images.
+//
+// WARNING: the Digest field of the returned image might not be a value relevant to the user issuing the pull.
 func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullPolicy, options *PullOptions) (_ []*Image, pullError error) {
 	logrus.Debugf("Pulling image %s (policy: %s)", name, pullPolicy)
 	if r.eventChannel != nil {
@@ -156,7 +159,7 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 		options.Variant = r.systemContext.VariantChoice
 	}
 
-	var pulledImages []string
+	var pulledImages []*Image
 
 	// Dispatch the copy operation.
 	switch ref.Transport().Name() {
@@ -166,24 +169,18 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 
 	// DOCKER ARCHIVE
 	case dockerArchiveTransport.Transport.Name():
-		pulledImages, err = r.copyFromDockerArchive(ctx, ref, &options.CopyOptions)
+		pulledImages, _, err = r.copyFromDockerArchive(ctx, ref, &options.CopyOptions)
 
 	// ALL OTHER TRANSPORTS
 	default:
-		pulledImages, err = r.copyFromDefault(ctx, ref, &options.CopyOptions)
+		pulledImages, _, err = r.copyFromDefault(ctx, ref, &options.CopyOptions)
 	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	localImages := []*Image{}
-	for _, iName := range pulledImages {
-		image, _, err := r.LookupImage(iName, nil)
-		if err != nil {
-			return nil, fmt.Errorf("locating pulled image %q name in containers storage: %w", iName, err)
-		}
-
+	for _, image := range pulledImages {
 		// Note that we can ignore the 2nd return value here. Some
 		// images may ship with "wrong" platform, but we already warn
 		// about it. Throwing an error is not (yet) the plan.
@@ -206,11 +203,9 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 			// Note that we use the input name here to preserve the transport data.
 			r.writeEvent(&Event{ID: image.ID(), Name: name, Time: time.Now(), Type: EventTypeImagePull})
 		}
-
-		localImages = append(localImages, image)
 	}
 
-	return localImages, pullError
+	return pulledImages, pullError
 }
 
 // nameFromAnnotations returns a reference string to be used as an image name,
@@ -229,10 +224,10 @@ func nameFromAnnotations(annotations map[string]string) string {
 
 // copyFromDefault is the default copier for a number of transports.  Other
 // transports require some specific dancing, sometimes Yoga.
-func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference, options *CopyOptions) ([]string, error) {
+func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference, options *CopyOptions) ([]*Image, []string, error) {
 	c, err := r.newCopier(options, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer c.Close()
 
@@ -243,7 +238,7 @@ func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference,
 		// Normalize to docker.io if needed (see containers/podman/issues/10998).
 		named, err := reference.ParseNormalizedNamed(strings.TrimLeft(ref.StringWithinTransport(), ":/"))
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		imageName = named.String()
 		storageName = imageName
@@ -252,7 +247,7 @@ func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference,
 		// Normalize to docker.io if needed (see containers/podman/issues/10998).
 		named, err := reference.ParseNormalizedNamed(ref.StringWithinTransport())
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		imageName = named.String()
 		storageName = imageName
@@ -264,7 +259,7 @@ func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference,
 			// the path to a directory as the name.
 			storageName, err = getImageID(ctx, ref, nil)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			imageName = "sha256:" + storageName[1:]
 		} else { // If the OCI-reference includes an image reference, use it
@@ -275,7 +270,7 @@ func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference,
 	case ociArchiveTransport.Transport.Name():
 		manifestDescriptor, err := ociArchiveTransport.LoadManifestDescriptorWithContext(r.SystemContext(), ref)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		storageName = nameFromAnnotations(manifestDescriptor.Annotations)
 		switch len(storageName) {
@@ -283,13 +278,13 @@ func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference,
 			// If there's no reference name in the annotations, compute an ID.
 			storageName, err = getImageID(ctx, ref, nil)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			imageName = "sha256:" + storageName[1:]
 		default:
 			named, err := NormalizeName(storageName)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			imageName = named.String()
 			storageName = imageName
@@ -299,7 +294,7 @@ func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference,
 		storageName = ref.StringWithinTransport()
 		named := ref.DockerReference()
 		if named == nil {
-			return nil, fmt.Errorf("could not get an image name for storage reference %q", ref)
+			return nil, nil, fmt.Errorf("could not get an image name for storage reference %q", ref)
 		}
 		imageName = named.String()
 
@@ -309,7 +304,7 @@ func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference,
 		// instead of looking at the StringWithinTransport().
 		storageName, err = getImageID(ctx, ref, nil)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		imageName = "sha256:" + storageName[1:]
 	}
@@ -317,11 +312,14 @@ func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference,
 	// Create a storage reference.
 	destRef, err := storageTransport.Transport.ParseStoreReference(r.store, storageName)
 	if err != nil {
-		return nil, fmt.Errorf("parsing %q: %w", storageName, err)
+		return nil, nil, fmt.Errorf("parsing %q: %w", storageName, err)
 	}
-
-	_, err = c.Copy(ctx, ref, destRef)
-	return []string{imageName}, err
+	image, err := c.copyToStorage(ctx, ref, destRef)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to perform copy: %w", err)
+	}
+	resolvedImage := r.storageToImage(image, nil)
+	return []*Image{resolvedImage}, []string{imageName}, err
 }
 
 // storageReferencesFromArchiveReader returns a slice of image references inside the
@@ -368,12 +366,12 @@ func (r *Runtime) storageReferencesReferencesFromArchiveReader(ctx context.Conte
 }
 
 // copyFromDockerArchive copies one image from the specified reference.
-func (r *Runtime) copyFromDockerArchive(ctx context.Context, ref types.ImageReference, options *CopyOptions) ([]string, error) {
+func (r *Runtime) copyFromDockerArchive(ctx context.Context, ref types.ImageReference, options *CopyOptions) ([]*Image, []string, error) {
 	// There may be more than one image inside the docker archive, so we
 	// need a quick glimpse inside.
 	reader, readerRef, err := dockerArchiveTransport.NewReaderForReference(&r.systemContext, ref)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer func() {
 		if err := reader.Close(); err != nil {
@@ -385,35 +383,38 @@ func (r *Runtime) copyFromDockerArchive(ctx context.Context, ref types.ImageRefe
 }
 
 // copyFromDockerArchiveReaderReference copies the specified readerRef from reader.
-func (r *Runtime) copyFromDockerArchiveReaderReference(ctx context.Context, reader *dockerArchiveTransport.Reader, readerRef types.ImageReference, options *CopyOptions) ([]string, error) {
+func (r *Runtime) copyFromDockerArchiveReaderReference(ctx context.Context, reader *dockerArchiveTransport.Reader, readerRef types.ImageReference, options *CopyOptions) ([]*Image, []string, error) {
 	c, err := r.newCopier(options, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer c.Close()
 
 	// Get a slice of storage references we can copy.
 	references, destNames, err := r.storageReferencesReferencesFromArchiveReader(ctx, readerRef, reader)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
+	images := []*Image{}
 	// Now copy all of the images.  Use readerRef for performance.
 	for _, destRef := range references {
-		if _, err := c.Copy(ctx, readerRef, destRef); err != nil {
-			return nil, err
+		image, err := c.copyToStorage(ctx, readerRef, destRef)
+		if err != nil {
+			return nil, nil, err
 		}
+		resolvedImage := r.storageToImage(image, nil)
+		images = append(images, resolvedImage)
 	}
 
-	return destNames, nil
+	return images, destNames, nil
 }
 
 // copyFromRegistry pulls the specified, possibly unqualified, name from a
-// registry.  On successful pull it returns the ID of the image in local
-// storage.
+// registry.  On successful pull it returns slice of the pulled images.
 //
 // If options.All is set, all tags from the specified registry will be pulled.
-func (r *Runtime) copyFromRegistry(ctx context.Context, ref types.ImageReference, inputName string, pullPolicy config.PullPolicy, options *PullOptions) ([]string, error) {
+func (r *Runtime) copyFromRegistry(ctx context.Context, ref types.ImageReference, inputName string, pullPolicy config.PullPolicy, options *PullOptions) ([]*Image, error) {
 	// Sanity check.
 	if err := pullPolicy.Validate(); err != nil {
 		return nil, err
@@ -424,7 +425,7 @@ func (r *Runtime) copyFromRegistry(ctx context.Context, ref types.ImageReference
 		if err != nil {
 			return nil, err
 		}
-		return []string{pulled}, nil
+		return []*Image{pulled}, nil
 	}
 
 	// Copy all tags
@@ -434,7 +435,7 @@ func (r *Runtime) copyFromRegistry(ctx context.Context, ref types.ImageReference
 		return nil, err
 	}
 
-	pulledIDs := []string{}
+	pulledImages := []*Image{}
 	for _, tag := range tags {
 		select { // Let's be gentle with Podman remote.
 		case <-ctx.Done():
@@ -450,19 +451,18 @@ func (r *Runtime) copyFromRegistry(ctx context.Context, ref types.ImageReference
 		if err != nil {
 			return nil, err
 		}
-		pulledIDs = append(pulledIDs, pulled)
+		pulledImages = append(pulledImages, pulled)
 	}
 
-	return pulledIDs, nil
+	return pulledImages, nil
 }
 
 // copySingleImageFromRegistry pulls the specified, possibly unqualified, name
-// from a registry.  On successful pull it returns the ID of the image in local
-// storage (or, FIXME, a name/ID? that could be resolved in local storage)
-func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName string, pullPolicy config.PullPolicy, options *PullOptions) (string, error) { //nolint:gocyclo
+// from a registry.  On successful pull it returns the Image from the local storage.
+func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName string, pullPolicy config.PullPolicy, options *PullOptions) (*Image, error) { //nolint:gocyclo
 	// Sanity check.
 	if err := pullPolicy.Validate(); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	var (
@@ -487,14 +487,7 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 	if options.OS != runtime.GOOS {
 		lookupImageOptions.OS = options.OS
 	}
-	// FIXME: We sometimes return resolvedImageName from this function.
-	// The function documentation says this returns an image ID, resolvedImageName is frequently not an image ID.
-	//
-	// Ultimately Runtime.Pull looks up the returned name... again, possibly finding some other match
-	// than we did.
-	//
-	// This should be restructured so that the image we found here is returned to the caller of Pull
-	// directly, without another image -> name -> image round-trip and possible inconsistency.
+
 	localImage, resolvedImageName, err = r.LookupImage(imageName, lookupImageOptions)
 	if err != nil && !errors.Is(err, storage.ErrImageUnknown) {
 		logrus.Errorf("Looking up %s in local storage: %v", imageName, err)
@@ -525,23 +518,23 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 	if pullPolicy == config.PullPolicyNever {
 		if localImage != nil {
 			logrus.Debugf("Pull policy %q and %s resolved to local image %s", pullPolicy, imageName, resolvedImageName)
-			return resolvedImageName, nil
+			return localImage, nil
 		}
 		logrus.Debugf("Pull policy %q but no local image has been found for %s", pullPolicy, imageName)
-		return "", fmt.Errorf("%s: %w", imageName, storage.ErrImageUnknown)
+		return nil, fmt.Errorf("%s: %w", imageName, storage.ErrImageUnknown)
 	}
 
 	if pullPolicy == config.PullPolicyMissing && localImage != nil {
-		return resolvedImageName, nil
+		return localImage, nil
 	}
 
 	// If we looked up the image by ID, we cannot really pull from anywhere.
 	if localImage != nil && strings.HasPrefix(localImage.ID(), imageName) {
 		switch pullPolicy {
 		case config.PullPolicyAlways:
-			return "", fmt.Errorf("pull policy is always but image has been referred to by ID (%s)", imageName)
+			return nil, fmt.Errorf("pull policy is always but image has been referred to by ID (%s)", imageName)
 		default:
-			return resolvedImageName, nil
+			return localImage, nil
 		}
 	}
 
@@ -566,9 +559,9 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 	resolved, err := shortnames.Resolve(sys, imageName)
 	if err != nil {
 		if localImage != nil && pullPolicy == config.PullPolicyNewer {
-			return resolvedImageName, nil
+			return localImage, nil
 		}
-		return "", err
+		return nil, err
 	}
 
 	// NOTE: Below we print the description from the short-name resolution.
@@ -598,10 +591,9 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 	if socketPath, ok := os.LookupEnv("NOTIFY_SOCKET"); ok {
 		options.extendTimeoutSocket = socketPath
 	}
-	var resolvedReference types.ImageReference
-	c, err := r.newCopier(&options.CopyOptions, &resolvedReference)
+	c, err := r.newCopier(&options.CopyOptions, nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer c.Close()
 
@@ -611,7 +603,7 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 		logrus.Debugf("Attempting to pull candidate %s for %s", candidateString, imageName)
 		srcRef, err := registryTransport.NewReference(candidate.Value)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
 		if pullPolicy == config.PullPolicyNewer && localImage != nil {
@@ -629,18 +621,19 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 
 		destRef, err := storageTransport.Transport.ParseStoreReference(r.store, candidate.Value.String())
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
 		if err := writeDesc(); err != nil {
-			return "", err
+			return nil, err
 		}
 		if options.Writer != nil {
 			if _, err := io.WriteString(options.Writer, fmt.Sprintf("Trying to pull %s...\n", candidateString)); err != nil {
-				return "", err
+				return nil, err
 			}
 		}
-		if _, err := c.Copy(ctx, srcRef, destRef); err != nil {
+		image, err := c.copyToStorage(ctx, srcRef, destRef)
+		if err != nil {
 			logrus.Debugf("Error pulling candidate %s: %v", candidateString, err)
 			pullErrors = append(pullErrors, err)
 			continue
@@ -651,25 +644,18 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 			// read-only which can cause issues.
 			logrus.Errorf("Error recording short-name alias %q: %v", candidateString, err)
 		}
-
 		logrus.Debugf("Pulled candidate %s successfully", candidateString)
-		if resolvedReference == nil { // resolvedReference should always be set for storageTransport destinations
-			return "", fmt.Errorf("internal error: After pulling %s, resolvedReference is nil", candidateString)
-		}
-		_, image, err := storageTransport.ResolveReference(resolvedReference)
-		if err != nil {
-			return "", fmt.Errorf("resolving an already-resolved reference %q to the pulled image: %w", transports.ImageName(resolvedReference), err)
-		}
-		return image.ID, nil
+		resolvedImage := r.storageToImage(image, nil)
+		return resolvedImage, err
 	}
 
 	if localImage != nil && pullPolicy == config.PullPolicyNewer {
-		return resolvedImageName, nil
+		return localImage, nil
 	}
 
 	if len(pullErrors) == 0 {
-		return "", fmt.Errorf("internal error: no image pulled (pull policy %s)", pullPolicy)
+		return nil, fmt.Errorf("internal error: no image pulled (pull policy %s)", pullPolicy)
 	}
 
-	return "", resolved.FormatPullErrors(pullErrors)
+	return nil, resolved.FormatPullErrors(pullErrors)
 }

--- a/libimage/push.go
+++ b/libimage/push.go
@@ -118,7 +118,7 @@ func (r *Runtime) Push(ctx context.Context, source, destination string, options 
 		}
 	}
 
-	c, err := r.newCopier(&options.CopyOptions, nil)
+	c, err := r.newCopier(&options.CopyOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/libimage/save.go
+++ b/libimage/save.go
@@ -119,7 +119,7 @@ func (r *Runtime) saveSingleImage(ctx context.Context, name, format, path string
 		return err
 	}
 
-	c, err := r.newCopier(&options.CopyOptions, nil)
+	c, err := r.newCopier(&options.CopyOptions)
 	if err != nil {
 		return err
 	}
@@ -204,7 +204,7 @@ func (r *Runtime) saveDockerArchive(ctx context.Context, names []string, path st
 		copyOpts := options.CopyOptions
 		copyOpts.dockerArchiveAdditionalTags = local.tags
 
-		c, err := r.newCopier(&copyOpts, nil)
+		c, err := r.newCopier(&copyOpts)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Following commit fixes a `race` condition in `libimage` because in `Pull(` after performing `copy` from remote sources it agains attempts to resolve image via `LookupImage`, any operation between `copy` and `LookupImage` can remove `name` from the recently pulled image. Causing race in builds.

Removing unnecessary `image -> name -> image` round-trip from `Pull(`

This issue was discoverd while working on PR https://github.com/containers/buildah/pull/5971
```
buildah build -t test --jobs=2 --skip-unused-stages=false .
```

Containerfile
```
FROM quay.io/jitesoft/alpine
RUN arch
FROM --platform=linux/arm64 quay.io/jitesoft/alpine AS foreign
```

Following commit also addresses the commit https://github.com/containers/common/pull/2202/commits/e2324ddbb2a729945bbf4e7127066be008fe5056 by performing the neccessary refactor.

No functional change in public exposed API, exisiting tests should pass as-is. [NO NEW TESTS NEEDED]

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
