### PR TITLE
Makefile,.golangci.yml: rm exclude_graphdriver_devicemapper

### DIFF
--- a/.golangci-extra.yml
+++ b/.golangci-extra.yml
@@ -13,7 +13,6 @@ run:
     - selinux
     - systemd
     - exclude_graphdriver_btrfs
-    - exclude_graphdriver_devicemapper
     - containers_image_openpgp
   concurrency: 6
   deadline: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,6 @@ run:
     - selinux
     - systemd
     - exclude_graphdriver_btrfs
-    - exclude_graphdriver_devicemapper
     - containers_image_openpgp
     - cni
   timeout: 5m

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export GOPROXY=https://proxy.golang.org
 
 GO ?= go
 GO_BUILD=$(GO) build
-BUILDTAGS := containers_image_openpgp,systemd,exclude_graphdriver_devicemapper
+BUILDTAGS := containers_image_openpgp,systemd
 DESTDIR ?=
 PREFIX := /usr/local
 CONFIGDIR := ${PREFIX}/share/containers


### PR DESCRIPTION
It is not needed since commit c347a01f ("Bump c/image to v5.31.0, c/storage v1.54.0", PR #2011), which removes device mapper support.