### PR TITLE
ci: fixups to golangci lint configuration

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,6 @@ env:
     GOPATH: &gopath "/var/tmp/go"
     GOBIN: "${GOPATH}/bin"
     GOCACHE: "${GOPATH}/cache"
-    GOLANGCI_LINT_CACHE: "$GOCACHE"
     GOSRC: &gosrc "${GOPATH}/src/github.com/containers/common"
     CIRRUS_WORKING_DIR: *gosrc
     # The default is 'sh' if unspecified
@@ -47,7 +46,6 @@ testing_task:
   env:
     NETAVARK_BINARY: "/usr/libexec/podman/netavark"
   test_script:
-    - mkdir "$GOLANGCI_LINT_CACHE"
     - export PATH="$PATH:$GOPATH/bin"
     - gpg --batch --passphrase '' --quick-gen-key tester@localhost default default never
     - make vendor

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,6 @@ linters:
     - exhaustive
     - gochecknoglobals
     - err113
-    - gomnd
     - nolintlint
     - wrapcheck
     - varnamelen
@@ -47,7 +46,6 @@ linters:
     - maintidx
     - ireturn
     - exhaustruct
-    - execinquery
     - gosec
     - godot
     - gocyclo

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ docs:
 	$(MAKE) -C docs
 
 .PHONY: validate
-validate: build/golangci-lint
-	./build/golangci-lint run
+validate:
+	golangci-lint run
 	./tools/validate_seccomp.sh ./pkg/seccomp
 
 vendor-in-container:
@@ -85,12 +85,9 @@ vendor:
 	$(GO) mod verify
 
 .PHONY: install.tools
-install.tools: build/golangci-lint .install.md2man
+install.tools: .install.md2man
 
-build/golangci-lint: VERSION=v1.60.3
-build/golangci-lint:
-	curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/$(VERSION)/install.sh | sh -s -- -b ./build $(VERSION)
-
+.PHONY: .install.md2man
 .install.md2man:
 	$(GO) install github.com/cpuguy83/go-md2man/v2@latest
 


### PR DESCRIPTION
### 1. Makefile: rm golangci-lint installation
    
Currently, "make validate" is not used from any CI workflows, meaning
it is there for local developer consumption only. For that case, we
can safely assume that a developer can maintain a recent golangci-lint
installation.
    
This also fixes the problem of golangci-lint version discrepancy between
Makefile and .github/workflows/validate.yml, introduced by commit 9378a51a1
("renovate: teach it to update the lint version").
    
### 2. ci: rm deprecated linters from .golangci.yml
    
This fixes the following warnings from golangci-lint v1.64.6:
    
            WARN [lintersdb] The linter "gomnd" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle
            WARN [lintersdb] The linter "execinquery" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle

(observed since at least https://github.com/containers/common/pull/2323)

### 3. .cirrus.yml: rm GOLANGCILINT_CACHE
    
It is not used since commit 08e77b27 ("cirrus-ci: rm make validate").
    
