### PR TITLE
Fix getLibpodTmpDir() on Windows

### DIFF
--- a/pkg/config/default_windows.go
+++ b/pkg/config/default_windows.go
@@ -38,7 +38,7 @@ func getDefaultLockType() string {
 }
 
 func getLibpodTmpDir() string {
-	return "/run/libpod"
+	return filepath.Join(getDefaultTmpDir(), "libpod")
 }
 
 // getDefaultMachineVolumes returns default mounted volumes (possibly with env vars, which will be expanded)


### PR DESCRIPTION
Changes the function to return an absolute path. Without this, EngineConfig.Validate() will return an error on Windows when using the default values.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
