### PR TITLE
fix(libnetwork): interface name length validation

### DIFF
--- a/libnetwork/internal/util/create.go
+++ b/libnetwork/internal/util/create.go
@@ -39,6 +39,13 @@ func CommonNetworkCreate(n NetUtil, network *types.Network) error {
 			network.NetworkInterface = name
 		}
 	}
+
+	// Validate interface name if specified
+	if network.NetworkInterface != "" {
+		if err := ValidateInterfaceName(network.NetworkInterface); err != nil {
+			return fmt.Errorf("network interface name %s invalid: %w", network.NetworkInterface, err)
+		}
+	}
 	return nil
 }
 

--- a/libnetwork/types/define.go
+++ b/libnetwork/types/define.go
@@ -30,4 +30,7 @@ var (
 	// NotHexRegex is a regular expression to check if a string is
 	// a hexadecimal string.
 	NotHexRegex = regexp.Delayed(`[^0-9a-fA-F]`)
+
+	// MaxInterfaceNameLength is the maximum length of a network interface name
+	MaxInterfaceNameLength = 15
 )


### PR DESCRIPTION
## Description
The Linux kernel imposes a 15-character limit on network interface names. Currently,
Podman allows creating networks with interface names longer than this limit, which
leads to runtime failures when attempting to use these networks.

### How to reproduce error
#### For example:
```bash
# Creation succeeds but network is unusable
podman network create my_net --interface-name abcdefghij123456

# Container fails to start with netlink error
podman run -it --network my_net alpine
Error: preparing container: netavark (exit code 1): get bridge interface: 
Netlink error: Numerical result out of range (os error 34)
```

### Fix
This change adds validation during network creation by adopting the same approach
used in the [CNI project](https://github.com/containernetworking/cni/blob/main/pkg/utils/utils.go#L32), which already handles this kernel limitation.