### PR TITLE
config: mask thermal interrupt info paths

### DIFF
--- a/pkg/config/default_linux_test.go
+++ b/pkg/config/default_linux_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultMaskedPaths(t *testing.T) {
+	maskedPaths, err := getMaskedPaths()
+	assert.NoError(t, err)
+
+	root := "/sys/devices/system/cpu"
+
+	entries, err := os.ReadDir(root)
+	assert.NoError(t, err)
+
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), "cpu") {
+			continue
+		}
+		path := filepath.Join(root, entry.Name(), "thermal_throttle")
+		if _, err := os.Stat(path); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			assert.NoError(t, err)
+		}
+		assert.Contains(t, maskedPaths, path)
+	}
+}


### PR DESCRIPTION
On Linux, mask "/proc/interrupts" and
"/sys/devices/system/cpu/*/thermal_throttle" inside containers by default.

It is the equivalent of https://github.com/moby/moby/pull/49560 for Moby.

Mitigates potential Thermal Side-Channel Vulnerability Exploit (https://github.com/moby/moby/security/advisories/GHSA-6fw5-f8r9-fgfm).

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
