### PR TITLE
ci: fix running extra linters

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,11 +42,10 @@ jobs:
         version: "${{ env.LINT_VERSION }}"
         args: --verbose
     # Extra linters, only checking new code from a pull request.
-    - name: Extra golangci-lint config. switcharoo
-      run: mv .golangci-extra.yml golangci.yml
     - name: lint-extra
       uses: golangci/golangci-lint-action@v6
       with:
+        args: --config=.golangci-extra.yml
         version: "${{ env.LINT_VERSION }}"
         only-new-issues: true
 

--- a/.golangci-extra.yml
+++ b/.golangci-extra.yml
@@ -14,8 +14,7 @@ run:
     - systemd
     - exclude_graphdriver_btrfs
     - containers_image_openpgp
-  concurrency: 6
-  deadline: 5m
+  timeout: 5m
 
 linters:
   disable-all: true


### PR DESCRIPTION
Commit 84128ce8 ("CI: enable extra linters for new code", PR #1040) introduced the feature of running some extra linters for any newly added code (see the commit description for motivation).

Alas, commit 13bf5e99 ("use runc cgroup creation logic", PR #936) broke the feature, because it contains:

	mv .golangci-extra.yml golangci.yml

(Note the missing dot in the destination file name.)

As a result, golangci-lint was running twice with the same config.

Let's fix it by using args: action parameter.
    
Also, some time later, a new golangci-lint removed support for deadline
option, and commit fbedd992 ("update golangci.yml", PR #2152) fixed it
for the main config. Let's do the same for the extra config.
