### PR TITLE
libimage: fix one copyToStorage error message

### DIFF
--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -489,7 +489,7 @@ func (c *Copier) copyToStorage(ctx context.Context, source, destination types.Im
 	var resolvedReference types.ImageReference
 	_, err := c.copyInternal(ctx, source, destination, &resolvedReference)
 	if err != nil {
-		return nil, fmt.Errorf("internal error: unable to copy from source %s: %w", source, err)
+		return nil, fmt.Errorf("internal error: unable to copy from source %s: %w", transports.ImageName(source), err)
 	}
 	if resolvedReference == nil {
 		return nil, fmt.Errorf("internal error: After attempting to copy %s, resolvedReference is nil", source)


### PR DESCRIPTION
ImageReference is an interface and we generally have no idea about the underlying layout here and if that can be printed as string. In case of the docker transport we get:
`{{{docker.io library/busybox} latest} %!s(bool=false)}`

That is clearly wrong and confusing, instead use transports.ImageName() which is the recommended way to refer to images in the UI.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
