### PR TITLE
libimage: fix manifest race during listing

### DIFF
--- a/libimage/history.go
+++ b/libimage/history.go
@@ -25,7 +25,7 @@ func (i *Image) History(ctx context.Context) ([]ImageHistory, error) {
 		return nil, err
 	}
 
-	layerTree, err := i.runtime.newFreshLayerTree(ctx)
+	layerTree, err := i.runtime.newFreshLayerTree()
 	if err != nil {
 		return nil, err
 	}

--- a/libimage/image.go
+++ b/libimage/image.go
@@ -197,7 +197,7 @@ func (i *Image) IsDangling(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	tree, err := i.runtime.newLayerTreeFromData(ctx, images, layers, true)
+	tree, err := i.runtime.newLayerTreeFromData(images, layers, true)
 	if err != nil {
 		return false, err
 	}
@@ -267,7 +267,7 @@ func (i *Image) TopLayer() string {
 
 // Parent returns the parent image or nil if there is none
 func (i *Image) Parent(ctx context.Context) (*Image, error) {
-	tree, err := i.runtime.newFreshLayerTree(ctx)
+	tree, err := i.runtime.newFreshLayerTree()
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +301,7 @@ func (i *Image) Children(ctx context.Context) ([]*Image, error) {
 // created for this invocation only.
 func (i *Image) getChildren(ctx context.Context, all bool, tree *layerTree) ([]*Image, error) {
 	if tree == nil {
-		t, err := i.runtime.newFreshLayerTree(ctx)
+		t, err := i.runtime.newFreshLayerTree()
 		if err != nil {
 			return nil, err
 		}

--- a/libimage/image_tree.go
+++ b/libimage/image_tree.go
@@ -38,7 +38,7 @@ func (i *Image) Tree(ctx context.Context, traverseChildren bool) (string, error)
 		fmt.Fprintf(sb, "No Image Layers")
 	}
 
-	layerTree, err := i.runtime.newFreshLayerTree(ctx)
+	layerTree, err := i.runtime.newFreshLayerTree()
 	if err != nil {
 		return "", err
 	}

--- a/libimage/manifests/manifests.go
+++ b/libimage/manifests/manifests.go
@@ -149,7 +149,7 @@ func LoadFromImage(store storage.Store, image string) (string, List, error) {
 	}
 	manifestList, err := manifests.FromBlob(manifestBytes)
 	if err != nil {
-		return "", nil, err
+		return "", nil, fmt.Errorf("decoding manifest blob for image %q: %w", image, err)
 	}
 	list := &list{
 		List:      manifestList,

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -634,7 +634,7 @@ func (r *Runtime) ListImages(ctx context.Context, options *ListImagesOptions) ([
 
 	var tree *layerTree
 	if needsLayerTree {
-		tree, err = r.newLayerTreeFromData(ctx, images, snapshot.Layers, true)
+		tree, err = r.newLayerTreeFromData(images, snapshot.Layers, true)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
I saw a flake in parallel podman testing, podman images can fail if the manifest was removed at the right time. In general listing should never be able to fail when another image or manifest is removed in parallel.

Change the logic to convert to manifest and only collect the digests in the success case and ignore all other errors to make the listing more robust.

I observed the following error from podman images: Error: locating image "xxx" for loading instance list: locating image with ID "xxx": image not known

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
