### PR TITLE
libimage: remove unnecessary reportResolvedReference from `NewCopier`

### DIFF
--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -178,7 +178,7 @@ type Copier struct {
 // Note that fields in options *may* overwrite the counterparts of
 // the specified system context.  Please make sure to call `(*Copier).Close()`.
 func (r *Runtime) newCopier(options *CopyOptions) (*Copier, error) {
-	return NewCopier(options, r.SystemContext(), nil)
+	return NewCopier(options, r.SystemContext())
 }
 
 // storageAllowedPolicyScopes overrides the policy for local storage
@@ -225,7 +225,7 @@ func getDockerAuthConfig(name, passwd, creds, idToken string) (*types.DockerAuth
 // NewCopier creates a Copier based on a provided system context.
 // Note that fields in options *may* overwrite the counterparts of
 // the specified system context.  Please make sure to call `(*Copier).Close()`.
-func NewCopier(options *CopyOptions, sc *types.SystemContext, reportResolvedReference *types.ImageReference) (*Copier, error) {
+func NewCopier(options *CopyOptions, sc *types.SystemContext) (*Copier, error) {
 	c := Copier{extendTimeoutSocket: options.extendTimeoutSocket}
 	sysContextCopy := *sc
 	c.systemContext = &sysContextCopy
@@ -332,7 +332,6 @@ func NewCopier(options *CopyOptions, sc *types.SystemContext, reportResolvedRefe
 	c.imageCopyOptions.SignBySigstorePrivateKeyFile = options.SignBySigstorePrivateKeyFile
 	c.imageCopyOptions.SignSigstorePrivateKeyPassphrase = options.SignSigstorePrivateKeyPassphrase
 	c.imageCopyOptions.ReportWriter = options.Writer
-	c.imageCopyOptions.ReportResolvedReference = reportResolvedReference
 
 	defaultContainerConfig, err := config.Default()
 	if err != nil {


### PR DESCRIPTION
After https://github.com/containers/common/pull/2339 there is no need for this argument so remove this.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

Closes: https://github.com/containers/common/issues/2392