### PR TITLE
AppArmor: report true if apparmor parser is found on the host

### DIFF
--- a/pkg/apparmor/apparmor_linux.go
+++ b/pkg/apparmor/apparmor_linux.go
@@ -32,6 +32,17 @@ func IsEnabled() bool {
 	return supported.NewAppArmorVerifier().IsSupported() == nil
 }
 
+// IsAppArmorAvailable returns true if the `apparmor_parser` binary is found on the host,
+// which is required to apply profiles. This function was added in parallel to IsEnabled
+// to avoid breaking existing users of IsEnabled. Prefer using IsAppArmorAvailable for
+// new implementations.
+func IsAppArmorAvailable() bool {
+	if _, err := supported.NewAppArmorVerifier().FindAppArmorParserBinary(); err != nil {
+		return false
+	}
+	return true
+}
+
 // profileData holds information about the given profile for generation.
 type profileData struct {
 	// Name is profile name.


### PR DESCRIPTION
When printing the CRI-O version, there is `AppArmorEnabled` that indicates whether AppArmor is enabled or not. However, in case of running it as non-root it reports AppArmor as not enabled even though it is actually enabled on the host. For example, `apparmor_status`  binary confirms that the default CRI-O profile is loaded. 

```
crio version
INFO[2025-03-31T13:00:26.638381533Z] Updating config from single file: /etc/crio/crio.conf
INFO[2025-03-31T13:00:26.638417334Z] Updating config from drop-in file: /etc/crio/crio.conf
INFO[2025-03-31T13:00:26.638433367Z] Skipping not-existing config file "/etc/crio/crio.conf"
INFO[2025-03-31T13:00:26.638455635Z] Updating config from path: /etc/crio/crio.conf.d
INFO[2025-03-31T13:00:26.638506983Z] Updating config from drop-in file: /etc/crio/crio.conf.d/10-crio.conf
Version:        1.32.2
GitCommit:      318db72eb0b3d18c22c995aa7614a13142287296
GitCommitDate:  2025-03-02T18:05:31Z
GitTreeState:   dirty
BuildDate:      1970-01-01T00:00:00Z
GoVersion:      go1.23.3
Compiler:       gc
Platform:       linux/amd64
Linkmode:       static
BuildTags:
  static
  netgo
  osusergo
  exclude_graphdriver_btrfs
  seccomp
  apparmor
  selinux
  exclude_graphdriver_devicemapper
LDFlags:          unknown
SeccompEnabled:   true
AppArmorEnabled:  false
```
```
sudo apparmor_status | grep crio
   crio-default
```

Currently, CRI-O uses the `IsSupported()` method to determine whether AppArmor is enabled. However, `IsSupported() `checks more than just the existence of the AppArmor parser - it also considers whether the environment is rootless and whether runc is enabled. This leads to incorrect reporting in scenarios where AppArmor is enabled on the host but the environment is rootless, causing AppArmor to be shown as disabled.

This patch replaces the use of `IsSupported()` with a check using `FindAppArmorParserBinary()`, which only verifies the existence of the AppArmor parser binary. This provides a more accurate indication of weather  AppArmor is enabled from CRI-O's perspective.

This patch adds `IsAppArmorAvailable()` parallel to `IsSupported()` (to avoid breaking existing users of `IsSupported()`), which only verifies the existence of the AppArmor parser binary.

