### PR TITLE
seccomp: allow fanotify_init without CAP_SYS_ADMIN

### DIFF
--- a/pkg/seccomp/default_linux.go
+++ b/pkg/seccomp/default_linux.go
@@ -145,6 +145,7 @@ func DefaultProfile() *Seccomp {
 				"fadvise64",
 				"fadvise64_64",
 				"fallocate",
+				"fanotify_init",
 				"fanotify_mark",
 				"fchdir",
 				"fchmod",
@@ -614,7 +615,6 @@ func DefaultProfile() *Seccomp {
 		{
 			Names: []string{
 				"bpf",
-				"fanotify_init",
 				"lookup_dcookie",
 				"quotactl",
 				"quotactl_fd",
@@ -630,7 +630,6 @@ func DefaultProfile() *Seccomp {
 		},
 		{
 			Names: []string{
-				"fanotify_init",
 				"lookup_dcookie",
 				"perf_event_open",
 				"quotactl",

--- a/pkg/seccomp/seccomp.json
+++ b/pkg/seccomp/seccomp.json
@@ -152,6 +152,7 @@
 				"fadvise64",
 				"fadvise64_64",
 				"fallocate",
+				"fanotify_init",
 				"fanotify_mark",
 				"fchdir",
 				"fchmod",
@@ -691,7 +692,6 @@
 		{
 			"names": [
 				"bpf",
-				"fanotify_init",
 				"lookup_dcookie",
 				"quotactl",
 				"quotactl_fd",
@@ -711,7 +711,6 @@
 		},
 		{
 			"names": [
-				"fanotify_init",
 				"lookup_dcookie",
 				"perf_event_open",
 				"quotactl",


### PR DESCRIPTION
Closes: https://github.com/containers/common/issues/2411

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
