### PR TITLE
pkg/cgroups: do not log ENOENT for Stat()

### DIFF
--- a/pkg/cgroups/cgroups_linux.go
+++ b/pkg/cgroups/cgroups_linux.go
@@ -533,7 +533,6 @@ func (c *CgroupControl) Stat() (*cgroups.Stats, error) {
 			if !errors.Is(err, os.ErrNotExist) {
 				return nil, err
 			}
-			logrus.Warningf("Failed to retrieve cgroup stats: %v", err)
 			continue
 		}
 		found = true


### PR DESCRIPTION
This is flaking in podman for a while[1], likely ever since we enabled parallel tests. The cgroups may be removed while we try to gather stats, that is normal and expected and should not lead to warnings.

If no cgroup is found we still return ErrStatCgroup so a caller can then match this. There was attempt to fix this in podman[2] but we missed that the warning is printed here.

Example output from the test:
$ podman stats -a --no-stream --no-reset
time="2025-04-10T06:24:16-05:00" level=warning msg="Failed to retrieve cgroup stats: open /sys/fs/cgroup/user.slice/user-6259.slice/user@6259.service/user.slice/user-libpod_pod_6c6a40019844d59a70070655263388f2e81a04e2764a1cc138b37d8202e1fefe.slice/libpod-655275f1c204008257f81ebe2503557ffadaa210f988b2d15c1cc818160af72a.scope/memory.stat: no such file or directory" time="2025-04-10T06:24:16-05:00" level=warning msg="Failed to retrieve cgroup stats: open /sys/fs/cgroup/user.slice/user-6259.slice/user@6259.service/user.slice/user-libpod_pod_6c6a40019844d59a70070655263388f2e81a04e2764a1cc138b37d8202e1fefe.slice/libpod-655275f1c204008257f81ebe2503557ffadaa210f988b2d15c1cc818160af72a.scope/pids.current: no such file or directory"
ID            NAME                  CPU %       MEM USAGE / LIMIT  MEM %       NET IO       BLOCK IO    PIDS        CPU TIME    AVG CPU %
812b76331dbb  a8bc9aac52b7-service  3.99%       0B / 4.092GB       0.00%       0B / 0B      0B / 0B     1           7.311ms     3.99%
...

[1] https://api.cirrus-ci.com/v1/artifact/task/5931471380152320/html/sys-podman-fedora-41-rootless-host-sqlite.log.html
[2] https://github.com/containers/podman/pull/24400/commits/1f44d0f8b2b12d1d67d3474b160310d121af91d6

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
