### PR TITLE
*_test.go: use t.TempDir, t.Setenv

### DIFF
--- a/libnetwork/cni/config_test.go
+++ b/libnetwork/cni/config_test.go
@@ -26,11 +26,8 @@ var _ = Describe("Config", func() {
 	)
 
 	BeforeEach(func() {
-		var err error
-		cniConfDir, err = os.MkdirTemp("", "podman_cni_test")
-		if err != nil {
-			Fail("Failed to create tmpdir")
-		}
+		t := GinkgoT()
+		cniConfDir = t.TempDir()
 		logBuffer = bytes.Buffer{}
 		logrus.SetOutput(&logBuffer)
 		logrus.SetLevel(logrus.InfoLevel)
@@ -46,7 +43,6 @@ var _ = Describe("Config", func() {
 
 	AfterEach(func() {
 		logrus.SetLevel(logrus.InfoLevel)
-		os.RemoveAll(cniConfDir)
 	})
 
 	Context("basic network config tests", func() {

--- a/libnetwork/cni/config_test.go
+++ b/libnetwork/cni/config_test.go
@@ -31,6 +31,9 @@ var _ = Describe("Config", func() {
 		logBuffer = bytes.Buffer{}
 		logrus.SetOutput(&logBuffer)
 		logrus.SetLevel(logrus.InfoLevel)
+		DeferCleanup(func() {
+			logrus.SetLevel(logrus.InfoLevel)
+		})
 	})
 
 	JustBeforeEach(func() {
@@ -39,10 +42,6 @@ var _ = Describe("Config", func() {
 		if err != nil {
 			Fail("Failed to create NewCNINetworkInterface")
 		}
-	})
-
-	AfterEach(func() {
-		logrus.SetLevel(logrus.InfoLevel)
 	})
 
 	Context("basic network config tests", func() {

--- a/libnetwork/cni/run_test.go
+++ b/libnetwork/cni/run_test.go
@@ -86,12 +86,24 @@ var _ = Describe("run CNI", func() {
 		if err != nil {
 			Fail("Failed to create netns")
 		}
+		DeferCleanup(func() {
+			_ = netns.UnmountNS(netNSTest.Path())
+			_ = netNSTest.Close()
+		})
 
 		netNSContainer, err = netns.NewNS()
 		if err != nil {
 			Fail("Failed to create netns")
 		}
+		DeferCleanup(func() {
+			_ = netns.UnmountNS(netNSContainer.Path())
+			_ = netNSContainer.Close()
+		})
+
 		logrus.SetLevel(logrus.WarnLevel)
+		DeferCleanup(func() {
+			logrus.SetLevel(logrus.InfoLevel)
+		})
 	})
 
 	JustBeforeEach(func() {
@@ -100,16 +112,6 @@ var _ = Describe("run CNI", func() {
 		if err != nil {
 			Fail("Failed to create NewCNINetworkInterface")
 		}
-	})
-
-	AfterEach(func() {
-		logrus.SetLevel(logrus.InfoLevel)
-
-		_ = netns.UnmountNS(netNSTest.Path())
-		_ = netNSTest.Close()
-
-		_ = netns.UnmountNS(netNSContainer.Path())
-		_ = netNSContainer.Close()
 	})
 
 	Context("network setup test", func() {

--- a/libnetwork/cni/run_test.go
+++ b/libnetwork/cni/run_test.go
@@ -790,8 +790,8 @@ var _ = Describe("run CNI", func() {
 					},
 				}
 
-				os.Setenv("CNI_ARGS", "IP="+ip)
-				defer os.Unsetenv("CNI_ARGS")
+				t := GinkgoT()
+				t.Setenv("CNI_ARGS", "IP="+ip)
 
 				res, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
 				Expect(err).ToNot(HaveOccurred())

--- a/libnetwork/cni/run_test.go
+++ b/libnetwork/cni/run_test.go
@@ -76,14 +76,12 @@ var _ = Describe("run CNI", func() {
 			Skip("this test needs to be run as root")
 		}
 
-		var err error
-		cniConfDir, err = os.MkdirTemp("", "podman_cni_test")
-		if err != nil {
-			Fail("Failed to create tmpdir")
-		}
+		t := GinkgoT()
+		cniConfDir = t.TempDir()
 		logBuffer = bytes.Buffer{}
 		logrus.SetOutput(&logBuffer)
 
+		var err error
 		netNSTest, err = netns.NewNS()
 		if err != nil {
 			Fail("Failed to create netns")
@@ -106,7 +104,6 @@ var _ = Describe("run CNI", func() {
 
 	AfterEach(func() {
 		logrus.SetLevel(logrus.InfoLevel)
-		_ = os.RemoveAll(cniConfDir)
 
 		_ = netns.UnmountNS(netNSTest.Path())
 		_ = netNSTest.Close()

--- a/libnetwork/netavark/config_test.go
+++ b/libnetwork/netavark/config_test.go
@@ -28,11 +28,8 @@ var _ = Describe("Config", func() {
 	)
 
 	BeforeEach(func() {
-		var err error
-		networkConfDir, err = os.MkdirTemp("", "podman_netavark_test")
-		if err != nil {
-			Fail("Failed to create tmpdir")
-		}
+		t := GinkgoT()
+		networkConfDir = t.TempDir()
 		logBuffer = bytes.Buffer{}
 		logrus.SetOutput(&logBuffer)
 	})
@@ -43,10 +40,6 @@ var _ = Describe("Config", func() {
 		if err != nil {
 			Fail("Failed to create NewCNINetworkInterface")
 		}
-	})
-
-	AfterEach(func() {
-		os.RemoveAll(networkConfDir)
 	})
 
 	Context("basic network config tests", func() {

--- a/libnetwork/netavark/ipam_test.go
+++ b/libnetwork/netavark/ipam_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"fmt"
 	"net"
-	"os"
 
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/pkg/config"
@@ -23,11 +22,8 @@ var _ = Describe("IPAM", func() {
 	)
 
 	BeforeEach(func() {
-		var err error
-		networkConfDir, err = os.MkdirTemp("", "podman_netavark_test")
-		if err != nil {
-			Fail("Failed to create tmpdir")
-		}
+		t := GinkgoT()
+		networkConfDir = t.TempDir()
 		logBuffer = bytes.Buffer{}
 		logrus.SetOutput(&logBuffer)
 	})
@@ -46,10 +42,6 @@ var _ = Describe("IPAM", func() {
 		// run network list to force a network load
 		_, err = networkInterface.NetworkList()
 		Expect(err).ToNot(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		os.RemoveAll(networkConfDir)
 	})
 
 	It("simple ipam alloc", func() {

--- a/libnetwork/netavark/plugin_test.go
+++ b/libnetwork/netavark/plugin_test.go
@@ -4,7 +4,6 @@ package netavark_test
 
 import (
 	"bytes"
-	"os"
 	"path/filepath"
 
 	"github.com/containers/common/libnetwork/types"
@@ -23,11 +22,8 @@ var _ = Describe("Plugins", func() {
 	)
 
 	BeforeEach(func() {
-		var err error
-		networkConfDir, err = os.MkdirTemp("", "podman_netavark_test")
-		if err != nil {
-			Fail("Failed to create tmpdir")
-		}
+		t := GinkgoT()
+		networkConfDir = t.TempDir()
 		logBuffer = bytes.Buffer{}
 		logrus.SetOutput(&logBuffer)
 	})
@@ -38,10 +34,6 @@ var _ = Describe("Plugins", func() {
 		if err != nil {
 			Fail("Failed to create NewNetworkInterface")
 		}
-	})
-
-	AfterEach(func() {
-		os.RemoveAll(networkConfDir)
 	})
 
 	It("create plugin network", func() {

--- a/libnetwork/netavark/run_test.go
+++ b/libnetwork/netavark/run_test.go
@@ -73,12 +73,10 @@ var _ = Describe("run netavark", func() {
 			Skip("this test needs to be run as root")
 		}
 
-		var err error
-		confDir, err = os.MkdirTemp("", "podman_netavark_test")
-		if err != nil {
-			Fail("Failed to create tmpdir")
-		}
+		t := GinkgoT()
+		confDir = t.TempDir()
 
+		var err error
 		netNSTest, err = netns.NewNS()
 		if err != nil {
 			Fail("Failed to create netns")
@@ -91,7 +89,7 @@ var _ = Describe("run netavark", func() {
 
 		// Force iptables driver, firewalld is broken inside the extra
 		// namespace because it still connects to firewalld on the host.
-		_ = os.Setenv("NETAVARK_FW", "iptables")
+		t.Setenv("NETAVARK_FW", "iptables")
 	})
 
 	JustBeforeEach(func() {
@@ -105,15 +103,12 @@ var _ = Describe("run netavark", func() {
 	AfterEach(func() {
 		logrus.SetFormatter(&logrus.TextFormatter{})
 		logrus.SetLevel(logrus.InfoLevel)
-		_ = os.RemoveAll(confDir)
 
 		_ = netns.UnmountNS(netNSTest.Path())
 		_ = netNSTest.Close()
 
 		_ = netns.UnmountNS(netNSContainer.Path())
 		_ = netNSContainer.Close()
-
-		_ = os.Unsetenv("NETAVARK_FW")
 	})
 
 	It("test basic setup", func() {

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -13,35 +13,28 @@ import (
 var _ = Describe("Config", func() {
 	Describe("ValidateAuth", func() {
 		It("validate GetDefaultAuthFile", func() {
+			t := GinkgoT()
 			// Given
-			oldDockerConf, envDockerSet := os.LookupEnv("DOCKER_CONFIG")
-			os.Setenv("DOCKER_CONFIG", "/tmp")
-			oldConf, envSet := os.LookupEnv("REGISTRY_AUTH_FILE")
-			os.Setenv("REGISTRY_AUTH_FILE", "/tmp/registry.file")
+			t.Setenv("DOCKER_CONFIG", "/tmp")
+			t.Setenv("REGISTRY_AUTH_FILE", "/tmp/registry.file")
 			// When			// When
 			authFile := GetDefaultAuthFile()
 			// Then
 			gomega.Expect(authFile).To(gomega.BeEquivalentTo("/tmp/registry.file"))
-			os.Unsetenv("REGISTRY_AUTH_FILE")
 
-			// Fall back to DOCKER_CONFIG
+			// Given
+			t.Setenv("REGISTRY_AUTH_FILE", "")
+			// When
 			authFile = GetDefaultAuthFile()
 			// Then
 			gomega.Expect(authFile).To(gomega.BeEquivalentTo("/tmp/config.json"))
-			os.Unsetenv("DOCKER_CONFIG")
 
-			// Fall back to DOCKER_CONFIG
+			// Given
+			t.Setenv("DOCKER_CONFIG", "")
+			// When
 			authFile = GetDefaultAuthFile()
 			// Then
 			gomega.Expect(authFile).To(gomega.BeEquivalentTo(""))
-
-			// Undo that
-			if envSet {
-				os.Setenv("REGISTRY_AUTH_FILE", oldConf)
-			}
-			if envDockerSet {
-				os.Setenv("DOCKER_CONFIG", oldDockerConf)
-			}
 		})
 	})
 

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -391,25 +391,19 @@ var _ = Describe("Config Local", func() {
 			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		}
 		// Given we do
-		oldContainersConf, envSet := os.LookupEnv(containersConfEnv)
-		os.Setenv(containersConfEnv, "/dev/null")
+		t := GinkgoT()
+		t.Setenv(containersConfEnv, "/dev/null")
 
 		// When
 		config, err := Default()
 
-		// Undo that
-		if envSet {
-			os.Setenv(containersConfEnv, oldContainersConf)
-		} else {
-			os.Unsetenv(containersConfEnv)
-		}
 		// Then
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.GetDefaultEnv()).To(gomega.BeEquivalentTo(envs))
 		config.Containers.HTTPProxy = true
 		gomega.Expect(config.GetDefaultEnv()).To(gomega.BeEquivalentTo(envs))
-		os.Setenv("HTTP_PROXY", "localhost")
-		os.Setenv("FOO", "BAR")
+		t.Setenv("HTTP_PROXY", "localhost")
+		t.Setenv("FOO", "BAR")
 		newenvs := []string{"HTTP_PROXY=localhost"}
 		envs = append(newenvs, envs...)
 		gomega.Expect(config.GetDefaultEnv()).To(gomega.BeEquivalentTo(envs))

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -41,11 +41,8 @@ var _ = Describe("Config Local", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
-		validDirPath, err := os.MkdirTemp("", "config-empty")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(validDirPath)
+		t := GinkgoT()
+		validDirPath := t.TempDir()
 
 		// Given
 		defConf.Network.NetworkConfigDir = validDirPath
@@ -63,11 +60,9 @@ var _ = Describe("Config Local", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(defConf).NotTo(gomega.BeNil())
 
-		validDirPath, err := os.MkdirTemp("", "config-empty")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(validDirPath)
+		t := GinkgoT()
+		validDirPath := t.TempDir()
+
 		// Given
 		defConf.Network.NetworkConfigDir = validDirPath
 		defConf.Network.CNIPluginDirs.Set([]string{validDirPath})

--- a/pkg/config/config_remote_test.go
+++ b/pkg/config/config_remote_test.go
@@ -3,19 +3,15 @@
 package config
 
 import (
-	"os"
-
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
 
 var _ = Describe("Config Remote", func() {
 	It("should succeed on invalid CNIPluginDirs", func() {
-		validDirPath, err := os.MkdirTemp("", "config-empty")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(validDirPath)
+		t := GinkgoT()
+		validDirPath := t.TempDir()
+
 		// Given
 		defConf, err := defaultConfig()
 		gomega.Expect(err).To(gomega.BeNil())
@@ -125,11 +121,9 @@ var _ = Describe("Config Remote", func() {
 	})
 
 	It("should succeed on invalid CNIPluginDirs", func() {
-		validDirPath, err := os.MkdirTemp("", "config-empty")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(validDirPath)
+		t := GinkgoT()
+		validDirPath := t.TempDir()
+
 		// Given
 		defConf, err := defaultConfig()
 		gomega.Expect(err).To(gomega.BeNil())
@@ -145,11 +139,9 @@ var _ = Describe("Config Remote", func() {
 	})
 
 	It("should succeed in validating invalid PluginDir", func() {
-		validDirPath, err := os.MkdirTemp("", "config-empty")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(validDirPath)
+		t := GinkgoT()
+		validDirPath := t.TempDir()
+
 		// Given
 		defConf, err := defaultConfig()
 		gomega.Expect(err).To(gomega.BeNil())

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -692,23 +693,25 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			gomega.Expect(newConfigs).To(gomega.Equal(configs))
 
-			dir, err := os.MkdirTemp("", "configTest")
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			defer os.RemoveAll(dir)
+			t := GinkgoT()
+			dir := t.TempDir()
 			file1 := tmpFilePath(dir, "b")
 			file2 := tmpFilePath(dir, "a")
 			file3 := tmpFilePath(dir, "2")
 			file4 := tmpFilePath(dir, "1")
 			// create a file in dir that is not a .conf to make sure
 			// it does not show up in configs
-			_, err = os.CreateTemp(dir, "notconf")
+			f, err := os.CreateTemp(dir, "notconf")
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			subdir, err := os.MkdirTemp(dir, "")
+			f.Close()
+			subdir := filepath.Join(dir, "subdir")
+			err = os.Mkdir(subdir, 0o700)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			// create a file in subdir, to make sure it does not
 			// show up in configs
-			_, err = os.CreateTemp(subdir, "")
+			f, err = os.CreateTemp(subdir, "")
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			f.Close()
 
 			newConfigs, err = addConfigs(dir, configs)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -180,30 +180,24 @@ var _ = Describe("Config", func() {
 
 	Describe("readStorageTmp", func() {
 		It("test image_copy_tmp_dir='storage'", func() {
+			t := GinkgoT()
 			// Reload from new configuration file
-			testFile := "testdata/temp.conf"
+			testFile := t.TempDir() + "/temp.conf"
 			content := `[engine]
 image_copy_tmp_dir="storage"`
 			err := os.WriteFile(testFile, []byte(content), os.ModePerm)
 			// Then
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			defer os.Remove(testFile)
 
 			config, _ := NewConfig(testFile)
 			path, err := config.ImageCopyTmpDir()
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(path).To(gomega.ContainSubstring("containers/storage/tmp"))
 			// Given we do
-			oldTMPDIR, set := os.LookupEnv("TMPDIR")
-			os.Setenv("TMPDIR", "/var/tmp/foobar")
+			t.Setenv("TMPDIR", "/var/tmp/foobar")
 			path, err = config.ImageCopyTmpDir()
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(path).To(gomega.BeEquivalentTo("/var/tmp/foobar"))
-			if set {
-				os.Setenv("TMPDIR", oldTMPDIR)
-			} else {
-				os.Unsetenv("TMPDIR")
-			}
 		})
 	})
 
@@ -360,27 +354,15 @@ image_copy_tmp_dir="storage"`
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			}
 			httpEnvs := append([]string{"HTTP_PROXY=1.2.3.4"}, envs...)
-			oldProxy, proxyEnvSet := os.LookupEnv("HTTP_PROXY")
-			os.Setenv("HTTP_PROXY", "1.2.3.4")
-			oldFoo, fooEnvSet := os.LookupEnv("foo")
-			os.Setenv("foo", "bar")
+			t := GinkgoT()
+			t.Setenv("HTTP_PROXY", "1.2.3.4")
+			t.Setenv("foo", "bar")
 
 			defaultConfig, _ := defaultConfig()
 			gomega.Expect(defaultConfig.GetDefaultEnvEx(false, false)).To(gomega.BeEquivalentTo(envs))
 			gomega.Expect(defaultConfig.GetDefaultEnvEx(false, true)).To(gomega.BeEquivalentTo(httpEnvs))
 			gomega.Expect(strings.Join(defaultConfig.GetDefaultEnvEx(true, true), ",")).To(gomega.ContainSubstring("HTTP_PROXY"))
 			gomega.Expect(strings.Join(defaultConfig.GetDefaultEnvEx(true, true), ",")).To(gomega.ContainSubstring("foo"))
-			// Undo that
-			if proxyEnvSet {
-				os.Setenv("HTTP_PROXY", oldProxy)
-			} else {
-				os.Unsetenv("HTTP_PROXY")
-			}
-			if fooEnvSet {
-				os.Setenv("foo", oldFoo)
-			} else {
-				os.Unsetenv("foo")
-			}
 		})
 
 		It("should succeed with commented out configuration", func() {
@@ -461,16 +443,9 @@ image_copy_tmp_dir="storage"`
 			}
 
 			// Given we do
-			oldContainersConf, envSet := os.LookupEnv(containersConfEnv)
-			os.Setenv(containersConfEnv, "/dev/null")
+			GinkgoT().Setenv(containersConfEnv, "/dev/null")
 			// When
 			config, err := NewConfig("")
-			// Undo that
-			if envSet {
-				os.Setenv(containersConfEnv, oldContainersConf)
-			} else {
-				os.Unsetenv(containersConfEnv)
-			}
 			// Then
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal(apparmor.Profile))
@@ -529,16 +504,9 @@ image_copy_tmp_dir="storage"`
 
 		It("contents of passed-in file should override others", func() {
 			// Given we do
-			oldContainersConf, envSet := os.LookupEnv(containersConfEnv)
-			os.Setenv(containersConfEnv, "containers.conf")
+			GinkgoT().Setenv(containersConfEnv, "containers.conf")
 			// When
 			config, err := NewConfig("testdata/containers_override.conf")
-			// Undo that
-			if envSet {
-				os.Setenv(containersConfEnv, oldContainersConf)
-			} else {
-				os.Unsetenv(containersConfEnv)
-			}
 
 			crunWasm := "crun-wasm"
 			PlatformToOCIRuntimeMap := map[string]string{
@@ -698,24 +666,12 @@ image_copy_tmp_dir="storage"`
 	})
 
 	Describe("Service Destinations", func() {
-		ConfPath := struct {
-			Value string
-			IsSet bool
-		}{}
-
 		BeforeEach(func() {
-			ConfPath.Value, ConfPath.IsSet = os.LookupEnv(containersConfEnv)
-			conf, _ := os.CreateTemp("", "containersconf")
-			os.Setenv(containersConfEnv, conf.Name())
-		})
-
-		AfterEach(func() {
-			os.Remove(os.Getenv(containersConfEnv))
-			if ConfPath.IsSet {
-				os.Setenv(containersConfEnv, ConfPath.Value)
-			} else {
-				os.Unsetenv(containersConfEnv)
-			}
+			t := GinkgoT()
+			name := t.TempDir() + "/containersconf"
+			err := os.WriteFile(name, []byte{}, os.ModePerm)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			t.Setenv(containersConfEnv, name)
 		})
 
 		It("test addConfigs", func() {
@@ -786,36 +742,24 @@ image_copy_tmp_dir="storage"`
 
 	Describe("Reload", func() {
 		It("test new config from reload", func() {
+			t := GinkgoT()
 			// Default configuration
 			defaultTestFile := "testdata/containers_default.conf"
-			oldEnv, set := os.LookupEnv(containersConfEnv)
-			os.Setenv(containersConfEnv, defaultTestFile)
+			t.Setenv(containersConfEnv, defaultTestFile)
 			cfg, err := Default()
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			if set {
-				os.Setenv(containersConfEnv, oldEnv)
-			} else {
-				os.Unsetenv(containersConfEnv)
-			}
 
 			// Reload from new configuration file
-			testFile := "testdata/temp.conf"
+			testFile := t.TempDir() + "/temp.conf"
 			content := `[containers]
 env=["foo=bar"]`
 			err = os.WriteFile(testFile, []byte(content), os.ModePerm)
-			defer os.Remove(testFile)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			oldEnv, set = os.LookupEnv(containersConfEnv)
-			os.Setenv(containersConfEnv, testFile)
+			t.Setenv(containersConfEnv, testFile)
 			_, err = Reload()
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			newCfg, err := Default()
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			if set {
-				os.Setenv(containersConfEnv, oldEnv)
-			} else {
-				os.Unsetenv(containersConfEnv)
-			}
 
 			expectOldEnv := []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
 			expectNewEnv := []string{"foo=bar"}
@@ -837,15 +781,14 @@ env=["foo=bar"]`
 	})
 
 	It("CONTAINERS_CONF_OVERRIDE", func() {
-		os.Setenv("CONTAINERS_CONF_OVERRIDE", "testdata/containers_override.conf")
-		defer os.Unsetenv("CONTAINERS_CONF_OVERRIDE")
+		t := GinkgoT()
+		t.Setenv("CONTAINERS_CONF_OVERRIDE", "testdata/containers_override.conf")
 		config, err := NewConfig("")
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal("overridden-default"))
 
 		// Make sure that _OVERRIDE is loaded even when CONTAINERS_CONF is set.
-		os.Setenv(containersConfEnv, "testdata/containers_default.conf")
-		defer os.Unsetenv(containersConfEnv)
+		t.Setenv(containersConfEnv, "testdata/containers_default.conf")
 		config, err = NewConfig("")
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Containers.ApparmorProfile).To(gomega.Equal("overridden-default"))

--- a/pkg/config/connections_test.go
+++ b/pkg/config/connections_test.go
@@ -17,20 +17,12 @@ var _ = Describe("Connections conf", func() {
 	)
 
 	BeforeEach(func() {
-		dir := GinkgoT().TempDir()
+		t := GinkgoT()
+		dir := t.TempDir()
 		connectionsConfFile = filepath.Join(dir, "connections.json")
-		err := os.Setenv("PODMAN_CONNECTIONS_CONF", connectionsConfFile)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		t.Setenv("PODMAN_CONNECTIONS_CONF", connectionsConfFile)
 		containersConfFile = filepath.Join(dir, "containers.conf")
-		err = os.Setenv(containersConfEnv, containersConfFile)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	})
-
-	AfterEach(func() {
-		err := os.Unsetenv("PODMAN_CONNECTIONS_CONF")
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		err = os.Unsetenv(containersConfEnv)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		t.Setenv(containersConfEnv, containersConfFile)
 	})
 
 	It("read non existent file", func() {


### PR DESCRIPTION
Those are cases not reported by `usetesting` linter (most probably because it doesn't grok ginkgo tests).

It's hard to separate the changes into smaller commits, thus it's somewhat harder to review.

## Summary by Sourcery

Refactor test code to use Ginkgo's t.TempDir() and t.Setenv() methods for better test management and cleanup

Enhancements:
- Simplify temporary file and environment variable management in test cases
- Remove manual cleanup of temporary resources by leveraging Ginkgo's built-in test helpers

Tests:
- Replace manual temporary directory and environment variable management with Ginkgo's t.TempDir() and t.Setenv() methods
- Remove redundant cleanup code in test cases