### PR TITLE
config: drop SetDefaultConfigFilePath($CONTAINERS_STORAGE_CONF)

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -361,11 +361,6 @@ func defaultEngineConfig() (*EngineConfig, error) {
 	c.ComposeProviders.Set(getDefaultComposeProviders()) // may vary across supported platforms
 	c.ComposeWarningLogs = true
 
-	if path, ok := os.LookupEnv("CONTAINERS_STORAGE_CONF"); ok {
-		if err := types.SetDefaultConfigFilePath(path); err != nil {
-			return nil, err
-		}
-	}
 	storeOpts, err := types.DefaultStoreOptions()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
the containers/storage setup code already looks for that, and forcefully setting it confuses storage setup in
loadStoreOptionsFromConfFile.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

## Summary by Sourcery

Chores:
- Remove redundant code that sets the default storage configuration file path