### PR TITLE
image: Abort load if ENOSPC occurs

### DIFF
--- a/libimage/load.go
+++ b/libimage/load.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"syscall"
 	"time"
 
 	dirTransport "github.com/containers/image/v5/directory"
@@ -112,7 +113,7 @@ func (r *Runtime) Load(ctx context.Context, path string, options *LoadOptions) (
 		logrus.Debugf("Error loading %s (%s): %v", path, transportName, err)
 		loadErrors = append(loadErrors, fmt.Errorf("%s: %v", transportName, err))
 
-		if errors.Is(err, errors.New("no space left on device")) {
+		if errors.Is(err, syscall.ENOSPC) {
 			break
 		}
 	}


### PR DESCRIPTION
Fix: https://github.com/containers/podman/issues/26197

In image loading, exit immediately on ENOSPC instead of trying other formats.

## Summary by Sourcery

Bug Fixes:
- Stop iterating through image transports and break out of the load loop on ENOSPC errors during image import.