### PR TITLE
ci: add govulncheck job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -51,3 +51,8 @@ jobs:
 
     - name: validate seccomp
       run: ./tools/validate_seccomp.sh ./pkg/seccomp
+
+  govulncheck:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: golang/govulncheck-action@v1


### PR DESCRIPTION
The main idea here is to find any possible vulnerabilities in dependencies that would require upgrades. This is better than just blindly updating dependencies to their latest versions.

Note that this setup ignores Go stdlib vulnerabilities by using latest Go version (which is a default for govulncheck-action), as this is a library and we should not care much about specific Go version used.

## Summary by Sourcery

CI:
- Introduce a govulncheck GitHub Action step running on Ubuntu 24.04 using golang/govulncheck-action@v1 to detect dependency vulnerabilities.