### PR TITLE
cgroups: change memory usage calculation to match Docker

### DIFF
--- a/pkg/cgroups/memory_linux.go
+++ b/pkg/cgroups/memory_linux.go
@@ -3,9 +3,7 @@
 package cgroups
 
 import (
-	"fmt"
 	"path/filepath"
-	"strconv"
 
 	"github.com/opencontainers/cgroups"
 	"github.com/opencontainers/cgroups/fs"
@@ -57,31 +55,44 @@ func (c *linuxMemHandler) Stat(ctr *CgroupControl, m *cgroups.Stats) error {
 	if ctr.cgroup2 {
 		memoryRoot = filepath.Join(cgroupRoot, ctr.config.Path)
 		limitFilename = "memory.max"
-		if memUsage.Usage.Usage, err = readFileByKeyAsUint64(filepath.Join(memoryRoot, "memory.stat"), "anon"); err != nil {
+
+		// Read memory.current
+		current, err := readFileAsUint64(filepath.Join(memoryRoot, "memory.current"))
+		if err != nil {
 			return err
+		}
+
+		// Read inactive_file from memory.stat
+		inactiveFile, err := readFileByKeyAsUint64(filepath.Join(memoryRoot, "memory.stat"), "inactive_file")
+		if err != nil {
+			return err
+		}
+
+		// Docker calculation: memory.current - memory.stat['inactive_file']
+		memUsage.Usage.Usage = 0
+		if inactiveFile < current {
+			memUsage.Usage.Usage = current - inactiveFile
 		}
 	} else {
 		memoryRoot = ctr.getCgroupv1Path(Memory)
 		limitFilename = "memory.limit_in_bytes"
 
-		path := filepath.Join(memoryRoot, "memory.stat")
-		values, err := readCgroupMapPath(path)
+		// Read memory.usage_in_bytes
+		usageInBytes, err := readFileAsUint64(filepath.Join(memoryRoot, "memory.usage_in_bytes"))
 		if err != nil {
 			return err
 		}
 
-		// cgroup v1 does not have a single "anon" field, but we can calculate it
-		// from total_active_anon and total_inactive_anon
+		// Read total_inactive_file from memory.stat
+		totalInactiveFile, err := readFileByKeyAsUint64(filepath.Join(memoryRoot, "memory.stat"), "total_inactive_file")
+		if err != nil {
+			return err
+		}
+
+		// Docker calculation: memory.usage_in_bytes - memory.stat['total_inactive_file']
 		memUsage.Usage.Usage = 0
-		for _, key := range []string{"total_active_anon", "total_inactive_anon"} {
-			if _, found := values[key]; !found {
-				continue
-			}
-			res, err := strconv.ParseUint(values[key][0], 10, 64)
-			if err != nil {
-				return fmt.Errorf("parse %s from %s: %w", key, path, err)
-			}
-			memUsage.Usage.Usage += res
+		if totalInactiveFile < usageInBytes {
+			memUsage.Usage.Usage = usageInBytes - totalInactiveFile
 		}
 	}
 


### PR DESCRIPTION
This changes the memory usage calculation to follow Docker's approach:

- For cgroup v2: memory.current - memory.stat['inactive_file']
- For cgroup v1: memory.usage_in_bytes - memory.stat['total_inactive_file']

The previous calculation used anonymous memory only, but Docker's calculation provides more accurate memory usage by excluding inactive file cache.

Closes: https://github.com/containers/common/issues/2454

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

## Summary by Sourcery

Align cgroup memory usage calculation with Docker by subtracting inactive file caches for both v1 and v2

Enhancements:
- Compute cgroup v2 memory usage as memory.current minus memory.stat['inactive_file']
- Compute cgroup v1 memory usage as memory.usage_in_bytes minus memory.stat['total_inactive_file']