### PR TITLE
SecretsManager - support ignore flag to noop if already exists

### DIFF
--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -151,6 +151,14 @@ func TestAddSecretDupName(t *testing.T) {
 	storeOpts.Replace = true
 	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, storeOpts)
 	require.NoError(t, err)
+
+	storeOpts.IgnoreIfExists = true
+	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, storeOpts)
+	require.Error(t, err)
+
+	storeOpts.Replace = false
+	_, err = manager.Store("mysecret", []byte("mydata"), drivertype, storeOpts)
+	require.NoError(t, err)
 }
 
 func TestAddReplaceSecretName(t *testing.T) {


### PR DESCRIPTION
## Summary by Sourcery

Enhance SecretsManager.Store to support an ignore-if-exists flag with proper validation and add corresponding tests

New Features:
- Add IgnoreIfExists option to skip storing when a secret already exists

Bug Fixes:
- Prevent using IgnoreIfExists and Replace flags together

Enhancements:
- Return existing secret ID when IgnoreIfExists is set

Tests:
- Add tests for flag combination validation and ignore-if-exists behavior