### PR TITLE
Add /var/run/cdi as a default cdi spec dir in config

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -696,7 +696,7 @@ The default path on Windows is:
 
 Path to the OCI hooks directories for automatically executed hooks.
 
-**cdi_spec_dirs**=["/etc/cdi", ...]
+**cdi_spec_dirs**=["/etc/cdi", "/var/run/cdi", ...]
 
 Directories to scan for CDI Spec files.
 

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -351,13 +351,13 @@ var _ = Describe("Config Local", func() {
 		config1, err := New(nil)
 		// Then
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		gomega.Expect(config1.Engine.CdiSpecDirs.Get()).To(gomega.Equal([]string{"/etc/cdi"}))
+		gomega.Expect(config1.Engine.CdiSpecDirs.Get()).To(gomega.Equal([]string{"/etc/cdi", "/var/run/cdi"}))
 
 		// Given default just get default
 		config2, err := NewConfig("testdata/containers_default.conf")
 		// Then
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		gomega.Expect(config2.Engine.CdiSpecDirs.Get()).To(gomega.Equal([]string{"/etc/cdi"}))
+		gomega.Expect(config2.Engine.CdiSpecDirs.Get()).To(gomega.Equal([]string{"/etc/cdi", "/var/run/cdi"}))
 
 		// Given override just get override
 		config3, err := NewConfig("testdata/containers_override.conf")

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -588,6 +588,7 @@ default_sysctls = [
 #
 #cdi_spec_dirs = [
 #  "/etc/cdi",
+#  "/var/run/cdi",
 #]
 
 # Manifest Type (oci, v2s2, or v2s1) to use when pulling, pushing, building

--- a/pkg/config/containers.conf-freebsd
+++ b/pkg/config/containers.conf-freebsd
@@ -437,6 +437,7 @@ default_sysctls = [
 #
 #cdi_spec_dirs = [
 #  "/etc/cdi",
+#  "/var/run/cdi",
 #]
 
 # Manifest Type (oci, v2s2, or v2s1) to use when pulling, pushing, building

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -102,7 +102,7 @@ var (
 	// DefaultHooksDirs defines the default hooks directory.
 	DefaultHooksDirs = []string{"/usr/share/containers/oci/hooks.d"}
 	// DefaultCdiSpecDirs defines the default cdi spec directories.
-	DefaultCdiSpecDirs = []string{"/etc/cdi"}
+	DefaultCdiSpecDirs = []string{"/etc/cdi", "/var/run/cdi"}
 	// DefaultCapabilities is the default for the default_capabilities option in the containers.conf file.
 	DefaultCapabilities = []string{
 		"CAP_CHOWN",

--- a/pkg/config/testdata/containers_comment.conf
+++ b/pkg/config/testdata/containers_comment.conf
@@ -83,6 +83,7 @@
 #
 #cdi_spec_dirs = [
 #  "/etc/cdi",
+#  "/var/run/cdi",
 #]
 
 # Size of /dev/shm. Specified as <number><unit>.

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -230,7 +230,7 @@ hooks_dir = [
 ]
 
 # Directories to scan for CDI Spec files.
-# cdi_spec_dirs = [ "/etc/cdi" ]
+# cdi_spec_dirs = [ "/etc/cdi", "/var/run/cdi" ]
 
 # Default infra (pause) image name for pod infra containers
 infra_image = "registry.k8s.io/pause:3.4.1"

--- a/pkg/config/testdata/containers_invalid.conf
+++ b/pkg/config/testdata/containers_invalid.conf
@@ -134,7 +134,7 @@ hooks_dir = [
 ]
 
 # Directories to scan for CDI Spec files.
-cdi_spec_dirs = [ "/etc/cdi" ]
+cdi_spec_dirs = [ "/etc/cdi", "/var/run/cdi" ]
 
 # Whether to use chroot instead of pivot_root in the runtime
 no_pivot_root = false


### PR DESCRIPTION
Fixes: #2460 by adding `/var/run/cdi` explicitly as an additional default CDI spec directory

I haven't added a test to compare the default dirs to what's defined in `container-device-interface/pkgs/cdi`, since that would potentially block dependency updates in the future, though I do wonder if that might be desirable, to catch + allow updating the default and documentation? Though I guess might also just be a chore

I also haven't added any additional tests, and just updated what was already present in pkg/config/config_local_test.go but I'm happy to add + do any additional testing if required/desired, thanks!

## Summary by Sourcery

Include `/var/run/cdi` as a default CDI spec directory and propagate the change through configuration defaults, tests, and documentation.

Enhancements:
- Add "/var/run/cdi" to the default CDI spec directories

Documentation:
- Revise documentation and sample `containers.conf` files to include `/var/run/cdi` in `cdi_spec_dirs`

Tests:
- Update config tests to expect both "/etc/cdi" and "/var/run/cdi"