### PR TITLE
libnetwork/etchosts: add host.containers.internal for machine

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -226,11 +226,10 @@ setup. Adding these internal hostnames to `/etc/hosts` is silently skipped then.
 Set this config to `none` to never add the internal hostnames to `/etc/hosts`.
 
 Note: If Podman is running in a virtual machine using `podman machine` (this
-includes Mac and Windows hosts), Podman will silently skip adding the internal
-hostnames to `/etc/hosts`, unless an IP address was configured manually. The
-internal hostnames are resolved by the gvproxy DNS resolver instead. This config
-has no effect on gvproxy. However, since `/etc/hosts` bypasses the DNS resolver,
-a manually configured IP address still takes precedence.
+includes Mac and Windows hosts), Podman resolves the `host.containers.internal`
+hostname via the podman machine (gvproxy) DNS resolver instead when it is empty.
+Also because the name will be resolved by the DNS name in gvproxy setting this
+to `none` has no effect. This option does not change the gvproxy behavior.
 
 Note: This config doesn't affect the actual network setup, it just tells Podman
 the IP address it should expect. Configuring an IP address here doesn't ensure


### PR DESCRIPTION
When running inside podman machine we cannot use the normal ip lookup logic for host.containers.internal because that should refer to the actual host system and not the VM ip.

gvproxy already resolves the host.containers.internal name correctly but the issue is when a users wants to set a custom name via --add-host foobar:host-gateway then we need to know the actual ip to replace the host-gateway part. Right now we just always error which is not good.

To fix this just look up the name ourselves so we can add it to /etc/hosts.

Fixes: containers/podman#21681

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

## Summary by Sourcery

Resolve and cache the host.containers.internal address via DNS in Podman machine mode so that custom host-gateway mappings can be added to /etc/hosts without errors

New Features:
- Add DNS lookup for host.containers.internal IP when running inside a Podman machine

Bug Fixes:
- Enable --add-host foobar:host-gateway to work by populating /etc/hosts with the resolved host.containers.internal IP instead of erroring

Enhancements:
- Cache the machine host-containers.internal lookup result using sync.OnceValue