### PR TITLE
libimage: drop "internal error" message on regular error

### DIFF
--- a/libimage/copier.go
+++ b/libimage/copier.go
@@ -488,7 +488,7 @@ func (c *Copier) copyToStorage(ctx context.Context, source, destination types.Im
 	var resolvedReference types.ImageReference
 	_, err := c.copyInternal(ctx, source, destination, &resolvedReference)
 	if err != nil {
-		return nil, fmt.Errorf("internal error: unable to copy from source %s: %w", transports.ImageName(source), err)
+		return nil, fmt.Errorf("unable to copy from source %s: %w", transports.ImageName(source), err)
 	}
 	if resolvedReference == nil {
 		return nil, fmt.Errorf("internal error: After attempting to copy %s, resolvedReference is nil", source)


### PR DESCRIPTION
This error can happen in many different cases such a a non existing image or other kind of pull errors. In all cases they do not reflect any sort of internal inconsistency in the code itself so this is just misleading to users.

Fixes: #2465

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

## Summary by Sourcery

Bug Fixes:
- Drop the "internal error:" prefix on regular copy failures when copying from a source image in Copier.copyToStorage