### PR TITLE
Fix broken gitignore exclude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 contrib/spec/podman.spec
 *.rpm
 *~
-build
 ./generate
 *.coverprofile
 /bin

--- a/vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go
+++ b/vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go
@@ -1,0 +1,80 @@
+package build
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/onsi/ginkgo/v2/ginkgo/command"
+	"github.com/onsi/ginkgo/v2/ginkgo/internal"
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+func BuildBuildCommand() command.Command {
+	var cliConfig = types.NewDefaultCLIConfig()
+	var goFlagsConfig = types.NewDefaultGoFlagsConfig()
+
+	flags, err := types.BuildBuildCommandFlagSet(&cliConfig, &goFlagsConfig)
+	if err != nil {
+		panic(err)
+	}
+
+	return command.Command{
+		Name:     "build",
+		Flags:    flags,
+		Usage:    "ginkgo build <FLAGS> <PACKAGES>",
+		ShortDoc: "Build the passed in <PACKAGES> (or the package in the current directory if left blank).",
+		DocLink:  "precompiling-suites",
+		Command: func(args []string, _ []string) {
+			var errors []error
+			cliConfig, goFlagsConfig, errors = types.VetAndInitializeCLIAndGoConfig(cliConfig, goFlagsConfig)
+			command.AbortIfErrors("Ginkgo detected configuration issues:", errors)
+
+			buildSpecs(args, cliConfig, goFlagsConfig)
+		},
+	}
+}
+
+func buildSpecs(args []string, cliConfig types.CLIConfig, goFlagsConfig types.GoFlagsConfig) {
+	suites := internal.FindSuites(args, cliConfig, false).WithoutState(internal.TestSuiteStateSkippedByFilter)
+	if len(suites) == 0 {
+		command.AbortWith("Found no test suites")
+	}
+
+	internal.VerifyCLIAndFrameworkVersion(suites)
+
+	opc := internal.NewOrderedParallelCompiler(cliConfig.ComputedNumCompilers())
+	opc.StartCompiling(suites, goFlagsConfig, true)
+
+	for {
+		suiteIdx, suite := opc.Next()
+		if suiteIdx >= len(suites) {
+			break
+		}
+		suites[suiteIdx] = suite
+		if suite.State.Is(internal.TestSuiteStateFailedToCompile) {
+			fmt.Println(suite.CompilationError.Error())
+		} else {
+			var testBinPath string
+			if len(goFlagsConfig.O) != 0 {
+				stat, err := os.Stat(goFlagsConfig.O)
+				if err != nil {
+					panic(err)
+				}
+				if stat.IsDir() {
+					testBinPath = goFlagsConfig.O + "/" + suite.PackageName + ".test"
+				} else {
+					testBinPath = goFlagsConfig.O
+				}
+			}
+			if len(testBinPath) == 0 {
+				testBinPath = path.Join(suite.Path, suite.PackageName+".test")
+			}
+			fmt.Printf("Compiled %s\n", testBinPath)
+		}
+	}
+
+	if suites.CountWithState(internal.TestSuiteStateFailedToCompile) > 0 {
+		command.AbortWith("Failed to compile all tests")
+	}
+}


### PR DESCRIPTION
.gitignore: do not ignore all build directories

This matches all directories not just the top level one we wanted to
ignore, however we no loner use or put anything into /build so we can
just remove it instead.

vendor: regenerate files

Now that build is no longer incorrectly excluded it gets added. The fact
that this did not cause a compile failure was just because gingko is
used directly by the tests and not compiled from these sources.