### PR TITLE
golangci-lint: fix all the reported lint errors

### DIFF
--- a/libnetwork/cni/config_freebsd.go
+++ b/libnetwork/cni/config_freebsd.go
@@ -3,13 +3,14 @@
 package cni
 
 import (
+	"context"
 	"os/exec"
 
 	"github.com/sirupsen/logrus"
 )
 
 func deleteLink(name string) {
-	if output, err := exec.Command("ifconfig", name, "destroy").CombinedOutput(); err != nil {
+	if output, err := exec.CommandContext(context.Background(), "ifconfig", name, "destroy").CombinedOutput(); err != nil {
 		// only log the error, it is not fatal
 		logrus.Infof("Failed to remove network interface %s: %v: %s", name, err, output)
 	}

--- a/libnetwork/cni/run_freebsd.go
+++ b/libnetwork/cni/run_freebsd.go
@@ -1,6 +1,7 @@
 package cni
 
 import (
+	"context"
 	"os/exec"
 )
 
@@ -9,11 +10,11 @@ import (
 // effect.
 func setupLoopback(namespacePath string) error {
 	// Try to run the command using ifconfig's -j flag (supported in 13.3 and later)
-	if err := exec.Command("ifconfig", "-j", namespacePath, "lo0", "inet", "127.0.0.1").Run(); err == nil {
+	if err := exec.CommandContext(context.Background(), "ifconfig", "-j", namespacePath, "lo0", "inet", "127.0.0.1").Run(); err == nil {
 		return nil
 	}
 
 	// Fall back to using the jexec wrapper to run the ifconfig command
 	// inside the jail.
-	return exec.Command("jexec", namespacePath, "ifconfig", "lo0", "inet", "127.0.0.1").Run()
+	return exec.CommandContext(context.Background(), "jexec", namespacePath, "ifconfig", "lo0", "inet", "127.0.0.1").Run()
 }

--- a/libnetwork/cni/run_test.go
+++ b/libnetwork/cni/run_test.go
@@ -15,6 +15,7 @@ package cni_test
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net"
 	"os"
@@ -1372,7 +1373,8 @@ var _ = Describe("run CNI", func() {
 func runNetListener(wg *sync.WaitGroup, protocol, ip string, port int, expectedData string) {
 	switch protocol {
 	case "tcp":
-		ln, err := net.Listen(protocol, net.JoinHostPort(ip, strconv.Itoa(port)))
+		lc := &net.ListenConfig{}
+		ln, err := lc.Listen(context.Background(), protocol, net.JoinHostPort(ip, strconv.Itoa(port)))
 		Expect(err).ToNot(HaveOccurred())
 		// make sure to read in a separate goroutine to not block
 		go func() {

--- a/libnetwork/netavark/exec.go
+++ b/libnetwork/netavark/exec.go
@@ -3,6 +3,7 @@
 package netavark
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -137,7 +138,7 @@ func (n *netavarkNetwork) execBinary(path string, args []string, stdin, result a
 		logWriter = io.MultiWriter(logWriter, &logrusNetavarkWriter{})
 	}
 
-	cmd := exec.Command(path, args...)
+	cmd := exec.CommandContext(context.Background(), path, args...)
 	// connect the pipes to stdin and stdout
 	cmd.Stdin = stdinR
 	cmd.Stdout = stdoutW

--- a/libnetwork/netavark/run_test.go
+++ b/libnetwork/netavark/run_test.go
@@ -14,6 +14,7 @@ package netavark_test
 // })
 
 import (
+	"context"
 	"io"
 	"net"
 	"os"
@@ -796,7 +797,8 @@ var _ = Describe("run netavark", func() {
 func runNetListener(wg *sync.WaitGroup, protocol, ip string, port int, expectedData string) {
 	switch protocol {
 	case "tcp":
-		ln, err := net.Listen(protocol, net.JoinHostPort(ip, strconv.Itoa(port)))
+		lc := &net.ListenConfig{}
+		ln, err := lc.Listen(context.Background(), protocol, net.JoinHostPort(ip, strconv.Itoa(port)))
 		Expect(err).ToNot(HaveOccurred())
 		// make sure to read in a separate goroutine to not block
 		go func() {

--- a/libnetwork/pasta/pasta_linux.go
+++ b/libnetwork/pasta/pasta_linux.go
@@ -11,6 +11,7 @@
 package pasta
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -69,7 +70,7 @@ func Setup(opts *SetupOptions) (*SetupResult, error) {
 
 	for {
 		// pasta forks once ready, and quits once we delete the target namespace
-		out, err := exec.Command(path, cmdArgs...).CombinedOutput()
+		out, err := exec.CommandContext(context.Background(), path, cmdArgs...).CombinedOutput()
 		if err != nil {
 			exitErr := &exec.ExitError{}
 			if errors.As(err, &exitErr) {

--- a/pkg/apparmor/apparmor_linux.go
+++ b/pkg/apparmor/apparmor_linux.go
@@ -5,6 +5,7 @@ package apparmor
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -96,7 +97,7 @@ func InstallDefault(name string) error {
 		return fmt.Errorf("find `apparmor_parser` binary: %w", err)
 	}
 
-	cmd := exec.Command(apparmorParserPath, "-Kr")
+	cmd := exec.CommandContext(context.Background(), apparmorParserPath, "-Kr")
 	pipe, err := cmd.StdinPipe()
 	if err != nil {
 		return fmt.Errorf("execute %s: %w", apparmorParserPath, err)
@@ -181,7 +182,7 @@ func IsLoaded(name string) (bool, error) {
 
 // execAAParser runs `apparmor_parser` with the passed arguments.
 func execAAParser(apparmorParserPath, dir string, args ...string) (string, error) {
-	c := exec.Command(apparmorParserPath, args...)
+	c := exec.CommandContext(context.Background(), apparmorParserPath, args...)
 	c.Dir = dir
 
 	output, err := c.Output()

--- a/pkg/cgroups/cgroups_linux_test.go
+++ b/pkg/cgroups/cgroups_linux_test.go
@@ -4,6 +4,7 @@ package cgroups
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math/big"
 	"os"
@@ -124,7 +125,7 @@ func TestResources(t *testing.T) {
 	}
 	defer os.RemoveAll("/dev/foodevdir")
 
-	c := exec.Command("mknod", "/dev/foodevdir/null", "b", "1", "3")
+	c := exec.CommandContext(context.Background(), "mknod", "/dev/foodevdir/null", "b", "1", "3")
 	c.Env = os.Environ()
 	c.Stderr = os.Stderr
 	c.Stdout = os.Stdout
@@ -133,7 +134,7 @@ func TestResources(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c = exec.Command("mknod", "/dev/foodevdir/bar", "b", "3", "10")
+	c = exec.CommandContext(context.Background(), "mknod", "/dev/foodevdir/bar", "b", "3", "10")
 	c.Env = os.Environ()
 	c.Stderr = os.Stderr
 	c.Stdout = os.Stdout
@@ -142,7 +143,7 @@ func TestResources(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c = exec.Command("mknod", "/dev/foodevdir/bat", "b", "5", "9")
+	c = exec.CommandContext(context.Background(), "mknod", "/dev/foodevdir/bat", "b", "5", "9")
 	c.Env = os.Environ()
 	c.Stderr = os.Stderr
 	c.Stdout = os.Stdout

--- a/pkg/crutils/checkpoint_restore_utils.go
+++ b/pkg/crutils/checkpoint_restore_utils.go
@@ -2,6 +2,7 @@ package crutils
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -212,7 +213,7 @@ func CRCreateFileWithLabel(directory, fileName, fileLabel string) error {
 func CRRuntimeSupportsCheckpointRestore(runtimePath string) bool {
 	// Check if the runtime implements checkpointing. Currently only
 	// runc's and crun's checkpoint/restore implementation is supported.
-	cmd := exec.Command(runtimePath, "checkpoint", "--help")
+	cmd := exec.CommandContext(context.Background(), runtimePath, "checkpoint", "--help")
 	if err := cmd.Start(); err != nil {
 		return false
 	}
@@ -227,7 +228,7 @@ func CRRuntimeSupportsCheckpointRestore(runtimePath string) bool {
 // the CRIU option --lsm-mount-context and the existence of this is checked
 // by this function. In addition it is necessary to at least have CRIU 3.16.
 func CRRuntimeSupportsPodCheckpointRestore(runtimePath string) bool {
-	cmd := exec.Command(runtimePath, "restore", "--lsm-mount-context")
+	cmd := exec.CommandContext(context.Background(), runtimePath, "restore", "--lsm-mount-context")
 	out, _ := cmd.CombinedOutput()
 	return bytes.Contains(out, []byte("flag needs an argument"))
 }

--- a/pkg/ssh/connection_golang.go
+++ b/pkg/ssh/connection_golang.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -260,7 +261,8 @@ func ValidateAndConfigure(uri *url.URL, iden string, insecureIsMachineConnection
 	} else if sock, found := os.LookupEnv("SSH_AUTH_SOCK"); found { // validate ssh information, specifically the unix file socket used by the ssh agent.
 		logrus.Debugf("Found SSH_AUTH_SOCK %q, ssh-agent signer enabled", sock)
 
-		c, err := net.Dial("unix", sock)
+		dialer := &net.Dialer{}
+		c, err := dialer.DialContext(context.Background(), "unix", sock)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ssh/connection_native.go
+++ b/pkg/ssh/connection_native.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -57,7 +58,7 @@ func nativeConnectionCreate(options ConnectionCreateOptions) error {
 
 	output := &bytes.Buffer{}
 	args = append(args, "podman", "info", "--format", "json")
-	info := exec.Command(ssh, args...)
+	info := exec.CommandContext(context.Background(), ssh, args...)
 	info.Stdout = output
 	err = info.Run()
 	if err != nil {
@@ -132,7 +133,7 @@ func nativeConnectionExec(options ConnectionExecOptions, input io.Reader) (*Conn
 		args = append(args, "-F", conf.Engine.SSHConfig)
 	}
 	args = append(args, options.Args...)
-	info := exec.Command(ssh, args...)
+	info := exec.CommandContext(context.Background(), ssh, args...)
 	info.Stdout = output
 	info.Stderr = errors
 	if input != nil {
@@ -184,7 +185,7 @@ func nativeConnectionScp(options ConnectionScpOptions) (*ConnectionScpReport, er
 		args = append(args, localPath, userString+host+":"+remotePath)
 	}
 
-	info := exec.Command(scp, args...)
+	info := exec.CommandContext(context.Background(), scp, args...)
 	err = info.Run()
 	if err != nil {
 		return nil, err

--- a/pkg/sysinfo/sysinfo_solaris.go
+++ b/pkg/sysinfo/sysinfo_solaris.go
@@ -4,6 +4,7 @@ package sysinfo
 
 import (
 	"bytes"
+	"context"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -31,7 +32,7 @@ import "C"
 // IsCPUSharesAvailable returns whether CPUShares setting is supported.
 // We need FSS to be set as default scheduling class to support CPU Shares
 func IsCPUSharesAvailable() bool {
-	cmd := exec.Command("/usr/sbin/dispadmin", "-d")
+	cmd := exec.CommandContext(context.Background(), "/usr/sbin/dispadmin", "-d")
 	outBuf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
 	cmd.Stderr = errBuf

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -22,7 +23,7 @@ func queryPackageVersion(cmdArg ...string) string {
 	}
 	output := UnknownPackage
 	if 1 < len(cmdArg) {
-		cmd := exec.Command(cmdArg[0], cmdArg[1:]...)
+		cmd := exec.CommandContext(context.Background(), cmdArg[0], cmdArg[1:]...)
 		if outp, err := cmd.Output(); err == nil {
 			output = string(outp)
 			switch cmdArg[0] {
@@ -32,7 +33,7 @@ func queryPackageVersion(cmdArg ...string) string {
 				output = l[0]
 				r := strings.Split(output, ": ")
 				regexpFormat := `^..\s` + r[0] + `\s`
-				cmd = exec.Command(cmdArg[0], "-P", regexpFormat, "-l")
+				cmd = exec.CommandContext(context.Background(), cmdArg[0], "-P", regexpFormat, "-l")
 				cmd.Env = []string{"COLUMNS=160"} // show entire value
 				// dlocate always returns exit code 1 for list command
 				if outp, _ = cmd.Output(); len(outp) > 0 {
@@ -48,13 +49,13 @@ func queryPackageVersion(cmdArg ...string) string {
 			case "/usr/bin/dpkg":
 				r := strings.Split(output, ": ")
 				queryFormat := `${Package}_${Version}_${Architecture}`
-				cmd = exec.Command("/usr/bin/dpkg-query", "-f", queryFormat, "-W", r[0])
+				cmd = exec.CommandContext(context.Background(), "/usr/bin/dpkg-query", "-f", queryFormat, "-W", r[0])
 				if outp, err := cmd.Output(); err == nil {
 					output = string(outp)
 				}
 			case "/usr/bin/pacman":
 				pkg := strings.Trim(output, "\n")
-				cmd = exec.Command(cmdArg[0], "-Q", "--", pkg)
+				cmd = exec.CommandContext(context.Background(), cmdArg[0], "-Q", "--", pkg)
 				if outp, err := cmd.Output(); err == nil {
 					output = strings.ReplaceAll(string(outp), " ", "-")
 				}
@@ -119,7 +120,7 @@ func ProgramDnsname(name string) (string, error) {
 }
 
 func program(program string, dnsname bool) (string, error) {
-	cmd := exec.Command(program, "--version")
+	cmd := exec.CommandContext(context.Background(), program, "--version")
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout


### PR DESCRIPTION
commit 2d75d8ec9116082c2420f2e86069cae48358636f bumped the linter version without fixing the new issues.

Follow-up for https://github.com/containers/common/pull/2482

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

## Summary by Sourcery

Fix all reported lint errors by replacing context-less calls to exec.Command, net.Listen, and net.Dial with their context-aware counterparts across the codebase.

Enhancements:
- Use exec.CommandContext with context.Background() instead of exec.Command for all external command invocations
- Use net.ListenConfig.Listen with context.Background() instead of net.Listen for TCP listeners in tests
- Use net.Dialer.DialContext with context.Background() instead of net.Dial for UNIX socket connections