### PR TITLE
golangci-lint: disable noctx linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,7 +44,6 @@ linters:
     - mirror
     - misspell
     - nilnesserr
-    - noctx
     - nosprintfhostport
     - perfsprint
     - prealloc


### PR DESCRIPTION
commit 2d75d8ec9116082c2420f2e86069cae48358636f bumped the linter version without fixing the new issues.

Follow-up for https://github.com/containers/common/pull/2482

Alternative to https://github.com/containers/common/pull/2484

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

## Summary by Sourcery

CI:
- Remove the noctx linter from .golangci.yml