### PR TITLE
add log_path option to container configuration

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -294,6 +294,12 @@ the user system_u, and the role system_r.
 
 Logging driver for the container. Currently available options are k8s-file, journald, none and passthrough, with json-file aliased to k8s-file for scripting compatibility.  The journald driver is used by default if the systemd journal is readable and writable.  Otherwise, the k8s-file driver is used.
 
+**log_path**=""
+
+Logging path for the container. When empty it will use the default container storage to keep
+its logging file. This feature needs the log_driver to be k8s-file. The specified 
+directory will be used for all container logging unless overridden by the --log-opt flag.
+
 **log_size_max**=-1
 
 Maximum size allowed for the container's log file. Negative numbers indicate

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -172,6 +172,9 @@ type ContainersConfig struct {
 	// LogDriver  for the container.  For example: k8s-file and journald
 	LogDriver string `toml:"log_driver,omitempty"`
 
+	// LogPath is the path to the container log file.
+	LogPath string `toml:"log_path,omitempty"`
+
 	// LogSizeMax is the maximum number of bytes after which the log file
 	// will be truncated. It can be expressed as a human-friendly string
 	// that is parsed to bytes.
@@ -880,6 +883,10 @@ func (c *ContainersConfig) Validate() error {
 	}
 
 	if err := c.validateUmask(); err != nil {
+		return err
+	}
+
+	if err := c.validateLogPath(); err != nil {
 		return err
 	}
 

--- a/pkg/config/config_local.go
+++ b/pkg/config/config_local.go
@@ -105,6 +105,18 @@ func (c *ContainersConfig) validateUmask() error {
 	return nil
 }
 
+func (c *ContainersConfig) validateLogPath() error {
+	if c.LogPath == "" {
+		return nil
+	}
+
+	if strings.ContainsAny(c.LogPath, "\x00\n\r\t") {
+		return fmt.Errorf("log_path contains invalid characters")
+	}
+
+	return nil
+}
+
 func isRemote() bool {
 	return false
 }

--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -588,4 +588,44 @@ var _ = Describe("Config Local", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config2.Machine.Rosetta).To(gomega.BeFalse())
 	})
+	It("should validate log_path correctly", func() {
+		defConf, err := defaultConfig()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(defConf).NotTo(gomega.BeNil())
+
+		// Test empty path
+		defConf.Containers.LogPath = ""
+		err = defConf.Containers.Validate()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		// Test absolute path
+		defConf.Containers.LogPath = "/var/log/containers"
+		err = defConf.Containers.Validate()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		// Test path with env var
+		defConf.Containers.LogPath = "$HOME/logs"
+		err = defConf.Containers.Validate()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		// Test relative path
+		defConf.Containers.LogPath = "./logs"
+		err = defConf.Containers.Validate()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		// Test path with null byte
+		defConf.Containers.LogPath = "/var/log\x00/containers"
+		err = defConf.Containers.Validate()
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("invalid characters"))
+	})
+	It("should parse log_path from config file", func() {
+		config, err := New(nil)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(config.Containers.LogPath).To(gomega.Equal(""))
+
+		config2, err := NewConfig("testdata/containers_default.conf")
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(config2.Containers.LogPath).To(gomega.Equal("/var/log/containers"))
+	})
 })

--- a/pkg/config/config_remote.go
+++ b/pkg/config/config_remote.go
@@ -35,3 +35,7 @@ func (c *ContainersConfig) validateTZ() error {
 func (c *ContainersConfig) validateUmask() error {
 	return nil
 }
+
+func (c *ContainersConfig) validateLogPath() error {
+	return nil
+}

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -216,6 +216,12 @@ default_sysctls = [
 #
 #log_driver = "k8s-file"
 
+# Path to the directory where container log files are stored.
+# If not set, container logs are stored in the default location. 
+# This can be overridden by the --log-opt path=<path> runtime option.
+#
+#log_path = ""
+
 # Maximum size allowed for the container log file. Negative numbers indicate
 # that no size limit is imposed. If positive, it must be >= 8192 to match or
 # exceed conmon's read buffer. The file is truncated and re-opened so the

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -85,6 +85,8 @@ label = true
 # limit is never exceeded.
 log_size_max = -1
 
+log_path = "/var/log/containers"
+
 mounts= [
 	"type=glob,source=/tmp/test2*,ro=true",
 	"type=bind,source=/etc/services,destination=/etc/services,ro",


### PR DESCRIPTION
This adds support for configuring container log paths via container.conf, matching the functionality of --log-opts path=... at runtime

Fixes customer RFE for per-user container.conf log configuration for use with podman-kube systemd services.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
