### PR TITLE
pkg/config: fix broken tests due indirect merge conflict

### DIFF
--- a/pkg/config/config_local_test.go
+++ b/pkg/config/config_local_test.go
@@ -616,11 +616,11 @@ var _ = Describe("Config Local", func() {
 		gomega.Expect(err.Error()).To(gomega.ContainSubstring("null bytes"))
 	})
 	It("should parse log_path from config file", func() {
-		config, err := New(nil)
+		config, err := newLocked(&Options{}, &paths{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config.Containers.LogPath).To(gomega.Equal(""))
 
-		config2, err := NewConfig("testdata/containers_default.conf")
+		config2, err := newLocked(&Options{}, &paths{etc: "testdata/containers_default.conf"})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(config2.Containers.LogPath).To(gomega.Equal("/var/log/containers"))
 	})


### PR DESCRIPTION
Commit 57def960 added new test cases using the old function that were removed in 6c30f0c0. Because I didn't rebase my PR after the first commit was merged we introduced this conflict accidentally.

## Summary by Sourcery

Bug Fixes:
- Update test calls from deprecated New and NewConfig to the newLocked function with appropriate Options and paths arguments