### PR TITLE
libimage: fix manifest race for AnnotateInstance() and RemoveInstance()

### DIFF
--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -319,24 +319,16 @@ func (m *ManifestList) saveAndReload() error {
 	if err != nil {
 		return err
 	}
-
-	// Make sure to reload the image from the containers storage to fetch
-	// the latest data (e.g., new or delete digests).
-	if err := m.image.reload(); err != nil {
-		return err
-	}
-	image, list, err := m.image.runtime.lookupManifestList(newID)
-	if err != nil {
-		return err
-	}
-	m.image = image
-	m.list = list
-	return nil
+	return m.reloadID(newID)
 }
 
 // Reload the image and list instances from storage
 func (m *ManifestList) reload() error {
 	listID := m.ID()
+	return m.reloadID(listID)
+}
+
+func (m *ManifestList) reloadID(listID string) error {
 	if err := m.image.reload(); err != nil {
 		return err
 	}

--- a/libimage/manifest_list.go
+++ b/libimage/manifest_list.go
@@ -329,9 +329,6 @@ func (m *ManifestList) reload() error {
 }
 
 func (m *ManifestList) reloadID(listID string) error {
-	if err := m.image.reload(); err != nil {
-		return err
-	}
 	image, list, err := m.image.runtime.lookupManifestList(listID)
 	if err != nil {
 		return err


### PR DESCRIPTION
Neither AnnotateInstance() or RemoveInstance() use the lock so we were still open to many races.

The reason the should fix the podman manifest add race is because that one also always calls AnnotateInstance().

Fixes: https://issues.redhat.com/browse/RHEL-21291

Also some two small commits to reduce the overhead of reload a bit.
