### PR TITLE
spec: loosen permissions on /usr/lib/containers/storage/* dirs

### DIFF
--- a/rpm/containers-common.spec
+++ b/rpm/containers-common.spec
@@ -145,9 +145,9 @@ install -dp %{buildroot}%{_sysconfdir}/containers/{certs.d,oci/hooks.d,networks,
 install -dp %{buildroot}%{_sharedstatedir}/containers/sigstore
 install -dp %{buildroot}%{_datadir}/containers/systemd
 install -dp %{buildroot}%{_prefix}/lib/containers/storage
-install -dp -m 700 %{buildroot}%{_prefix}/lib/containers/storage/overlay-images
+install -dp -m 755 %{buildroot}%{_prefix}/lib/containers/storage/overlay-images
 touch %{buildroot}%{_prefix}/lib/containers/storage/overlay-images/images.lock
-install -dp -m 700 %{buildroot}%{_prefix}/lib/containers/storage/overlay-layers
+install -dp -m 755 %{buildroot}%{_prefix}/lib/containers/storage/overlay-layers
 touch %{buildroot}%{_prefix}/lib/containers/storage/overlay-layers/layers.lock
 
 install -Dp -m0644 shortnames.conf %{buildroot}%{_sysconfdir}/containers/registries.conf.d/000-shortnames.conf


### PR DESCRIPTION
Since /usr/lib/containers/storage/ is configured as an additional store by default [1] these directories are important to be able to be read by unprivileged users.

The problem I ran into was when generating a disk image using supermin [2] it didn't pick up the images.lock and layers.lock files when creating the resulting filesystem (because running supermin unprivileged means they weren't viewable because they were under directories that weren't accessible to non-root).

Because those files weren't there, when I eventually ran OSBuild inside the supermin VM, which happens to mount in /usr/ read-only inside the OSBuild env I'd get an error when trying to do podman/skopeo operations:

```
Copying blob sha256:9dad063a624b62064bf25dbbc2e802e472d636056f661f2a0be73efd8a4da98b
time="2025-08-11T15:45:48Z" level=fatal msg="trying to reuse blob
sha256:7842e86602a2d0ca8e8e12adc8520579a1fef4fad571bb83a450b5d98269ae5a at destination:
looking for layers with digest \"sha256:7842e86602a2d0ca8e8e12adc8520579a1fef4fad571bb83a450b5d98269ae5a\":
loading additional layer stores: open /usr/lib/containers/storage/overlay-layers/layers.lock: read-only file system"
```

If the *.lock files exist. The errors won't manifest.

[1] https://github.com/containers/common/blob/6f98aea06fcd025b418e7414d6b33df02478aa51/rpm/update-config-files.sh#L46-L49
[2] https://libguestfs.org/supermin.1.html

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

## Summary by Sourcery

Loosen directory permissions for overlay-images and overlay-layers under /usr/lib/containers/storage to allow unprivileged users to read lock files and prevent read-only filesystem errors in unprivileged workflows

Bug Fixes:
- Change install mode from 700 to 755 for overlay-images directory in the RPM spec
- Change install mode from 700 to 755 for overlay-layers directory in the RPM spec