### PR TITLE
Add config to set default runtime flags

### DIFF
--- a/docs/containers.conf.5.md
+++ b/docs/containers.conf.5.md
@@ -934,6 +934,12 @@ URI to access the Podman service
 
 Path to file containing ssh identity key
 
+**[engine.runtimes_flags]**
+
+Lists of default runtime flags for each valid OCI runtime (crun, runc, kata, runsc, krun, etc).
+
+To list the supported flags, please consult the documentation of the selected container runtime.
+
 **[engine.volume_plugins]**
 
 A table of all the enabled volume plugins on the system. Volume plugins can be

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -423,6 +423,9 @@ type EngineConfig struct {
 	// OCIRuntimes are the set of configured OCI runtimes (default is runc).
 	OCIRuntimes map[string][]string `toml:"runtimes,omitempty"`
 
+	// OCIRuntimesFlags are the set of configured OCI runtimes' flags
+	OCIRuntimesFlags map[string][]string `toml:"runtimes_flags,omitempty"`
+
 	// PlatformToOCIRuntime requests specific OCI runtime for a specified platform of image.
 	PlatformToOCIRuntime map[string]string `toml:"platform_to_oci_runtime,omitempty"`
 
@@ -855,6 +858,11 @@ func (c *EngineConfig) Validate() error {
 	}
 
 	if _, err := ParseDBBackend(c.DBBackend); err != nil {
+		return err
+	}
+
+	// Check if runtimes specified under [engine.runtimes_flags] can be found under [engine.runtimes]
+	if err := c.validateRuntimeNames(); err != nil {
 		return err
 	}
 

--- a/pkg/config/config_local.go
+++ b/pkg/config/config_local.go
@@ -30,6 +30,17 @@ func (c *EngineConfig) validatePaths() error {
 	return nil
 }
 
+func (c *EngineConfig) validateRuntimeNames() error {
+	// Check if runtimes specified under [engine.runtimes_flags] can be found under [engine.runtimes]
+	for runtime := range c.OCIRuntimesFlags {
+		if _, exists := c.OCIRuntimes[runtime]; !exists {
+			return fmt.Errorf("invalid runtime %q in [engine.runtimes_flags]: "+
+				"not defined in [engine.runtimes]", runtime)
+		}
+	}
+	return nil
+}
+
 func (c *ContainersConfig) validateDevices() error {
 	for _, d := range c.Devices.Get() {
 		if parser.IsQualifiedName(d) {

--- a/pkg/config/config_remote.go
+++ b/pkg/config/config_remote.go
@@ -16,6 +16,8 @@ func (c *EngineConfig) validatePaths() error {
 	return nil
 }
 
+func (c *EngineConfig) validateRuntimeNames() error { return nil }
+
 func (c *ContainersConfig) validateDevices() error {
 	return nil
 }

--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -863,6 +863,23 @@ default_sysctls = [
 #  "/usr/local/bin/krun",
 #]
 
+# Default flags for a valid OCI runtime (crun, runc, kata, runsc, krun, etc)
+# Note: Do not pass the leading -- to the flag. To pass the runc flag --log-format json, the option given is log-format=json.
+[engine.runtimes_flags]
+#crun = []
+
+#crun-vm = []
+
+#kata = []
+
+#runc = []
+
+#runsc = []
+
+#youki = []
+
+#krun = []
+
 [engine.volume_plugins]
 #testplugin = "/run/podman/plugins/test.sock"
 

--- a/pkg/config/containers.conf-freebsd
+++ b/pkg/config/containers.conf-freebsd
@@ -669,6 +669,23 @@ default_sysctls = [
 #  "/usr/local/bin/krun",
 #]
 
+# Default flags for a valid OCI runtime (crun, runc, kata, runsc, krun, etc)
+# Note: Do not pass the leading -- to the flag. To pass the runc flag --log-format json, the option given is log-format=json.
+[engine.runtimes_flags]
+#crun = []
+
+#crun-vm = []
+
+#kata = []
+
+#runc = []
+
+#runsc = []
+
+#youki = []
+
+#krun = []
+
 [engine.volume_plugins]
 #testplugin = "/var/run/podman/plugins/test.sock"
 

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -470,6 +470,7 @@ func defaultEngineConfig() (*EngineConfig, error) {
 			"/usr/local/bin/ocijail",
 		},
 	}
+	c.OCIRuntimesFlags = map[string][]string{}
 	c.PlatformToOCIRuntime = map[string]string{
 		"wasi/wasm":   "crun-wasm",
 		"wasi/wasm32": "crun-wasm",

--- a/pkg/config/testdata/containers_default.conf
+++ b/pkg/config/testdata/containers_default.conf
@@ -311,6 +311,17 @@ crun = [
 	    "/usr/local/bin/crun",
 ]
 
+# Default flags for a valid OCI runtime (crun, runc, kata, runsc, krun, etc)
+# Note: Do not pass the leading -- to the flag. To pass the runc flag --log-format json, the option given is log-format=json.
+[engine.runtimes_flags]
+crun = [
+    "debug"
+]
+
+runsc = [
+    "net-raw"
+]
+
 [podmansh]
 # Shell to start in container. Default: /bin/sh.
 shell = "/bin/zsh"


### PR DESCRIPTION
Added a way to define default runtime flags in config.

I have already prepared relevant changes in podman: https://github.com/containers/podman/pull/26892

#### Fixes: https://github.com/containers/common/issues/715

Default runtime flags should be defined as shown below:
```
[engine.runtimes_flags]
runsc = [
  "net-raw",
]

crun = [
  "debug",
]
```
<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->

## Summary by Sourcery

Introduce a new configuration section for default OCI runtime flags, wire it through EngineConfig, add tests for parsing, and update documentation accordingly.

New Features:
- Allow specifying default OCI runtime flags via the [engine.runtimes_flags] configuration section

Enhancements:
- Add OCIRuntimesFlags field to EngineConfig and initialize it to an empty map in defaults
- Include [engine.runtimes_flags] section in containers.conf and FreeBSD variant with commented runtime entries

Documentation:
- Document the [engine.runtimes_flags] section in the containers.conf man page

Tests:
- Add unit test to verify parsing of OCIRuntimesFlags from the config file