### PR TITLE
Move the repository to monorepo.

### DIFF
--- a/.github/workflows/auto-close-prs.yml
+++ b/.github/workflows/auto-close-prs.yml
@@ -1,0 +1,15 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+    branches:
+      - main
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@9c18513d320d7b2c7185fb93396d0c664d5d8448
+      with:
+        comment: "This repository has been migrated to https://github.com/containers/container-libs. Please open your PR there."

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # containers/common
 
+> [!WARNING]
+> This package was moved; please update your references to use `go.podman.io/common` instead.
+> New development of this project happens on https://github.com/containers/container-libs.
+> For more information, check https://blog.podman.io/2025/08/upcoming-migration-of-three-containers-repositories-to-monorepo/.
+
 Location for shared common files and common go code to manage those files in
 github.com/containers repos.
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Use go.podman.io/common instead.
 module github.com/containers/common
 
 // Warning: Ensure the "go" and "toolchain" versions match exactly to prevent unwanted auto-updates


### PR DESCRIPTION
This commit:
- mentions the monorepo in the README.MD.
- deprecates the module in favor of go.podman.io/common.
- adds github workflow to auto-close newly created PRs.

> [!WARNING]
> I only need a review. I will merge it myself tomorrow as part of the migration to monorepo.

## Summary by Sourcery

Migrate the repository to the new monorepo by updating documentation, marking the module as deprecated, and auto-closing incoming PRs to redirect contributors to the new location.

Enhancements:
- Deprecate module in go.mod in favor of go.podman.io/common

CI:
- Introduce GitHub Actions workflow to auto-close new PRs and guide contributors to the monorepo

Documentation:
- Add warning and migration notice to README pointing to the monorepo and blog post