### PR TITLE
seccomp: allow perf_event_open if CAP_PERFMON

### DIFF
--- a/pkg/seccomp/default_linux.go
+++ b/pkg/seccomp/default_linux.go
@@ -616,6 +616,7 @@ func DefaultProfile() *Seccomp {
 			Names: []string{
 				"bpf",
 				"lookup_dcookie",
+				"perf_event_open",
 				"quotactl",
 				"quotactl_fd",
 				"setdomainname",
@@ -631,7 +632,6 @@ func DefaultProfile() *Seccomp {
 		{
 			Names: []string{
 				"lookup_dcookie",
-				"perf_event_open",
 				"quotactl",
 				"quotactl_fd",
 				"setdomainname",
@@ -927,7 +927,7 @@ func DefaultProfile() *Seccomp {
 			ErrnoRet: &eperm,
 			Args:     []*Arg{},
 			Excludes: Filter{
-				Caps: []string{"CAP_SYS_ADMIN", "CAP_BPF"},
+				Caps: []string{"CAP_SYS_ADMIN", "CAP_PERFMON"},
 			},
 		},
 		{

--- a/pkg/seccomp/seccomp.json
+++ b/pkg/seccomp/seccomp.json
@@ -693,6 +693,7 @@
 			"names": [
 				"bpf",
 				"lookup_dcookie",
+				"perf_event_open",
 				"quotactl",
 				"quotactl_fd",
 				"setdomainname",
@@ -712,7 +713,6 @@
 		{
 			"names": [
 				"lookup_dcookie",
-				"perf_event_open",
 				"quotactl",
 				"quotactl_fd",
 				"setdomainname",
@@ -1105,7 +1105,7 @@
 			"excludes": {
 				"caps": [
 					"CAP_SYS_ADMIN",
-					"CAP_BPF"
+					"CAP_PERFMON"
 				]
 			},
 			"errnoRet": 1,


### PR DESCRIPTION
Currently `perf_event_open` is only allowed if both `CAP_SYS_ADMIN` and `CAP_PERFMON` are enabled. `CAP_SYS_ADMIN` is a very overloaded capability and is best avoided. This PR enables `perf_event_open` if either (or both) capabilities are enabled. In particular, this enables a container to profile itself by only enabling `CAP_PERFMON`.

This change does not deny anything new, nor does it enable `perf_event_open` by default. In summary:

| Capabilities | `perf_event_open` return (before) | `perf_event_open` return (after) |
|---|---|---|
| `CAP_PERFMON` + `CAP_SYS_ADMIN` | No error | No error |
| `CAP_PERFMON` | `EPERM` | No error |
| `CAP_SYS_ADMIN` | `ENOSYS` | No error |
| (none of the above) | `EPERM` | `EPERM` |