### PR TITLE
[WIP] config: change default macOS machine provider to libkrun

### DIFF
--- a/pkg/config/containers.conf
+++ b/pkg/config/containers.conf
@@ -911,9 +911,9 @@ default_sysctls = [
 #    wsl     - Windows Subsystem for Linux (Default)
 #    hyperv  - Windows Server Virtualization
 # Mac: there are currently two options:
-#    applehv - Default Apple Hypervisor (Default)
 #    libkrun - Launch virtual machines using the libkrun platform, optimized
-#              for sharing GPU with the machine.
+#              for sharing GPU with the machine. (Default)
+#    applehv - Launch virtual machines using the vfkit platform.
 #provider = ""
 
 # Rosetta supports running x86_64 Linux binaries on a Podman machine on Apple silicon.


### PR DESCRIPTION
Change the containers.conf comments to correctly identify the default macOS machine provider as libkrun.

Related to: https://github.com/containers/podman/pull/27546

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
