### PR TITLE
[moved] Use 127.0.0.1 for host.containers.internal with host network

### DIFF
--- a/libnetwork/etchosts/ip.go
+++ b/libnetwork/etchosts/ip.go
@@ -28,6 +28,8 @@ type HostContainersInternalOptions struct {
 	// lower priority than the containers.conf config option.
 	// This is used for the pasta --map-guest-addr ip.
 	PreferIP string
+	// HostNetwork is true if the container is using host networking.
+	HostNetwork bool
 }
 
 // Lookup "host.containers.internal" dns name so we can add it to /etc/hosts when running inside podman machine.
@@ -59,6 +61,10 @@ func GetHostContainersInternalIP(opts HostContainersInternalOptions) string {
 		return ""
 	default:
 		return opts.Conf.Containers.HostContainersInternalIP
+	}
+
+	if opts.HostNetwork {
+		return "127.0.0.1"
 	}
 
 	// caller has a specific ip it prefers


### PR DESCRIPTION
#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] Tests have been added/updated (or no tests are needed)
- [ ] Documentation has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] Release note entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
With `--network=host`, `host.containers.internal` now resolves to `127.0.0.1` (localhost) instead of an external IP address.
```

Ref: https://github.com/containers/podman/pull/27927