### PR TITLE
libimage: treat localhost/ images as local-only

### DIFF
--- a/libimage/pull.go
+++ b/libimage/pull.go
@@ -501,6 +501,18 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 		}
 	}
 
+	// Images prefixed with "localhost/" (without a port) are local-only by
+	// convention and cannot be pulled from a remote registry.  Return the
+	// local image if available, or an error if not found, without ever
+	// attempting a network pull (see containers/podman/issues/28038).
+	if isLocalhostImage(imageName) {
+		if localImage != nil {
+			logrus.Debugf("Image %s is a localhost image, returning local image", imageName)
+			return localImage, nil
+		}
+		return nil, fmt.Errorf("%s: %w", imageName, storage.ErrImageUnknown)
+	}
+
 	customPlatform := len(options.Architecture)+len(options.OS)+len(options.Variant) > 0
 	if customPlatform && pullPolicy != config.PullPolicyAlways && pullPolicy != config.PullPolicyNever {
 		// Unless the pull policy is always/never, we must
@@ -658,4 +670,12 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 	}
 
 	return nil, resolved.FormatPullErrors(pullErrors)
+}
+
+// isLocalhostImage returns true if the image name refers to a localhost-only
+// image (i.e., prefixed with "localhost/" but without a port number).
+// Images with "localhost:PORT/" are actual registry references and should
+// not be treated as local-only.
+func isLocalhostImage(name string) bool {
+	return strings.HasPrefix(name, "localhost/")
 }


### PR DESCRIPTION
## Summary

Fixes an issue where images prefixed with `localhost/` (without a port) were incorrectly treated as remote Docker registry references, causing `podman build` to fail with:

```
Error: creating build container: unable to copy from source docker://localhost/base-toolbox:latest: pinging container registry localhost: Get "https://localhost/v2/": dial tcp [::1]:443: connect: connection refused
```

## Problem

Images named with `localhost/` prefix (e.g., `localhost/base-toolbox:latest`) are a naming convention for local-only images in Podman/Buildah. They should never attempt a network pull from a Docker registry.

Previously, when building an image with `FROM localhost/base-toolbox:latest` in a Containerfile, the code would:
1. Look up the image locally
2. If pull policy was `newer` or `always`, attempt to pull from `docker://localhost/base-toolbox:latest`
3. This fails because `localhost` without a port is not a real Docker registry

## Solution

Added a check in `copySingleImageFromRegistry()` to detect `localhost/` prefixed image names (without a port) and:
- Return the local image if found in storage
- Return `storage.ErrImageUnknown` if not found

This prevents any network pull attempts for localhost images.

## Testing

The fix can be verified by:
1. Building a local image tagged as `localhost/base:latest`
2. Building another image with `FROM localhost/base:latest` in its Containerfile
3. The build should now succeed without attempting to contact a remote registry

Fixes: containers/podman#28038