### PR TITLE
network: use rootless user check for config paths

### DIFF
--- a/libnetwork/network/interface.go
+++ b/libnetwork/network/interface.go
@@ -65,10 +65,10 @@ func netavarkBackendFromConf(store storage.Store, conf *config.Config, syslog bo
 
 	// We cannot use the runroot for rootful since the network namespace is shared for all
 	// libpod instances they also have to share the same ipam db.
-	// For rootless we have our own network namespace per libpod instances,
+	// For rootless users we have our own network namespace per libpod instances,
 	// so this is not a problem there.
 	runDir := netavarkRunDir
-	if unshare.IsRootless() {
+	if isRootlessUser() {
 		runDir = filepath.Join(store.RunRoot(), "networks")
 	}
 
@@ -141,8 +141,16 @@ func defaultNetworkBackend(store storage.Store, conf *config.Config) (backend ty
 // use "/etc/containers/networks" and for rootless "$graphroot/networks". We cannot
 // use the graphroot for rootful since the network namespace is shared for all
 // libpod instances.
+func isRootlessUser() bool {
+	return rootlessModeForUser(unshare.IsRootless(), unshare.GetRootlessUID())
+}
+
+func rootlessModeForUser(isRootless bool, rootlessUID int) bool {
+	return isRootless && rootlessUID > 0
+}
+
 func getDefaultNetavarkConfigDir(store storage.Store) string {
-	if !unshare.IsRootless() {
+	if !isRootlessUser() {
 		return netavarkConfigDir
 	}
 	return filepath.Join(store.GraphRoot(), "networks")

--- a/libnetwork/network/interface_cni.go
+++ b/libnetwork/network/interface_cni.go
@@ -14,7 +14,6 @@ import (
 	"github.com/containers/common/pkg/machine"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/homedir"
-	"github.com/containers/storage/pkg/unshare"
 )
 
 const (
@@ -42,7 +41,7 @@ func getCniInterface(conf *config.Config) (types.ContainerNetwork, error) {
 }
 
 func getDefaultCNIConfigDir() (string, error) {
-	if !unshare.IsRootless() {
+	if !isRootlessUser() {
 		return cniConfigDir, nil
 	}
 

--- a/libnetwork/network/interface_test.go
+++ b/libnetwork/network/interface_test.go
@@ -1,0 +1,45 @@
+//go:build linux || freebsd
+
+package network
+
+import "testing"
+
+func TestRootlessModeForUser(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		isRootless  bool
+		rootlessUID int
+		expect      bool
+	}{
+		{
+			name:        "rootless user",
+			isRootless:  true,
+			rootlessUID: 1000,
+			expect:      true,
+		},
+		{
+			name:        "root in nested user namespace",
+			isRootless:  true,
+			rootlessUID: 0,
+			expect:      false,
+		},
+		{
+			name:        "rootful",
+			isRootless:  false,
+			rootlessUID: 0,
+			expect:      false,
+		},
+	}
+
+	for _, tcl := range testCases {
+		tc := tcl
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := rootlessModeForUser(tc.isRootless, tc.rootlessUID); got != tc.expect {
+				t.Fatalf("expected %v, got %v", tc.expect, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Dependency support for the main Podman fix: https://github.com/podman-container-tools/podman/pull/28995

Bug report: https://github.com/podman-container-tools/podman/issues/18783

Network config/runtime path selection should distinguish a real rootless user from UID 0 running inside a nested user namespace.

This changes netavark and CNI config path selection to use rootless-user semantics, matching Podman's behavior for nested root: `unshare.IsRootless()` is only treated as rootless networking when the originating rootless UID is non-zero. UID 0 in a delegated container environment should continue to use rootful network paths.

## Tests

- `GOOS=linux go test -c -o /private/tmp/common-network.test ./libnetwork/network`
- `GOOS=linux go test -tags cni -c -o /private/tmp/common-network-cni.test ./libnetwork/network`
