### PR TITLE
apparmor: allow change_profile for nested container runtimes

### DIFF
--- a/pkg/apparmor/apparmor_linux_template.go
+++ b/pkg/apparmor/apparmor_linux_template.go
@@ -25,6 +25,14 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   signal (receive) peer={/usr/bin/,/usr/sbin/,}runc,
   signal (receive) peer={/usr/bin/,/usr/sbin/,}crun*,
   signal (receive) peer={/usr/bin/,/usr/sbin/,}podman,
+  # Allow OCI runtimes running inside this container to assign AppArmor
+  # profiles to child containers (needed when podman socket is used from
+  # a systemd/Quadlet-launched container on kernel >= 6.17).
+  change_profile -> **,
+  # Allow OCI runtimes running inside this container to assign AppArmor
+  # profiles to child containers (needed when podman socket is used from
+  # a systemd/Quadlet-launched container on kernel >= 6.17).
+  change_profile -> **,
 {{end}}
 
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/28992"


## Problem

On kernel 6.17, starting a container via the Docker-compat API
(docker compose / docker CLI pointed at the podman socket) from inside a
**systemd/Quadlet-launched** container fails with:

    crun: `/proc/thread-self/attr/apparmor/exec`: OCI runtime error:
    unable to assign security attribute

The outer container runs under `containers-default-*`. When crun inside
that container tries to write an AppArmor profile name to
`/proc/thread-self/attr/apparmor/exec` for the child container, the
kernel rejects it because `change_profile` is not permitted by the outer
container's profile.

Native `podman run` from the host is unaffected (process is unconfined).
`podman --remote` is also unaffected.  Only the compat API path from
inside a confined systemd container triggers this.

Reported: containers/podman#28992
Downstream: moghtech/komodo#1488

## Fix
Add `change_profile -> **,` inside the `>= 208096` version guard,
alongside the existing signal rules for crun/runc/podman. This gives
OCI runtimes running inside a container permission to assign AppArmor
profiles to their child processes.

## Testing
reproduction:
1. launch a container via Quadlet with `--cgroups=split --sdnotify=conmon`
   and the host's rootful podman socket bind-mounted.
2. from inside that container run `docker run alpine echo hi` against the
   socket.
3. without this fix: `crun: unable to assign security attribute`
4. With this fix: container starts successfully