### PR TITLE
libimage: clarify local image transport error

### DIFF
--- a/libimage/image_test.go
+++ b/libimage/image_test.go
@@ -188,6 +188,9 @@ func TestLookupImage(t *testing.T) {
 	runtime := testNewRuntime(t)
 	ctx := context.Background()
 
+	_, _, err := runtime.LookupImage("docker://busybox", nil)
+	require.EqualError(t, err, `unsupported transport "docker" for looking up local images; remove the transport prefix to refer to an image in local storage`)
+
 	pullOptions := &PullOptions{}
 	pullOptions.Writer = os.Stdout
 

--- a/libimage/runtime.go
+++ b/libimage/runtime.go
@@ -249,7 +249,7 @@ func (r *Runtime) LookupImage(name string, options *LookupImageOptions) (*Image,
 	storageRef, err := alltransports.ParseImageName(name)
 	if err == nil {
 		if storageRef.Transport().Name() != storageTransport.Transport.Name() {
-			return nil, "", fmt.Errorf("unsupported transport %q for looking up local images", storageRef.Transport().Name())
+			return nil, "", fmt.Errorf("unsupported transport %q for looking up local images; remove the transport prefix to refer to an image in local storage", storageRef.Transport().Name())
 		}
 		_, img, err := storageTransport.ResolveReference(storageRef)
 		if err != nil {


### PR DESCRIPTION
## Summary

Clarify the error returned by `Runtime.LookupImage` when a local image lookup is attempted using a non-storage transport such as `docker://`.

Previously the error identified the unsupported transport but did not explain how to refer to a locally stored image. This change preserves the existing rejection while adding guidance to remove the transport prefix.

## Changes

- Clarify the error returned for non-storage transports in `Runtime.LookupImage`
- Extend `TestLookupImage` to cover `docker://` references
- Preserve existing lookup and error propagation behavior

## Testing

```bash
go test -run '^TestLookupImage$' -count=1 -tags containers_image_openpgp ./libimage
```

The targeted test exceeded the local execution limit because the existing test pulls Alpine.

Also verified:

```bash
git diff --check
```